### PR TITLE
fix: Docker image builds post Hub→Hubble rename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,14 +65,13 @@ COPY --chown=node:node --from=prune /home/node/app/out/yarn.lock ./yarn.lock
 RUN yarn install --frozen-lockfile --production --network-timeout 1800000
 
 # Copy results from previous stage
-COPY --chown=node:node --from=build /home/node/app/packages/flatbuffers/dist ./packages/flatbuffers/dist
-COPY --chown=node:node --from=build /home/node/app/packages/grpc/dist ./packages/grpc/dist
+COPY --chown=node:node --from=build /home/node/app/packages/protobufs/dist ./packages/protobufs/dist
 COPY --chown=node:node --from=build /home/node/app/packages/utils/dist ./packages/utils/dist
 COPY --chown=node:node tsconfig.json tsconfig.json
 
 # TODO: determine if this can be removed while using tsx (or find alternative)
 # since we should be able to run with just the compiled javascript in build/
-COPY --chown=node:node ./apps/hub ./apps/hub
+COPY --chown=node:node ./apps/hubble ./apps/hub
 
 # TODO: load identity from some secure store instead of generating a new one
 RUN yarn --cwd=apps/hub identity create

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hub",
+  "name": "hubble",
   "description": "A monorepo for the Farcaster Hub",
   "version": "0.0.0",
   "private": true,


### PR DESCRIPTION
## Motivation

Docker builds stopped working post repo rename from `hub` to `hubble`.

## Change Summary

Fix the Docker image build.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

N/A
