### PR TITLE
feat: injest ethEventsProvider event logs in batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ coverage/
 out
 
 dist
+
+# Editor Cache
+.vscode
+.idea
+.fleet

--- a/apps/hubble/src/eth/ethEventsProvider.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.ts
@@ -251,32 +251,6 @@ export class EthEventsProvider {
         }
       }
     }
-
-    // const oldIdEvents = await ResultAsync.fromPromise(
-    //   this._idRegistryContract.queryFilter(typeString, Number(fromBlock), Number(toBlock)),
-    //   (e) => e
-    // );
-    // if (oldIdEvents.isErr()) {
-    //   log.error({ err: oldIdEvents.error }, 'failed to get old Id events');
-    //   return;
-    // }
-    //
-    // for (const event of oldIdEvents.value) {
-    //   const toIndex = type === protobufs.IdRegistryEventType.ID_REGISTRY_EVENT_TYPE_REGISTER ? 0 : 1;
-    //   const idIndex = type === protobufs.IdRegistryEventType.ID_REGISTRY_EVENT_TYPE_REGISTER ? 1 : 2;
-    //
-    //   // Parsing can throw errors, so we'll just log them and continue
-    //   try {
-    //     const to: string = event.args?.at(toIndex);
-    //     const id: BigNumber = BigNumber.from(event.args?.at(idIndex));
-    //     const from: string =
-    //       type === protobufs.IdRegistryEventType.ID_REGISTRY_EVENT_TYPE_REGISTER ? null : event.args?.at(0);
-    //
-    //     await this.cacheIdRegistryEvent(from, to, id, type, event);
-    //   } catch (e) {
-    //     log.error({ event }, 'failed to parse event args');
-    //   }
-    // }
   }
 
   /**


### PR DESCRIPTION
## Motivation
This PR resolves issue #317, related to injesting the event logs from smart contracts in batches, vs all at once.

tl;dr for #317 is that trying to injest hundreds of thousands of events in one go, can lead to timeout and associated bugs, but processing them in smaller batches will allow them to be processed easier

## Change Summary
I updated the `syncHistoricalIdEvents` and `syncHistoricalNameEvents` functions to use a configurable batchSize parameter. This allows event logs to be injested in batches, vs all at once.

Along with that, although its outside of the scope of the issue, I added a section for Editor cache to the .gitignore, including .vscode, .idea, and .fleet, since I didn't want to accidentally commit my cache

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [] Changes to the protocol specification have been merged - N/A, I don't think theres any protocol spec that needs to be updated/merged for this PR? Happy to update it if there is, though.

## Additional Context
N/A
