### PR TITLE
chore: Test Docker builds in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_and_test:
+  build:
     timeout-minutes: 10
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        shard: [1/2, 2/2]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v4
+        with:
+          cache-from: type=gha
+          cache-to: type=gha
+
+  analyze:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
@@ -43,6 +55,31 @@ jobs:
 
       - name: Run linter
         run: yarn lint
+
+  test:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        shard: [1/2, 2/2]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Restore cached dependencies for Node modules.
+        id: module-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/node_modules
+          key: ${{ runner.os }}--node--${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn install
 
       - name: Run build
         run: yarn build


### PR DESCRIPTION
## Motivation

To prevent accidental breakages, test our Docker builds on PRs.

This should be relatively fast thanks to GitHub Actions caching, and the fact that the NPM `rocksdb` package has a pre-built binary for x64, which is what `ubuntu-latest` runs.

## Change Summary

Split out `analyze`, `build`, and `test` jobs from the `build_and_test` job.

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
