### PR TITLE
chore: Remove shard flag from tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,6 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        shard: [1/2, 2/2]
-
     steps:
       - uses: actions/checkout@v3
 
@@ -85,7 +81,7 @@ jobs:
         run: yarn build
 
       - name: Run tests
-        run: yarn test:ci --shard=${{ matrix.shard }}
+        run: yarn test:ci
 
       - name: Upload coverage results
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Motivation

This doesn't appear to serve any purpose, since the second shard appears to run the same tests as the first shard. Either this is misconfigured or broken, but regardless it's confusing.

## Change Summary

Remove the unnecessary flag.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
