### PR TITLE
fix: Docker build failing after package removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,6 @@ COPY --chown=node:node --from=build /home/node/app/node_modules ./node_modules
 COPY --chown=node:node --from=build /home/node/app/packages/protobufs/dist ./packages/protobufs/dist/
 COPY --chown=node:node --from=build /home/node/app/packages/protobufs/node_modules ./packages/protobufs/node_modules/
 COPY --chown=node:node --from=build /home/node/app/packages/utils/dist ./packages/utils/dist/
-COPY --chown=node:node --from=build /home/node/app/packages/utils/node_modules ./packages/utils/node_modules/
 
 # TODO: determine if this can be removed while using tsx (or find alternative)
 # since we should be able to run with just the compiled javascript in build/


### PR DESCRIPTION
## Motivation

A package removal in d21a8f2e caused the Docker build to start failing. Removing this line seems to fix it.


## Change Summary

Removed a line referring to a directory that no longer existed during the build.

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
