### PR TITLE
fix: Update Turbo 1.6.3 → 1.7.3.canary.1 to fix Docker builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "rimraf": "^3.0.2",
     "ts-node": "^10.9.1",
     "tsup": "^6.5.0",
-    "turbo": "^1.6.3",
+    "turbo": "^1.7.3-canary.1",
     "typescript": "4.9.4"
   },
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7449,47 +7449,47 @@ tty-table@^4.1.5:
     wcwidth "^1.0.1"
     yargs "^17.1.1"
 
-turbo-darwin-64@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.6.3.tgz#fad7e078784b0fafc0b1f75ce9378828918595f5"
-  integrity sha512-QmDIX0Yh1wYQl0bUS0gGWwNxpJwrzZU2GIAYt3aOKoirWA2ecnyb3R6ludcS1znfNV2MfunP+l8E3ncxUHwtjA==
+turbo-darwin-64@1.7.3-canary.1:
+  version "1.7.3-canary.1"
+  resolved "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-1.7.3-canary.1.tgz#849243cbfae33420925bd6809b9d692cb56234c7"
+  integrity sha512-Xs7AsZEkWhXtZcBstCTbfMNb5SIqh6HaO2zS7it8zEbJUI+/GyND2YNUfkOswoD7hLYxBqFkaEzFOAlxJ5R28Q==
 
-turbo-darwin-arm64@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.6.3.tgz#f0a32cae39e3fcd3da5e3129a94c18bb2e3ed6aa"
-  integrity sha512-75DXhFpwE7CinBbtxTxH08EcWrxYSPFow3NaeFwsG8aymkWXF+U2aukYHJA6I12n9/dGqf7yRXzkF0S/9UtdyQ==
+turbo-darwin-arm64@1.7.3-canary.1:
+  version "1.7.3-canary.1"
+  resolved "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-1.7.3-canary.1.tgz#a1c273c6c4b75804166790375bacd898f07287fc"
+  integrity sha512-zs/RawpVFuvVu3o4XShxTsET8q3ZbgCzC8Sn/ZtBEIzL3Ixfg1Cta8AcC8fIUvL8BBqoehMcT1XLyKHp0nAfdQ==
 
-turbo-linux-64@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.6.3.tgz#8ddc6ac55ef84641182fe5ff50647f1b355826b0"
-  integrity sha512-O9uc6J0yoRPWdPg9THRQi69K6E2iZ98cRHNvus05lZbcPzZTxJYkYGb5iagCmCW/pq6fL4T4oLWAd6evg2LGQA==
+turbo-linux-64@1.7.3-canary.1:
+  version "1.7.3-canary.1"
+  resolved "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-1.7.3-canary.1.tgz#fddf586eb6862aa8d74fe76ff243824bb3f9f012"
+  integrity sha512-n92Y7sUxFrR8/hl6642QFXGYIUyUualw1bGT8buqjZKmhVaYquTKHIWTm2HT+GkxWfALYSBk8UYrwT3FiuaGQA==
 
-turbo-linux-arm64@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.6.3.tgz#846c1dc84d8dc741651906613c16acccba30428c"
-  integrity sha512-dCy667qqEtZIhulsRTe8hhWQNCJO0i20uHXv7KjLHuFZGCeMbWxB8rsneRoY+blf8+QNqGuXQJxak7ayjHLxiA==
+turbo-linux-arm64@1.7.3-canary.1:
+  version "1.7.3-canary.1"
+  resolved "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-1.7.3-canary.1.tgz#920da4d81bd686a5dd2977f6f2f82fb7bfbb9956"
+  integrity sha512-KtOnSuYaFNM+0EH/YzNs+sc+p+BB1Yshte7nQ5Gg7tomRRRV9t4YPoPVTwIvqxJbb8of1Pnf56pYvzISi9ipUw==
 
-turbo-windows-64@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.6.3.tgz#89ac819fa76ad31d12fbfdeb3045bcebd0d308eb"
-  integrity sha512-lKRqwL3mrVF09b9KySSaOwetehmGknV9EcQTF7d2dxngGYYX1WXoQLjFP9YYH8ZV07oPm+RUOAKSCQuDuMNhiA==
+turbo-windows-64@1.7.3-canary.1:
+  version "1.7.3-canary.1"
+  resolved "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-1.7.3-canary.1.tgz#9223988e04a2104ae276bf8f68ffb3bab1665d5f"
+  integrity sha512-k/G1gvyRoquI5Y0m5jiqpiWm+PRMXd4LrO5Pb4GQH+fGajjwdqn9IGFkGorVJ+9u8yAzgxfBpeMpOED7KeoPWQ==
 
-turbo-windows-arm64@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.6.3.tgz#977607c9a51f0b76076c8b158bafce06ce813070"
-  integrity sha512-BXY1sDPEA1DgPwuENvDCD8B7Hb0toscjus941WpL8CVd10hg9pk/MWn9CNgwDO5Q9ks0mw+liDv2EMnleEjeNA==
+turbo-windows-arm64@1.7.3-canary.1:
+  version "1.7.3-canary.1"
+  resolved "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-1.7.3-canary.1.tgz#faf4b58a1b8b1c02c596f7c2101f45eaaf1e446c"
+  integrity sha512-wGhSry3OkVMT54AvuiUi8hV3QiN7L+pRaS8Vjm12fh/5ZAJgS41maUFDVEdJlvHJnL88/8y46ww19+pUqtGgGw==
 
-turbo@^1.6.3:
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/turbo/-/turbo-1.6.3.tgz#ec26cc8907c38a9fd6eb072fb10dad254733543e"
-  integrity sha512-FtfhJLmEEtHveGxW4Ye/QuY85AnZ2ZNVgkTBswoap7UMHB1+oI4diHPNyqrQLG4K1UFtCkjOlVoLsllUh/9QRw==
+turbo@^1.7.3-canary.1:
+  version "1.7.3-canary.1"
+  resolved "https://registry.npmjs.org/turbo/-/turbo-1.7.3-canary.1.tgz#8a3bd8d21ccfafb044f3352b85b879ed03c2ce93"
+  integrity sha512-CAD2Oz0LajNDgIJtAWfwcjfYMoLnfTFe8maDjuh4c1r95nHtipHs+A8YIm7cifCop56R+tOx5eFyWMe+Drxkww==
   optionalDependencies:
-    turbo-darwin-64 "1.6.3"
-    turbo-darwin-arm64 "1.6.3"
-    turbo-linux-64 "1.6.3"
-    turbo-linux-arm64 "1.6.3"
-    turbo-windows-64 "1.6.3"
-    turbo-windows-arm64 "1.6.3"
+    turbo-darwin-64 "1.7.3-canary.1"
+    turbo-darwin-arm64 "1.7.3-canary.1"
+    turbo-linux-64 "1.7.3-canary.1"
+    turbo-linux-arm64 "1.7.3-canary.1"
+    turbo-windows-64 "1.7.3-canary.1"
+    turbo-windows-arm64 "1.7.3-canary.1"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Motivation

We need this update to fix an issue with our builds that occurs on GitHub Actions only (cannot repro locally).

Based on [this issue](https://github.com/vercel/turbo/issues/3570#issuecomment-1413350084), this should be fixed in 1.7.3, but since that release is not available, we'll use the canary for now.

## Change Summary

Updated Turbo to 1.7.3 canary build 1.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged
