### PR TITLE
fix: Use hash bytes instead of hex string to calculate hashes

### DIFF
--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -242,8 +242,8 @@ describe('MerkleTrie', () => {
       const expectedHash = Buffer.from(
         blake3
           .create({ dkLen: 20 })
-          .update(node?.children?.get(Buffer.from('3')[0] as number)?.hash || '')
-          .update(node?.children?.get(Buffer.from('4')[0] as number)?.hash || '')
+          .update(Buffer.from(node?.children?.get(Buffer.from('3')[0] as number)?.hash || '', 'hex'))
+          .update(Buffer.from(node?.children?.get(Buffer.from('4')[0] as number)?.hash || '', 'hex'))
           .digest()
       ).toString('hex');
       expect(snapshot.excludedHashes).toEqual([
@@ -262,14 +262,14 @@ describe('MerkleTrie', () => {
       snapshot = trie.getSnapshot(Buffer.from('1665182343'));
       node = trie.getTrieNodeMetadata(Buffer.from('166518234'));
       const expectedLastHash = Buffer.from(
-        blake3(node?.children?.get(Buffer.from('5')[0] as number)?.hash || '', { dkLen: 20 })
+        blake3(Buffer.from(node?.children?.get(Buffer.from('5')[0] as number)?.hash || '', 'hex'), { dkLen: 20 })
       ).toString('hex');
       node = trie.getTrieNodeMetadata(Buffer.from('16651823'));
       const expectedPenultimateHash = Buffer.from(
         blake3
           .create({ dkLen: 20 })
-          .update(node?.children?.get(Buffer.from('3')[0] as number)?.hash || '')
-          .update(node?.children?.get(Buffer.from('5')[0] as number)?.hash || '')
+          .update(Buffer.from(node?.children?.get(Buffer.from('3')[0] as number)?.hash || '', 'hex'))
+          .update(Buffer.from(node?.children?.get(Buffer.from('5')[0] as number)?.hash || '', 'hex'))
           .digest()
       ).toString('hex');
       expect(snapshot.excludedHashes).toEqual([

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -303,6 +303,9 @@ describe('Multi peer sync engine', () => {
         totalMessages += batchSize;
       }
 
+      // Make sure the recalculatedHash matches root hash
+      expect(Buffer.from(syncEngine1.trie.root.recalculateHash()).toString('hex')).toEqual(syncEngine1.trie.rootHash);
+
       const engine2 = new Engine(testDb2, network);
       const syncEngine2 = new SyncEngine(engine2);
       syncEngine2.initialize();

--- a/apps/hubble/src/network/sync/trieNode.test.ts
+++ b/apps/hubble/src/network/sync/trieNode.test.ts
@@ -174,6 +174,9 @@ describe('TrieNode', () => {
         root.insert(ids[i] as Uint8Array);
       }
 
+      // Except the recalculatedHash to match the root hash
+      expect(root.hash).toEqual(Buffer.from(root.recalculateHash()).toString('hex'));
+
       // Remove the first id
       root.delete(ids[0] as Uint8Array);
 


### PR DESCRIPTION
## Motivation

Use hash bytes instead of hex strings to calculate a node's hash. 

## Change Summary

- recalculateHash method to recalculate hashes if needed
- Use hash bytes instead of hex strings of child's hash

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
