### PR TITLE
feat: Use bytes instead of hex string for SyncIds

### DIFF
--- a/apps/hubble/src/console/syncTrieCommand.ts
+++ b/apps/hubble/src/console/syncTrieCommand.ts
@@ -20,7 +20,7 @@ export class SyncTrieCommand implements ConsoleCommandInterface {
   }
 
   rootHash = async () => {
-    const result = await this.rpcClient.getSyncSnapshotByPrefix(TrieNodePrefix.create({ prefix: '' }));
+    const result = await this.rpcClient.getSyncSnapshotByPrefix(TrieNodePrefix.create({ prefix: new Uint8Array() }));
     return result.match(
       (snapshot) => {
         return snapshot.rootHash;
@@ -31,8 +31,10 @@ export class SyncTrieCommand implements ConsoleCommandInterface {
     );
   };
 
-  snapshot = async (prefix?: string) => {
-    const result = await this.rpcClient.getSyncSnapshotByPrefix(TrieNodePrefix.create({ prefix: prefix ?? '' }));
+  snapshot = async (prefix?: Uint8Array) => {
+    const result = await this.rpcClient.getSyncSnapshotByPrefix(
+      TrieNodePrefix.create({ prefix: prefix ?? new Uint8Array() })
+    );
     return result.match<any>(
       (snapshot) => {
         return snapshot;
@@ -43,8 +45,10 @@ export class SyncTrieCommand implements ConsoleCommandInterface {
     );
   };
 
-  metadata = async (prefix?: string) => {
-    const result = await this.rpcClient.getSyncMetadataByPrefix(TrieNodePrefix.create({ prefix: prefix ?? '' }));
+  metadata = async (prefix?: Uint8Array) => {
+    const result = await this.rpcClient.getSyncMetadataByPrefix(
+      TrieNodePrefix.create({ prefix: prefix ?? new Uint8Array() })
+    );
     return result.match<any>(
       (metadata) => {
         return metadata;
@@ -55,8 +59,10 @@ export class SyncTrieCommand implements ConsoleCommandInterface {
     );
   };
 
-  syncIds = async (prefix?: string) => {
-    const result = await this.rpcClient.getAllSyncIdsByPrefix(TrieNodePrefix.create({ prefix: prefix ?? '' }));
+  syncIds = async (prefix?: Uint8Array) => {
+    const result = await this.rpcClient.getAllSyncIdsByPrefix(
+      TrieNodePrefix.create({ prefix: prefix ?? new Uint8Array() })
+    );
     return result.match<any>(
       (syncIds) => {
         return syncIds;

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -355,7 +355,9 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
     }
 
     // First, get the latest state from the peer
-    const peerStateResult = await rpcClient.getSyncSnapshotByPrefix(protobufs.TrieNodePrefix.create({ prefix: '' }));
+    const peerStateResult = await rpcClient.getSyncSnapshotByPrefix(
+      protobufs.TrieNodePrefix.create({ prefix: new Uint8Array() })
+    );
     if (peerStateResult.isErr()) {
       log.warn(`Failed to get peer state, skipping sync`);
       this.emit('syncComplete', false);

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -186,7 +186,7 @@ describe('SyncEngine', () => {
 
       // Return an empty child map so sync will finish with a noop
       const emptyMetadata = protobufs.TrieNodeMetadataResponse.create({
-        prefix: '',
+        prefix: new Uint8Array(),
         numMessages: 1000,
         hash: '',
         children: [],

--- a/apps/hubble/src/network/sync/syncId.ts
+++ b/apps/hubble/src/network/sync/syncId.ts
@@ -2,7 +2,7 @@ import * as protobufs from '@farcaster/protobufs';
 import { makeUserKey, typeToSetPostfix } from '~/storage/db/message';
 
 const TIMESTAMP_LENGTH = 10; // 10 bytes for timestamp in decimal
-const HASH_LENGTH = 160; // We're using 20 byte blake2b hashes
+const HASH_LENGTH = 20; // We're using 20 byte blake2b hashes
 
 /**
  * SyncId allows for a stable, time ordered lexicographic sorting of messages across hubs
@@ -11,32 +11,33 @@ const HASH_LENGTH = 160; // We're using 20 byte blake2b hashes
  */
 class SyncId {
   private readonly _fid: number;
-  private readonly _tsHash: Uint8Array;
+  private readonly _hash: Uint8Array;
   private readonly _timestamp: number;
   private readonly _type: number;
 
   constructor(message: protobufs.Message) {
     this._fid = message.data?.fid || 0;
-    this._tsHash = message.hash;
+    this._hash = message.hash;
     this._timestamp = message.data?.timestamp || 0;
     this._type = message.data?.type || 0;
   }
 
-  public idString(): string {
+  public syncId(): Uint8Array {
     // For our MerkleTrie, seconds is a good enough resolution
     // We also want to normalize the length to 10 characters, so that the MerkleTrie
     // will always have the same depth for any timestamp (even 0).
     const timestampString = timestampToPaddedTimestampPrefix(this._timestamp);
 
-    const buf = makeMessagePrimaryKey(this._fid, this._type, this._tsHash);
-    return timestampString + buf.toString('hex');
+    const buf = makeMessagePrimaryKey(this._fid, this._type, this._hash);
+    // We prepend the timestamp to the hash so that the MerkleTrie is sorted by timestamp
+    return Buffer.concat([Buffer.from(timestampString), buf]);
   }
 
-  static pkFromIdString(idString: string): Buffer {
+  static pkFromSyncId(syncId: Uint8Array): Buffer {
     // The first 10 bytes are the timestamp, so we skip them
-    const pk = idString.slice(TIMESTAMP_LENGTH);
+    const pk = syncId.slice(TIMESTAMP_LENGTH);
 
-    return Buffer.from(pk, 'hex');
+    return Buffer.from(pk);
   }
 }
 

--- a/apps/hubble/src/network/utils/factories.ts
+++ b/apps/hubble/src/network/utils/factories.ts
@@ -46,15 +46,14 @@ const SyncIdFactory = Factory.define<undefined, { date: Date; hash: string; fid:
   ({ onCreate, transientParams }) => {
     onCreate(async () => {
       const { date, hash, fid } = transientParams;
-      const hashBytes = hexStringToBytes(hash || faker.datatype.hexadecimal({ length: HASH_LENGTH }))._unsafeUnwrap();
-      const ethSigner = Factories.Eip712Signer.build();
-      const signerMessage = await Factories.SignerAddMessage.create(
-        {
-          hash: hashBytes,
-          data: { fid: fid || Factories.Fid.build(), timestamp: (date || faker.date.recent()).getTime() / 1000 },
-        },
-        { transient: { signer: ethSigner } }
-      );
+      const hashBytes = hexStringToBytes(
+        hash || faker.datatype.hexadecimal({ length: HASH_LENGTH * 2 })
+      )._unsafeUnwrap();
+
+      const signerMessage = await Factories.SignerAddMessage.create({
+        hash: hashBytes,
+        data: { fid: fid || Factories.Fid.build(), timestamp: (date || faker.date.recent()).getTime() / 1000 },
+      });
 
       return new SyncId(signerMessage);
     });

--- a/apps/hubble/src/rpc/server/test/verificationService.test.ts
+++ b/apps/hubble/src/rpc/server/test/verificationService.test.ts
@@ -111,7 +111,7 @@ describe('getVerificationsByFid', () => {
     expect(verifications._unsafeUnwrap().messages.map((m) => protobufs.Message.toJSON(m))).toEqual(
       [verificationAdd].map((m) => protobufs.Message.toJSON(m))
     );
-  }, 1000000);
+  });
 
   test('returns empty array without messages', async () => {
     const verifications = await client.getVerificationsByFid(protobufs.FidRequest.create({ fid }));

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -153,8 +153,8 @@ class Engine {
       callback(message);
     }
   }
-  async getAllMessagesBySyncIds(syncIds: string[]): HubAsyncResult<protobufs.Message[]> {
-    const hashesBuf = syncIds.map((syncIdHash) => SyncId.pkFromIdString(syncIdHash));
+  async getAllMessagesBySyncIds(syncIds: Uint8Array[]): HubAsyncResult<protobufs.Message[]> {
+    const hashesBuf = syncIds.map((syncIdHash) => SyncId.pkFromSyncId(syncIdHash));
     const messages = await ResultAsync.fromPromise(getManyMessages(this._db, hashesBuf), (e) => e as HubError);
 
     return messages;

--- a/packages/protobufs/src/generated/rpc.ts
+++ b/packages/protobufs/src/generated/rpc.ts
@@ -38,25 +38,25 @@ export interface HubInfoResponse {
 }
 
 export interface TrieNodeMetadataResponse {
-  prefix: string;
+  prefix: Uint8Array;
   numMessages: number;
   hash: string;
   children: TrieNodeMetadataResponse[];
 }
 
 export interface TrieNodeSnapshotResponse {
-  prefix: string;
+  prefix: Uint8Array;
   excludedHashes: string[];
   numMessages: number;
   rootHash: string;
 }
 
 export interface TrieNodePrefix {
-  prefix: string;
+  prefix: Uint8Array;
 }
 
 export interface SyncIds {
-  syncIds: string[];
+  syncIds: Uint8Array[];
 }
 
 export interface FidRequest {
@@ -235,13 +235,13 @@ export const HubInfoResponse = {
 };
 
 function createBaseTrieNodeMetadataResponse(): TrieNodeMetadataResponse {
-  return { prefix: "", numMessages: 0, hash: "", children: [] };
+  return { prefix: new Uint8Array(), numMessages: 0, hash: "", children: [] };
 }
 
 export const TrieNodeMetadataResponse = {
   encode(message: TrieNodeMetadataResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.prefix !== "") {
-      writer.uint32(10).string(message.prefix);
+    if (message.prefix.length !== 0) {
+      writer.uint32(10).bytes(message.prefix);
     }
     if (message.numMessages !== 0) {
       writer.uint32(16).uint64(message.numMessages);
@@ -263,7 +263,7 @@ export const TrieNodeMetadataResponse = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.prefix = reader.string();
+          message.prefix = reader.bytes();
           break;
         case 2:
           message.numMessages = longToNumber(reader.uint64() as Long);
@@ -284,7 +284,7 @@ export const TrieNodeMetadataResponse = {
 
   fromJSON(object: any): TrieNodeMetadataResponse {
     return {
-      prefix: isSet(object.prefix) ? String(object.prefix) : "",
+      prefix: isSet(object.prefix) ? bytesFromBase64(object.prefix) : new Uint8Array(),
       numMessages: isSet(object.numMessages) ? Number(object.numMessages) : 0,
       hash: isSet(object.hash) ? String(object.hash) : "",
       children: Array.isArray(object?.children)
@@ -295,7 +295,8 @@ export const TrieNodeMetadataResponse = {
 
   toJSON(message: TrieNodeMetadataResponse): unknown {
     const obj: any = {};
-    message.prefix !== undefined && (obj.prefix = message.prefix);
+    message.prefix !== undefined &&
+      (obj.prefix = base64FromBytes(message.prefix !== undefined ? message.prefix : new Uint8Array()));
     message.numMessages !== undefined && (obj.numMessages = Math.round(message.numMessages));
     message.hash !== undefined && (obj.hash = message.hash);
     if (message.children) {
@@ -312,7 +313,7 @@ export const TrieNodeMetadataResponse = {
 
   fromPartial<I extends Exact<DeepPartial<TrieNodeMetadataResponse>, I>>(object: I): TrieNodeMetadataResponse {
     const message = createBaseTrieNodeMetadataResponse();
-    message.prefix = object.prefix ?? "";
+    message.prefix = object.prefix ?? new Uint8Array();
     message.numMessages = object.numMessages ?? 0;
     message.hash = object.hash ?? "";
     message.children = object.children?.map((e) => TrieNodeMetadataResponse.fromPartial(e)) || [];
@@ -321,13 +322,13 @@ export const TrieNodeMetadataResponse = {
 };
 
 function createBaseTrieNodeSnapshotResponse(): TrieNodeSnapshotResponse {
-  return { prefix: "", excludedHashes: [], numMessages: 0, rootHash: "" };
+  return { prefix: new Uint8Array(), excludedHashes: [], numMessages: 0, rootHash: "" };
 }
 
 export const TrieNodeSnapshotResponse = {
   encode(message: TrieNodeSnapshotResponse, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.prefix !== "") {
-      writer.uint32(10).string(message.prefix);
+    if (message.prefix.length !== 0) {
+      writer.uint32(10).bytes(message.prefix);
     }
     for (const v of message.excludedHashes) {
       writer.uint32(18).string(v!);
@@ -349,7 +350,7 @@ export const TrieNodeSnapshotResponse = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.prefix = reader.string();
+          message.prefix = reader.bytes();
           break;
         case 2:
           message.excludedHashes.push(reader.string());
@@ -370,7 +371,7 @@ export const TrieNodeSnapshotResponse = {
 
   fromJSON(object: any): TrieNodeSnapshotResponse {
     return {
-      prefix: isSet(object.prefix) ? String(object.prefix) : "",
+      prefix: isSet(object.prefix) ? bytesFromBase64(object.prefix) : new Uint8Array(),
       excludedHashes: Array.isArray(object?.excludedHashes) ? object.excludedHashes.map((e: any) => String(e)) : [],
       numMessages: isSet(object.numMessages) ? Number(object.numMessages) : 0,
       rootHash: isSet(object.rootHash) ? String(object.rootHash) : "",
@@ -379,7 +380,8 @@ export const TrieNodeSnapshotResponse = {
 
   toJSON(message: TrieNodeSnapshotResponse): unknown {
     const obj: any = {};
-    message.prefix !== undefined && (obj.prefix = message.prefix);
+    message.prefix !== undefined &&
+      (obj.prefix = base64FromBytes(message.prefix !== undefined ? message.prefix : new Uint8Array()));
     if (message.excludedHashes) {
       obj.excludedHashes = message.excludedHashes.map((e) => e);
     } else {
@@ -396,7 +398,7 @@ export const TrieNodeSnapshotResponse = {
 
   fromPartial<I extends Exact<DeepPartial<TrieNodeSnapshotResponse>, I>>(object: I): TrieNodeSnapshotResponse {
     const message = createBaseTrieNodeSnapshotResponse();
-    message.prefix = object.prefix ?? "";
+    message.prefix = object.prefix ?? new Uint8Array();
     message.excludedHashes = object.excludedHashes?.map((e) => e) || [];
     message.numMessages = object.numMessages ?? 0;
     message.rootHash = object.rootHash ?? "";
@@ -405,13 +407,13 @@ export const TrieNodeSnapshotResponse = {
 };
 
 function createBaseTrieNodePrefix(): TrieNodePrefix {
-  return { prefix: "" };
+  return { prefix: new Uint8Array() };
 }
 
 export const TrieNodePrefix = {
   encode(message: TrieNodePrefix, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.prefix !== "") {
-      writer.uint32(10).string(message.prefix);
+    if (message.prefix.length !== 0) {
+      writer.uint32(10).bytes(message.prefix);
     }
     return writer;
   },
@@ -424,7 +426,7 @@ export const TrieNodePrefix = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.prefix = reader.string();
+          message.prefix = reader.bytes();
           break;
         default:
           reader.skipType(tag & 7);
@@ -435,12 +437,13 @@ export const TrieNodePrefix = {
   },
 
   fromJSON(object: any): TrieNodePrefix {
-    return { prefix: isSet(object.prefix) ? String(object.prefix) : "" };
+    return { prefix: isSet(object.prefix) ? bytesFromBase64(object.prefix) : new Uint8Array() };
   },
 
   toJSON(message: TrieNodePrefix): unknown {
     const obj: any = {};
-    message.prefix !== undefined && (obj.prefix = message.prefix);
+    message.prefix !== undefined &&
+      (obj.prefix = base64FromBytes(message.prefix !== undefined ? message.prefix : new Uint8Array()));
     return obj;
   },
 
@@ -450,7 +453,7 @@ export const TrieNodePrefix = {
 
   fromPartial<I extends Exact<DeepPartial<TrieNodePrefix>, I>>(object: I): TrieNodePrefix {
     const message = createBaseTrieNodePrefix();
-    message.prefix = object.prefix ?? "";
+    message.prefix = object.prefix ?? new Uint8Array();
     return message;
   },
 };
@@ -462,7 +465,7 @@ function createBaseSyncIds(): SyncIds {
 export const SyncIds = {
   encode(message: SyncIds, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
     for (const v of message.syncIds) {
-      writer.uint32(10).string(v!);
+      writer.uint32(10).bytes(v!);
     }
     return writer;
   },
@@ -475,7 +478,7 @@ export const SyncIds = {
       const tag = reader.uint32();
       switch (tag >>> 3) {
         case 1:
-          message.syncIds.push(reader.string());
+          message.syncIds.push(reader.bytes());
           break;
         default:
           reader.skipType(tag & 7);
@@ -486,13 +489,13 @@ export const SyncIds = {
   },
 
   fromJSON(object: any): SyncIds {
-    return { syncIds: Array.isArray(object?.syncIds) ? object.syncIds.map((e: any) => String(e)) : [] };
+    return { syncIds: Array.isArray(object?.syncIds) ? object.syncIds.map((e: any) => bytesFromBase64(e)) : [] };
   },
 
   toJSON(message: SyncIds): unknown {
     const obj: any = {};
     if (message.syncIds) {
-      obj.syncIds = message.syncIds.map((e) => e);
+      obj.syncIds = message.syncIds.map((e) => base64FromBytes(e !== undefined ? e : new Uint8Array()));
     } else {
       obj.syncIds = [];
     }

--- a/packages/protobufs/src/schemas/rpc.proto
+++ b/packages/protobufs/src/schemas/rpc.proto
@@ -15,25 +15,25 @@ message HubInfoResponse {
 }
 
 message TrieNodeMetadataResponse {
-  string prefix = 1;
-  uint64 num_messages = 2;
-  string hash = 3;
-  repeated TrieNodeMetadataResponse children = 4;
+    bytes prefix = 1;
+    uint64 num_messages = 2;
+    string hash = 3;
+    repeated TrieNodeMetadataResponse children = 4;
 }
 
 message TrieNodeSnapshotResponse {
-  string prefix = 1;
-  repeated string excluded_hashes = 2;
-  uint64 num_messages = 3;
-  string root_hash = 4;
+    bytes prefix = 1;
+    repeated string excluded_hashes = 2;
+    uint64 num_messages = 3;
+    string root_hash = 4;
 }
 
 message TrieNodePrefix {
-  string prefix = 1;
+    bytes prefix = 1;
 }
 
 message SyncIds {
-  repeated string sync_ids = 1;
+    repeated bytes sync_ids = 1;
 }
 
 message FidRequest {


### PR DESCRIPTION
## Motivation

Use `Uint8Array` of bytes instead of hex strings in Sync Tries

## Change Summary

- Switch key to bytes instead of hex strings for memory efficiency
- Update tests and RPC protocol to use bytes for prefixes

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
