### PR TITLE
fix: Expose gossip protocol port outside of container by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,4 +77,4 @@ COPY --chown=node:node ./apps/hubble ./apps/hub
 # TODO: load identity from some secure store instead of generating a new one
 RUN yarn --cwd=apps/hub identity create
 
-CMD ["yarn", "--cwd=apps/hub", "start", "--rpc-port", "8080", "--gossip-port", "9090", "--eth-rpc-url", "https://eth-goerli.g.alchemy.com/v2/IvjMoCKt1hT66f9OJoL_dMXypnvQYUdd"]
+CMD ["yarn", "--cwd=apps/hub", "start", "--rpc-port", "8080", "--ip", "0.0.0.0", "--gossip-port", "9090", "--eth-rpc-url", "https://eth-goerli.g.alchemy.com/v2/IvjMoCKt1hT66f9OJoL_dMXypnvQYUdd"]


### PR DESCRIPTION
Binding to the loopback interface doesn't work when running within a
container.

## Motivation

Describe why this issue should be fixed and link to any relevant design docs, issues or other relevant items.

## Change Summary

Describe the changes being made in 1-2 concise sentences.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
