### PR TITLE
feat: Move ampService and userDataService tests

### DIFF
--- a/apps/hubble/src/rpc/server/test/ampService.test.ts
+++ b/apps/hubble/src/rpc/server/test/ampService.test.ts
@@ -1,0 +1,123 @@
+import * as protobufs from '@farcaster/protobufs';
+import { Factories, getHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
+import SyncEngine from '~/network/sync/syncEngine';
+import Server from '~/rpc/server';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import Engine from '~/storage/engine';
+import { MockHub } from '~/test/mocks';
+
+const db = jestRocksDB('protobufs.rpc.ampService.test');
+const network = protobufs.FarcasterNetwork.FARCASTER_NETWORK_TESTNET;
+const engine = new Engine(db, network);
+const hub = new MockHub(db, engine);
+
+let server: Server;
+let client: HubRpcClient;
+
+beforeAll(async () => {
+  server = new Server(hub, engine, new SyncEngine(engine));
+  const port = await server.start();
+  client = getHubRpcClient(`127.0.0.1:${port}`);
+});
+
+afterAll(async () => {
+  client.$.close();
+  await server.stop();
+});
+
+const fid = Factories.Fid.build();
+const custodySigner = Factories.Eip712Signer.build();
+const signer = Factories.Ed25519Signer.build();
+
+let custodyEvent: protobufs.IdRegistryEvent;
+let signerAdd: protobufs.Message;
+let ampAdd: protobufs.AmpAddMessage;
+
+beforeAll(async () => {
+  custodyEvent = Factories.IdRegistryEvent.build({ fid, to: custodySigner.signerKey });
+
+  signerAdd = await Factories.SignerAddMessage.create(
+    { data: { fid, network, signerBody: { signer: signer.signerKey } } },
+    { transient: { signer: custodySigner } }
+  );
+
+  ampAdd = await Factories.AmpAddMessage.create({ data: { fid, network } }, { transient: { signer } });
+});
+
+describe('getAmp', () => {
+  beforeEach(async () => {
+    await engine.mergeIdRegistryEvent(custodyEvent);
+    await engine.mergeMessage(signerAdd);
+  });
+
+  test('succeeds', async () => {
+    await engine.mergeMessage(ampAdd);
+
+    const result = await client.getAmp(protobufs.AmpRequest.create({ fid, targetFid: ampAdd.data.ampBody?.targetFid }));
+    expect(result.isOk()).toBeTruthy();
+    expect(protobufs.Message.toJSON(result._unsafeUnwrap())).toEqual(protobufs.Message.toJSON(ampAdd));
+  });
+
+  test('fails if amp is missing', async () => {
+    const result = await client.getAmp(protobufs.AmpRequest.create({ fid, targetFid: ampAdd.data.ampBody?.targetFid }));
+    expect(result._unsafeUnwrapErr().errCode).toEqual('not_found');
+  });
+
+  test('fails without user', async () => {
+    const result = await client.getAmp(protobufs.AmpRequest.create({ fid, targetFid: 0 }));
+    expect(result._unsafeUnwrapErr()).toEqual(new HubError('bad_request.validation_failure', 'fid is missing'));
+  });
+
+  test('fails without fid', async () => {
+    const result = await client.getAmp(
+      protobufs.AmpRequest.create({ fid: 0, targetFid: ampAdd.data.ampBody?.targetFid })
+    );
+    expect(result._unsafeUnwrapErr()).toEqual(new HubError('bad_request.validation_failure', 'fid is missing'));
+  });
+});
+
+describe('getAmpsByFid', () => {
+  beforeEach(async () => {
+    await engine.mergeIdRegistryEvent(custodyEvent);
+    await engine.mergeMessage(signerAdd);
+  });
+
+  test('succeeds', async () => {
+    await engine.mergeMessage(ampAdd);
+    const amps = await client.getAmpsByFid(protobufs.FidRequest.create({ fid }));
+    expect(amps._unsafeUnwrap().messages.map((m) => protobufs.Message.toJSON(m))).toEqual(
+      [ampAdd].map((m) => protobufs.Message.toJSON(m))
+    );
+  });
+
+  test('returns empty array without messages', async () => {
+    const amps = await client.getAmpsByFid(protobufs.FidRequest.create({ fid }));
+    expect(amps._unsafeUnwrap().messages.length).toEqual(0);
+  });
+});
+
+describe('getAmpsByUser', () => {
+  beforeEach(async () => {
+    await engine.mergeIdRegistryEvent(custodyEvent);
+    await engine.mergeMessage(signerAdd);
+  });
+
+  test('succeeds', async () => {
+    await engine.mergeMessage(ampAdd);
+    const amps = await client.getAmpsByUser(protobufs.FidRequest.create({ fid: ampAdd.data.ampBody?.targetFid }));
+    expect(amps._unsafeUnwrap().messages.map((m) => protobufs.Message.toJSON(m))).toEqual(
+      [ampAdd].map((m) => protobufs.Message.toJSON(m))
+    );
+  });
+
+  test('returns empty with the wrong fid', async () => {
+    await engine.mergeMessage(ampAdd);
+    const amps = await client.getAmpsByUser(protobufs.FidRequest.create({ fid }));
+    expect(amps._unsafeUnwrap().messages.length).toEqual(0);
+  });
+
+  test('returns empty array without messages', async () => {
+    const amps = await client.getAmpsByUser(protobufs.FidRequest.create({ fid: ampAdd.data.ampBody?.targetFid }));
+    expect(amps._unsafeUnwrap().messages.length).toEqual(0);
+  });
+});

--- a/apps/hubble/src/rpc/server/test/userDataService.test.ts
+++ b/apps/hubble/src/rpc/server/test/userDataService.test.ts
@@ -1,0 +1,141 @@
+import * as protobufs from '@farcaster/protobufs';
+import { bytesToUtf8String, Factories, getHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
+import { ok } from 'neverthrow';
+import SyncEngine from '~/network/sync/syncEngine';
+import Server from '~/rpc/server';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import Engine from '~/storage/engine';
+import { MockHub } from '~/test/mocks';
+
+const db = jestRocksDB('protobufs.rpc.userdataservice.test');
+const network = protobufs.FarcasterNetwork.FARCASTER_NETWORK_TESTNET;
+const engine = new Engine(db, network);
+const hub = new MockHub(db, engine);
+
+let server: Server;
+let client: HubRpcClient;
+
+beforeAll(async () => {
+  server = new Server(hub, engine, new SyncEngine(engine));
+  const port = await server.start();
+  client = getHubRpcClient(`127.0.0.1:${port}`);
+});
+
+afterAll(async () => {
+  client.$.close();
+  await server.stop();
+});
+
+const fid = Factories.Fid.build();
+const fname = Factories.Fname.build();
+const custodySigner = Factories.Eip712Signer.build();
+const signer = Factories.Ed25519Signer.build();
+
+let custodyEvent: protobufs.IdRegistryEvent;
+let signerAdd: protobufs.Message;
+
+let pfpAdd: protobufs.UserDataAddMessage;
+let locationAdd: protobufs.UserDataAddMessage;
+let addFname: protobufs.UserDataAddMessage;
+
+beforeAll(async () => {
+  custodyEvent = Factories.IdRegistryEvent.build({ fid, to: custodySigner.signerKey });
+
+  signerAdd = await Factories.SignerAddMessage.create(
+    { data: { fid, network, signerBody: { signer: signer.signerKey } } },
+    { transient: { signer: custodySigner } }
+  );
+
+  pfpAdd = await Factories.UserDataAddMessage.create(
+    { data: { fid, userDataBody: { type: protobufs.UserDataType.USER_DATA_TYPE_PFP } } },
+    { transient: { signer } }
+  );
+
+  locationAdd = await Factories.UserDataAddMessage.create(
+    { data: { fid, userDataBody: { type: protobufs.UserDataType.USER_DATA_TYPE_LOCATION } } },
+    { transient: { signer } }
+  );
+
+  addFname = await Factories.UserDataAddMessage.create(
+    {
+      data: {
+        fid,
+        userDataBody: {
+          type: protobufs.UserDataType.USER_DATA_TYPE_FNAME,
+          value: bytesToUtf8String(fname)._unsafeUnwrap(),
+        },
+      },
+    },
+    { transient: { signer } }
+  );
+});
+
+describe('getUserData', () => {
+  beforeEach(async () => {
+    await engine.mergeIdRegistryEvent(custodyEvent);
+    await engine.mergeMessage(signerAdd);
+  });
+
+  test('succeeds', async () => {
+    expect(await engine.mergeMessage(pfpAdd)).toEqual(ok(undefined));
+    expect(await engine.mergeMessage(locationAdd)).toEqual(ok(undefined));
+
+    const pfp = await client.getUserData(
+      protobufs.UserDataRequest.create({ fid, userDataType: protobufs.UserDataType.USER_DATA_TYPE_PFP })
+    );
+    expect(protobufs.Message.toJSON(pfp._unsafeUnwrap())).toEqual(protobufs.Message.toJSON(pfpAdd));
+
+    const location = await client.getUserData(
+      protobufs.UserDataRequest.create({ fid, userDataType: protobufs.UserDataType.USER_DATA_TYPE_LOCATION })
+    );
+    expect(protobufs.Message.toJSON(location._unsafeUnwrap())).toEqual(protobufs.Message.toJSON(locationAdd));
+
+    const nameRegistryEvent = Factories.NameRegistryEvent.build({ fname, to: custodySigner.signerKey });
+    await engine.mergeNameRegistryEvent(nameRegistryEvent);
+
+    expect(await engine.mergeMessage(addFname)).toEqual(ok(undefined));
+    const fnameData = await client.getUserData(
+      protobufs.UserDataRequest.create({ fid, userDataType: protobufs.UserDataType.USER_DATA_TYPE_FNAME })
+    );
+    expect(protobufs.Message.toJSON(fnameData._unsafeUnwrap())).toEqual(protobufs.Message.toJSON(addFname));
+  });
+
+  test('fails when user data is missing', async () => {
+    const pfp = await client.getUserData(
+      protobufs.UserDataRequest.create({ fid, userDataType: protobufs.UserDataType.USER_DATA_TYPE_PFP })
+    );
+    expect(pfp._unsafeUnwrapErr().errCode).toEqual('not_found');
+    const fname = await client.getUserData(
+      protobufs.UserDataRequest.create({ fid, userDataType: protobufs.UserDataType.USER_DATA_TYPE_FNAME })
+    );
+    expect(fname._unsafeUnwrapErr().errCode).toEqual('not_found');
+  });
+
+  test('fails without fid', async () => {
+    const result = await client.getUserData(
+      protobufs.UserDataRequest.create({ fid: 0, userDataType: protobufs.UserDataType.USER_DATA_TYPE_PFP })
+    );
+    expect(result._unsafeUnwrapErr()).toEqual(new HubError('bad_request.validation_failure', 'fid is missing'));
+  });
+});
+
+describe('getUserDataByFid', () => {
+  beforeEach(async () => {
+    await engine.mergeIdRegistryEvent(custodyEvent);
+    await engine.mergeMessage(signerAdd);
+  });
+
+  test('succeeds', async () => {
+    await engine.mergeMessage(pfpAdd);
+    await engine.mergeMessage(locationAdd);
+    const result = await client.getUserDataByFid(protobufs.FidRequest.create({ fid }));
+    expect(result._unsafeUnwrap().messages.map((m) => protobufs.Message.toJSON(m))).toEqual(
+      [pfpAdd, locationAdd].map((m) => protobufs.Message.toJSON(m))
+    );
+  });
+
+  test('returns empty array without messages', async () => {
+    const result = await client.getUserDataByFid(protobufs.FidRequest.create({ fid }));
+    expect(result._unsafeUnwrap().messages.length).toEqual(0);
+  });
+});

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -216,6 +216,16 @@ class Engine {
   /* -------------------------------------------------------------------------- */
 
   async getAmp(fid: number, targetFid: number): HubAsyncResult<protobufs.AmpAddMessage> {
+    const validatedFid = validations.validateFid(fid);
+    if (validatedFid.isErr()) {
+      return err(validatedFid.error);
+    }
+
+    const validatedTargetFid = validations.validateFid(targetFid);
+    if (validatedTargetFid.isErr()) {
+      return err(validatedTargetFid.error);
+    }
+
     return ResultAsync.fromPromise(this._ampStore.getAmpAdd(fid, targetFid), (e) => e as HubError);
   }
 
@@ -418,14 +428,29 @@ class Engine {
   /* -------------------------------------------------------------------------- */
 
   async getUserData(fid: number, type: protobufs.UserDataType): HubAsyncResult<protobufs.UserDataAddMessage> {
+    const validatedFid = validations.validateFid(fid);
+    if (validatedFid.isErr()) {
+      return err(validatedFid.error);
+    }
+
     return ResultAsync.fromPromise(this._userDataStore.getUserDataAdd(fid, type), (e) => e as HubError);
   }
 
   async getUserDataByFid(fid: number): HubAsyncResult<protobufs.UserDataAddMessage[]> {
+    const validatedFid = validations.validateFid(fid);
+    if (validatedFid.isErr()) {
+      return err(validatedFid.error);
+    }
+
     return ResultAsync.fromPromise(this._userDataStore.getUserDataAddsByFid(fid), (e) => e as HubError);
   }
 
   async getNameRegistryEvent(fname: Uint8Array): HubAsyncResult<protobufs.NameRegistryEvent> {
+    const validatedFname = validations.validateFname(fname);
+    if (validatedFname.isErr()) {
+      return err(validatedFname.error);
+    }
+
     return ResultAsync.fromPromise(this._userDataStore.getNameRegistryEvent(fname), (e) => e as HubError);
   }
 


### PR DESCRIPTION
## Motivation

Move ampservice and userdataservice tests to protobufs

## Change Summary

- Move ampservice and userdataservice tests to protobufs

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
