### PR TITLE
feat: Use uint32 for fid keys + ts compression in SyncID keys

### DIFF
--- a/apps/hubble/src/network/sync/trieNode.test.ts
+++ b/apps/hubble/src/network/sync/trieNode.test.ts
@@ -5,10 +5,8 @@ import { NetworkFactories } from '~/network/utils/factories';
 
 const fid = Factories.Fid.build();
 const sharedDate = new Date(1665182332000);
-const sharedPrefixHashA =
-  '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86a4321';
-const sharedPrefixHashB =
-  '0x09bc3dad4e7f2a77bbb2cccbecb06febfc3f0cbe7ea6a774d2dc043fd45c2c9912f130bf502c88fdedf7bbc4cd20b47aab2079e2d5cbd0a35afd2deec86b1234';
+const sharedPrefixHashA = '09bc3dad4e7f2a77bbb2cccbecb06febfc6a4321';
+const sharedPrefixHashB = '09bc3dad4e7f2a77bbb2cccbecb06febfc6b1234';
 
 describe('TrieNode', () => {
   // Traverse the node until we find a leaf or path splits into multiple choices

--- a/apps/hubble/src/storage/db/idRegistryEvent.ts
+++ b/apps/hubble/src/storage/db/idRegistryEvent.ts
@@ -6,7 +6,7 @@ import { FID_BYTES, RootPrefix } from '~/storage/db/types';
 export const makeIdRegistryEventPrimaryKey = (fid: number): Buffer => {
   const buffer = Buffer.alloc(1 + FID_BYTES);
   buffer.writeUint8(RootPrefix.IdRegistryEvent, 0);
-  buffer.writeBigUint64BE(BigInt(fid), 1); // Big endian for ordering
+  buffer.writeUint32BE(fid, 1); // Big endian for ordering
   return buffer;
 };
 

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -14,7 +14,9 @@ import {
 
 export const makeFidKey = (fid: number): Buffer => {
   const buffer = Buffer.alloc(FID_BYTES);
-  buffer.writeBigUInt64BE(BigInt(fid), 0);
+  // Even though fid is 64 bits, we're only using 32 bits for now, to save 4 bytes per key.
+  // This is fine until 4 billion users, after which we'll need to do a migration of this key in the DB.
+  buffer.writeUInt32BE(fid, 0);
   return buffer;
 };
 

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -1,8 +1,11 @@
 /** Used when index keys are sufficiently descriptive */
 export const TRUE_VALUE = Buffer.from([1]);
 
-/** Size in bytes of a Farcaster ID */
-export const FID_BYTES = 8;
+/**
+ * Size in bytes of a Farcaster ID. Even though it's technically 64 bit, we use 32-bit keys in the DB
+ * to save 4 bytes per key. This is fine until 4 billion users, after which we'll need to do a migration
+ */
+export const FID_BYTES = 4;
 
 /**
  * RootPrefix indicates the purpose of the key. It is the 1st byte of every key.

--- a/apps/hubble/src/storage/stores/ampStore.ts
+++ b/apps/hubble/src/storage/stores/ampStore.ts
@@ -145,7 +145,7 @@ class AmpStore extends SequentialMergeStore {
     const byTargetFidPrefix = makeAmpsByTargetFidKey(targetFid);
     const messageKeys: Buffer[] = [];
     for await (const [key] of this._db.iteratorByPrefix(byTargetFidPrefix, { keyAsBuffer: true, values: false })) {
-      const fid = Number((key as Buffer).readBigUint64BE(byTargetFidPrefix.length));
+      const fid = Number((key as Buffer).readUint32BE(byTargetFidPrefix.length));
       const tsHash = Uint8Array.from(key).subarray(byTargetFidPrefix.length + FID_BYTES);
       messageKeys.push(makeMessagePrimaryKey(fid, UserPostfix.AmpMessage, tsHash));
     }

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -166,7 +166,7 @@ class CastStore extends SequentialMergeStore {
     const byParentPrefix = makeCastsByParentKey(parentId);
     const messageKeys: Buffer[] = [];
     for await (const [key] of this._db.iteratorByPrefix(byParentPrefix, { keyAsBuffer: true, values: false })) {
-      const fid = Number((key as Buffer).readBigUint64BE(byParentPrefix.length));
+      const fid = Number((key as Buffer).readUint32BE(byParentPrefix.length));
       const tsHash = Uint8Array.from(key).subarray(byParentPrefix.length + FID_BYTES);
       const messagePrimaryKey = makeMessagePrimaryKey(fid, UserPostfix.CastMessage, tsHash);
       messageKeys.push(messagePrimaryKey);
@@ -179,7 +179,7 @@ class CastStore extends SequentialMergeStore {
     const byMentionPrefix = makeCastsByMentionKey(mentionFid);
     const messageKeys: Buffer[] = [];
     for await (const [key] of this._db.iteratorByPrefix(byMentionPrefix, { keyAsBuffer: true, values: false })) {
-      const fid = Number((key as Buffer).readBigUint64BE(byMentionPrefix.length));
+      const fid = Number((key as Buffer).readUint32BE(byMentionPrefix.length));
       const tsHash = Uint8Array.from(key).subarray(byMentionPrefix.length + FID_BYTES);
       const messagePrimaryKey = makeMessagePrimaryKey(fid, UserPostfix.CastMessage, tsHash);
       messageKeys.push(messagePrimaryKey);

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -215,7 +215,7 @@ class ReactionStore extends SequentialMergeStore {
 
     const messageKeys: Buffer[] = [];
     for await (const [key] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
-      const fid = Number((key as Buffer).readBigUint64BE(fidOffset));
+      const fid = Number((key as Buffer).readUint32BE(fidOffset));
       const tsHash = Uint8Array.from(key).subarray(tsHashOffset);
       messageKeys.push(makeMessagePrimaryKey(fid, UserPostfix.ReactionMessage, tsHash));
     }

--- a/apps/hubble/src/storage/stores/signerStore.ts
+++ b/apps/hubble/src/storage/stores/signerStore.ts
@@ -159,7 +159,7 @@ class SignerStore extends SequentialMergeStore {
     const prefix = Buffer.from([RootPrefix.IdRegistryEvent]);
     const fids: number[] = [];
     for await (const [key] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
-      fids.push(Number((key as Buffer).readBigUint64BE(1)));
+      fids.push(Number((key as Buffer).readUint32BE(1)));
     }
     return fids;
   }


### PR DESCRIPTION
## Motivation

To save 8 bytes in rocks DB keys, this PR:
1. Stores FID keys in messages as 32 bits
2. Don't use the "ts" part of the tshash in SyncID keys since the timestamp is also available.

## Change Summary

- Change fid keys to 32 bits
- Use the hash instead of tsHash in the SyncID keys
- Reconstruct primary key from SyncIDs by inserting the timestamp again. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
