### PR TITLE
chore: upgrade @ethers to 6 in @farcaster/hubble

### DIFF
--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -57,7 +57,7 @@
     "@libp2p/utils": "^3.0.2",
     "@multiformats/multiaddr": "^11.0.0",
     "commander": "^10.0.0",
-    "ethers": "^5.6.1",
+    "ethers": "^6.0.0",
     "libp2p": "^0.39.5",
     "neverthrow": "^6.0.0",
     "node-cron": "^3.0.2",

--- a/apps/hubble/src/eth/ethEventsProvider.test.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.test.ts
@@ -1,8 +1,7 @@
-import { Event } from '@ethersproject/contracts';
-import { BaseProvider, Block, TransactionReceipt, TransactionResponse } from '@ethersproject/providers';
 import * as protobufs from '@farcaster/protobufs';
 import { bytesToHexString, Factories, hexStringToBytes } from '@farcaster/utils';
-import { BigNumber, Contract, utils } from 'ethers';
+import { AbstractProvider, Block, Contract, Log, Provider, TransactionReceipt, TransactionResponse } from 'ethers';
+import { OrphanFilter } from 'ethers/types/providers';
 import { IdRegistry, NameRegistry } from '~/eth/abis';
 import { EthEventsProvider } from '~/eth/ethEventsProvider';
 import { getIdRegistryEvent } from '~/storage/db/idRegistryEvent';
@@ -24,7 +23,7 @@ let mockIdRegistry: Contract;
 let mockNameRegistry: Contract;
 
 /** A Mock RPC provider */
-class MockRPCProvider extends BaseProvider {
+class MockRPCProvider extends AbstractProvider {
   constructor() {
     // The Goerli networkID is 5
     super(5);
@@ -33,41 +32,64 @@ class MockRPCProvider extends BaseProvider {
   override async getLogs() {
     return [];
   }
+
+  override async getBlockNumber(): Promise<number> {
+    return Math.round(Math.random() * 100_000);
+  }
 }
 
-/** A Mock Event. Note the disabled no-empty-function rule at the top, it is needed to allow no-op functions in the mock. */
-class MockEvent implements Event {
-  event?: string;
-  eventSignature?: string;
-  args?: utils.Result;
-  decodeError?: Error;
-  decode?: (data: string, topics?: string[] | undefined) => any;
+/** MockLog mocks the Log class instead of EventLog since we do not need to access args in the test */
+class MockLog implements Log {
+  address: string;
+  blockNumber: number;
+  blockHash: string;
+  data: string;
+  index: number;
+  provider: Provider;
+  removed: boolean;
+  topics: string[];
+  transactionHash: string;
+  transactionIndex: number;
+
+  // Allow no-op functions in the mock
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   removeListener: () => void = () => {};
   getBlock: () => Promise<Block> = () => Promise.resolve({} as Block);
   getTransaction: () => Promise<TransactionResponse> = () => Promise.resolve({} as TransactionResponse);
   getTransactionReceipt: () => Promise<TransactionReceipt> = () => Promise.resolve({} as TransactionReceipt);
-  blockNumber: number;
-  blockHash: string;
-  transactionIndex: number;
-  removed: boolean;
-  address: string;
-  data: string;
-  topics: string[];
-  transactionHash: string;
-  logIndex: number;
 
-  constructor(blockNumber: number, blockHash: string, transactionHash: string, logIndex: number) {
+  constructor(
+    blockNumber: number,
+    blockHash: string,
+    transactionHash: string,
+    index: number,
+    provider: AbstractProvider
+  ) {
     this.blockNumber = blockNumber;
     this.blockHash = blockHash;
     this.transactionHash = transactionHash;
-    this.logIndex = logIndex;
+    this.index = index;
+    this.provider = provider;
 
     this.transactionIndex = 0;
     this.removed = false;
     this.address = '';
     this.data = '';
     this.topics = [];
+  }
+
+  get eventName(): string {
+    throw new Error('Method not implemented.');
+  }
+  get eventSignature(): string {
+    throw new Error('Method not implemented.');
+  }
+
+  toJSON() {
+    throw new Error('Method not implemented.');
+  }
+  removedEvent(): OrphanFilter {
+    throw new Error('Method not implemented.');
   }
 }
 
@@ -80,12 +102,10 @@ beforeAll(async () => {
 describe('process events', () => {
   beforeEach(async () => {
     ethEventsProvider = new EthEventsProvider(hub, mockRPCProvider, mockIdRegistry, mockNameRegistry);
-    mockRPCProvider.polling = true;
     await ethEventsProvider.start();
   });
 
   afterEach(async () => {
-    mockRPCProvider.polling = false;
     await ethEventsProvider.stop();
   });
 
@@ -115,10 +135,10 @@ describe('process events', () => {
     const rRegister = mockIdRegistry.emit(
       'Register',
       address1,
-      BigNumber.from(fid),
+      BigInt(fid),
       '',
       '',
-      new MockEvent(blockNumber++, '0xb00001', '0x400001', 0)
+      new MockLog(blockNumber++, '0xb00001', '0x400001', 0, mockRPCProvider)
     );
     expect(rRegister).toBeTruthy();
 
@@ -137,8 +157,8 @@ describe('process events', () => {
       'Transfer',
       address1,
       address2,
-      BigNumber.from(fid),
-      new MockEvent(blockNumber++, '0xb00002', '0x400002', 0)
+      BigInt(fid),
+      new MockLog(blockNumber++, '0xb00002', '0x400002', 0, mockRPCProvider)
     );
     // The event is not immediately available, since it has to wait for confirmations. We should still get the Register event
     const existingIdRegistryEvent = await getIdRegistryEvent(db, fid);
@@ -163,8 +183,8 @@ describe('process events', () => {
       'Transfer',
       '0x000001',
       '0x000002',
-      BigNumber.from(bytesToHexString(fname)._unsafeUnwrap()),
-      new MockEvent(blockNumber++, '0xb00001', '0x400001', 0)
+      BigInt(bytesToHexString(fname)._unsafeUnwrap()),
+      new MockLog(blockNumber++, '0xb00001', '0x400001', 0, mockRPCProvider)
     );
     expect(rTransfer).toBeTruthy();
 
@@ -182,7 +202,7 @@ describe('process events', () => {
     //   'Renew',
     //   BigNumber.from(bytesToHexString(fname)._unsafeUnwrap()),
     //   BigNumber.from(1000),
-    //   new MockEvent(blockNumber++, '0xb00002', '0x400002', 0)
+    //   new MockLog(blockNumber++, '0xb00002', '0x400002', 0)
     // );
     // // The event is not immediately available, since it has to wait for confirmations. We should still get the Transfer event
     // expect((await getNameRegistryEvent(db, fname)).type).toEqual(

--- a/apps/hubble/src/eth/utils.test.ts
+++ b/apps/hubble/src/eth/utils.test.ts
@@ -1,10 +1,9 @@
-import { BigNumber } from 'ethers';
 import { bytes32ToBytes } from '~/eth/utils';
 
 describe('bytes32ToBytes', () => {
-  const passingCases: [BigNumber, Uint8Array][] = [
+  const passingCases: [bigint, Uint8Array][] = [
     [
-      BigNumber.from('50839975223553296918063695500986414185067076564032165621192833738513116561408'),
+      BigInt('50839975223553296918063695500986414185067076564032165621192833738513116561408'),
       new Uint8Array([112, 102, 104]),
     ],
   ];

--- a/apps/hubble/src/eth/utils.ts
+++ b/apps/hubble/src/eth/utils.ts
@@ -1,9 +1,8 @@
 import { hexStringToBytes, HubResult } from '@farcaster/utils';
-import { BigNumber } from 'ethers';
 
-export const bytes32ToBytes = (value: BigNumber): HubResult<Uint8Array> => {
+export const bytes32ToBytes = (value: bigint): HubResult<Uint8Array> => {
   // Remove right padding
-  let hex = value.toHexString();
+  let hex = value.toString(16);
   while (hex.substring(hex.length - 2) === '00') {
     hex = hex.substring(0, hex.length - 2);
   }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,7 +20,7 @@
     "@farcaster/protobufs": "0.1.3",
     "@noble/ed25519": "^1.7.1",
     "@noble/hashes": "^1.2.0",
-    "ethers": "^5.7.2",
+    "ethers": "^6.0.0",
     "neverthrow": "^6.0.0"
   },
   "scripts": {

--- a/packages/utils/src/bytes.test.ts
+++ b/packages/utils/src/bytes.test.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers';
 import { err, ok } from 'neverthrow';
 import {
   bigNumberToBytes,
@@ -180,9 +179,9 @@ describe('utf8StringToBytes', () => {
 });
 
 describe('bigNumberToBytes', () => {
-  const passingCases: [BigNumber, Uint8Array][] = [
-    [BigNumber.from(1000), new Uint8Array([3, 232])],
-    [BigNumber.from(`${Number.MAX_SAFE_INTEGER}`).add(BigNumber.from(1)), new Uint8Array([32, 0, 0, 0, 0, 0, 0])],
+  const passingCases: [bigint, Uint8Array][] = [
+    [BigInt(1000), new Uint8Array([3, 232])],
+    [BigInt(`${Number.MAX_SAFE_INTEGER}`) + BigInt(1), new Uint8Array([32, 0, 0, 0, 0, 0, 0])],
   ];
 
   for (const [input, output] of passingCases) {

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -1,6 +1,5 @@
 /* eslint-disable security/detect-object-injection */
 import { utils } from '@noble/ed25519';
-import { BigNumber } from 'ethers';
 import { err, ok, Result } from 'neverthrow';
 import { HubError, HubResult } from './errors';
 
@@ -89,10 +88,10 @@ export const utf8StringToBytes = (utf8: string): HubResult<Uint8Array> => {
   return ok(encoder.encode(utf8));
 };
 
-export const bigNumberToBytes = (value: BigNumber): HubResult<Uint8Array> => {
-  return hexStringToBytes(value._hex);
+export const bigNumberToBytes = (value: bigint): HubResult<Uint8Array> => {
+  return hexStringToBytes(value.toString(16));
 };
 
-export const bytesToBigNumber = (bytes: Uint8Array): HubResult<BigNumber> => {
-  return bytesToHexString(bytes).map((hexString) => BigNumber.from(hexString));
+export const bytesToBigNumber = (bytes: Uint8Array): HubResult<bigint> => {
+  return bytesToHexString(bytes).map((hexString) => BigInt(hexString));
 };

--- a/packages/utils/src/crypto/eip712.test.ts
+++ b/packages/utils/src/crypto/eip712.test.ts
@@ -1,13 +1,13 @@
 import * as protobufs from '@farcaster/protobufs';
 import { blake3 } from '@noble/hashes/blake3';
-import { utils, Wallet } from 'ethers';
+import { getAddress, randomBytes, SigningKey, Wallet } from 'ethers';
 import { ok } from 'neverthrow';
 import { bytesToHexString, hexStringToBytes } from '../bytes';
 import { Factories } from '../factories';
 import { VerificationEthAddressClaim } from '../verifications';
 import * as eip712 from './eip712';
 
-const wallet = new Wallet(utils.randomBytes(32));
+const wallet = new Wallet(new SigningKey(randomBytes(32)));
 const fid = Factories.Fid.build();
 
 describe('signVerificationEthAddressClaim', () => {
@@ -40,7 +40,7 @@ describe('signVerificationEthAddressClaim', () => {
   });
 
   test('succeeds with checksummed address', async () => {
-    const claim2: VerificationEthAddressClaim = { ...claim, address: utils.getAddress(claim.address) };
+    const claim2: VerificationEthAddressClaim = { ...claim, address: getAddress(claim.address) };
     const signature2 = await eip712.signVerificationEthAddressClaim(claim2, wallet);
     expect(signature2).toEqual(ok(signature));
   });

--- a/packages/utils/src/factories.ts
+++ b/packages/utils/src/factories.ts
@@ -3,7 +3,7 @@ import { Factory } from '@farcaster/fishery';
 import * as protobufs from '@farcaster/protobufs';
 import { utils } from '@noble/ed25519';
 import { blake3 } from '@noble/hashes/blake3';
-import { BigNumber, ethers } from 'ethers';
+import { ethers, randomBytes, SigningKey } from 'ethers';
 import { bytesToHexString } from './bytes';
 import { Ed25519Signer, Eip712Signer, Signer } from './signers';
 import { getFarcasterTime } from './time';
@@ -109,7 +109,7 @@ const Ed25519SignatureHexFactory = Factory.define<string>(() => {
 });
 
 const Eip712SignerFactory = Factory.define<Eip712Signer>(() => {
-  const wallet = new ethers.Wallet(utils.randomBytes(32));
+  const wallet = new ethers.Wallet(new SigningKey(randomBytes(32)));
   return Eip712Signer.fromSigner(wallet, wallet.address)._unsafeUnwrap();
 });
 
@@ -423,7 +423,7 @@ const VerificationEthAddressClaimFactory = Factory.define<VerificationEthAddress
     const signer = transientParams.signer ?? Eip712SignerFactory.build();
 
     return {
-      fid: BigNumber.from(FidFactory.build()),
+      fid: BigInt(FidFactory.build()),
       address: signer.signerKeyHex,
       network: FarcasterNetworkFactory.build(),
       blockHash: BlockHashHexFactory.build(),
@@ -445,7 +445,7 @@ const VerificationAddEthAddressBodyFactory = Factory.define<
       const network = transientParams.network ?? FarcasterNetworkFactory.build();
       const blockHash = bytesToHexString(body.blockHash);
       const claim = VerificationEthAddressClaimFactory.build(
-        { fid: BigNumber.from(fid), network, blockHash: blockHash.isOk() ? blockHash.value : '0x' },
+        { fid: BigInt(fid), network, blockHash: blockHash.isOk() ? blockHash.value : '0x' },
         { transient: { signer: ethSigner } }
       );
       const ethSignature = await ethSigner.signVerificationEthAddressClaim(claim);

--- a/packages/utils/src/signers/ed25519Signer.test.ts
+++ b/packages/utils/src/signers/ed25519Signer.test.ts
@@ -1,5 +1,5 @@
 import { blake3 } from '@noble/hashes/blake3';
-import { randomBytes } from 'ethers/lib/utils';
+import { randomBytes } from 'ethers';
 import { ed25519 } from '../crypto';
 import { Factories } from '../factories';
 import { Ed25519Signer } from './ed25519Signer';

--- a/packages/utils/src/signers/eip712Signer.test.ts
+++ b/packages/utils/src/signers/eip712Signer.test.ts
@@ -1,7 +1,6 @@
 import { FarcasterNetwork } from '@farcaster/protobufs';
 import { blake3 } from '@noble/hashes/blake3';
-import { BigNumber, ethers } from 'ethers';
-import { randomBytes } from 'ethers/lib/utils';
+import { ethers, randomBytes, SigningKey } from 'ethers';
 import { bytesToHexString, hexStringToBytes } from '../bytes';
 import { eip712 } from '../crypto';
 import { Factories } from '../factories';
@@ -14,7 +13,7 @@ describe('Eip712Signer', () => {
   let ethAddress: string;
 
   beforeAll(async () => {
-    typedDataSigner = new ethers.Wallet(ethers.utils.randomBytes(32));
+    typedDataSigner = new ethers.Wallet(new SigningKey(randomBytes(32)));
     ethAddress = await typedDataSigner.getAddress();
     signer = Eip712Signer.fromSigner(typedDataSigner, ethAddress)._unsafeUnwrap();
   });
@@ -44,7 +43,7 @@ describe('Eip712Signer', () => {
 
       beforeAll(async () => {
         claim = {
-          fid: BigNumber.from(Factories.Fid.build()),
+          fid: BigInt(Factories.Fid.build()),
           address: signer.signerKeyHex,
           blockHash: Factories.BlockHashHex.build(undefined, { transient: { case: 'mixed' } }),
           network: FarcasterNetwork.FARCASTER_NETWORK_TESTNET,

--- a/packages/utils/src/signers/eip712Signer.ts
+++ b/packages/utils/src/signers/eip712Signer.ts
@@ -1,15 +1,12 @@
-import {
-  Signer as EthersAbstractSigner,
-  TypedDataSigner as EthersTypedDataSigner,
-} from '@ethersproject/abstract-signer';
 import { SignatureScheme } from '@farcaster/protobufs';
+import { Signer as EthersSigner } from 'ethers';
 import { hexStringToBytes } from '../bytes';
 import { eip712 } from '../crypto';
 import { HubAsyncResult, HubResult } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
 import { Signer } from './signer';
 
-export type TypedDataSigner = EthersAbstractSigner & EthersTypedDataSigner;
+// export type TypedDataSigner = EthersAbstractSigner & EthersTypedDataSigner;
 
 export class Eip712Signer implements Signer {
   public readonly scheme = SignatureScheme.SIGNATURE_SCHEME_EIP712;
@@ -18,14 +15,15 @@ export class Eip712Signer implements Signer {
   public readonly signerKey: Uint8Array;
   public readonly signerKeyHex: string;
 
-  private readonly _typedDataSigner: TypedDataSigner;
+  // TODO: rename if this works
+  private readonly _typedDataSigner: EthersSigner;
 
-  public static fromSigner(typedDataSigner: TypedDataSigner, address: string): HubResult<Eip712Signer> {
+  public static fromSigner(typedDataSigner: EthersSigner, address: string): HubResult<Eip712Signer> {
     const signerKeyHex = address.toLowerCase();
     return hexStringToBytes(signerKeyHex).map((signerKey) => new this(typedDataSigner, address, signerKey));
   }
 
-  constructor(typedDataSigner: TypedDataSigner, address: string, signerKey: Uint8Array) {
+  constructor(typedDataSigner: EthersSigner, address: string, signerKey: Uint8Array) {
     this._typedDataSigner = typedDataSigner;
     this.signerKeyHex = address.toLowerCase();
     this.signerKey = signerKey;

--- a/packages/utils/src/verifications.ts
+++ b/packages/utils/src/verifications.ts
@@ -1,12 +1,11 @@
 import { FarcasterNetwork } from '@farcaster/protobufs';
-import { BigNumber } from 'ethers';
 import { err, ok } from 'neverthrow';
 import { bytesToHexString } from './bytes';
 import { HubResult } from './errors';
 import { validateBlockHashHex, validateEthAddressHex } from './validations';
 
 export type VerificationEthAddressClaim = {
-  fid: BigNumber;
+  fid: bigint;
   address: string; // Hex string
   network: FarcasterNetwork;
   blockHash: string; // Hex string
@@ -29,7 +28,7 @@ export const makeVerificationEthAddressClaim = (
   }
 
   return ok({
-    fid: BigNumber.from(fid),
+    fid: BigInt(fid),
     address: ethAddressHex.value,
     network: network,
     blockHash: blockHashHex.value,

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,6 +35,11 @@
     uuid "^8.3.2"
     xml2js "^0.4.23"
 
+"@adraffy/ens-normalize@1.8.9":
+  version "1.8.9"
+  resolved "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.8.9.tgz#67b3acadebbb551669c9a1da15fac951db795b85"
+  integrity sha512-93OmGCV0vO8+JQ3FHG+gZk/MPHzzMPDRiCiFcCQNTCnHaaxsacO3ScTPGlu2wX2dOtgfalbchPcw1cOYYjHCYQ==
+
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -1999,10 +2004,20 @@
   resolved "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz#6899660f6fbb97798a6fbd227227c4589a454724"
   integrity sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==
 
+"@noble/hashes@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
+  integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
+
 "@noble/hashes@^1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz#a3150eeb09cc7ab207ebf6d7b9ad311a9bdbed12"
   integrity sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==
+
+"@noble/secp256k1@1.6.3":
+  version "1.6.3"
+  resolved "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz#7eed12d9f4404b416999d0c87686836c4c5c9b94"
+  integrity sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==
 
 "@noble/secp256k1@^1.5.4":
   version "1.7.0"
@@ -2682,6 +2697,11 @@ aes-js@3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
   integrity sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==
+
+aes-js@4.0.0-beta.3:
+  version "4.0.0-beta.3"
+  resolved "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.3.tgz#da2253f0ff03a0b3a9e445c8cbdf78e7fda7d48c"
+  integrity sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -3973,7 +3993,7 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-ethers@^5.6.1, ethers@^5.7.2:
+ethers@^5.7.2:
   version "5.7.2"
   resolved "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -4008,6 +4028,18 @@ ethers@^5.6.1, ethers@^5.7.2:
     "@ethersproject/wallet" "5.7.0"
     "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
+
+ethers@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/ethers/-/ethers-6.0.0.tgz#c2a0622bdd5d1597f6d67d7a57327f5f7b365d99"
+  integrity sha512-3zI3VqRS6ERFoRMDIaOPTlR2CFeRYLh21OgoIEL4P5thF2xleWCM6R4ks3qdPp0qYUNzkTV4F+NbczbxxD8ybQ==
+  dependencies:
+    "@adraffy/ens-normalize" "1.8.9"
+    "@noble/hashes" "1.1.2"
+    "@noble/secp256k1" "1.6.3"
+    aes-js "4.0.0-beta.3"
+    tslib "2.4.0"
+    ws "8.5.0"
 
 event-iterator@^2.0.0:
   version "2.0.0"
@@ -7638,6 +7670,11 @@ ts-proto@^1.139.0:
     ts-poet "^6.2.0"
     ts-proto-descriptors "1.7.1"
 
+tslib@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -8034,6 +8071,11 @@ ws@7.4.6:
   version "7.4.6"
   resolved "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+
+ws@8.5.0:
+  version "8.5.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
+  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
 
 xml2js@^0.4.23:
   version "0.4.23"


### PR DESCRIPTION
## Motivation

Ethers 6 is smaller, uses audited crypto libraries (noble), more null-safe and is all ES modules making easier to use in modern JS toolchains. More details [here](https://blog.ricmoo.com/highlights-ethers-js-december-2021-dc1adb779d1a).

## Change Summary

Upgrade all use of ethers 5 to 6

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
