### PR TITLE
chore: Reduce Docker image size using Alpine base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@
 ############## Stage 1: Create pruned version of monorepo #####################
 ###############################################################################
 
-FROM node:18 AS prune
+FROM node:18-alpine AS prune
+
+RUN apk add --no-cache libc6-compat
 
 USER node
 RUN mkdir /home/node/app
@@ -21,7 +23,10 @@ RUN /home/node/.yarn/bin/turbo prune --scope=@farcaster/hubble --docker
 ############## Stage 2: Build the code using a full node image ################
 ###############################################################################
 
-FROM node:18 AS build
+FROM node:18-alpine AS build
+
+# Needed for compilation step
+RUN apk add --no-cache libc6-compat python3 make g++ linux-headers
 
 USER node
 RUN mkdir /home/node/app
@@ -49,7 +54,7 @@ RUN yarn install --production --ignore-scripts --prefer-offline --force --frozen
 ########## Stage 3: Copy over the built code to a leaner alpine image #########
 ###############################################################################
 
-FROM node:18-slim as app
+FROM node:18-alpine as app
 
 # Set non-root user and expose port 8080
 USER node


### PR DESCRIPTION
## Motivation

This requires a few additional packages to be manually installed, but results in a smaller image (from ~530MB → ~465MB, over 12% reduction).

## Change Summary

We use `node:18-alpine` as the base image for all build steps.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
