### PR TITLE
chore: suppress false positive security warnings

### DIFF
--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -130,10 +130,13 @@ const writePeerId = async (peerId: PeerId, filepath: string) => {
   // Handling: using try-catch is more ergonomic than capturing and handling throwable, since we
   // want a fast failure back to the CLI
   try {
+    // Safety: directory, writefile are provided from the command line, and safe to trust
+    /* eslint-disable security/detect-non-literal-fs-filename */
     if (!existsSync(directory)) {
       await mkdir(directory, { recursive: true });
     }
     await writeFile(filepath, proto, 'binary');
+    /* eslint-enable security/detect-non-literal-fs-filename */
   } catch (err: any) {
     throw new Error(err);
   }
@@ -190,6 +193,8 @@ app
   });
 
 const readPeerId = async (filePath: string) => {
+  /* eslint-disable security/detect-non-literal-fs-filename */
+
   const proto = await readFile(filePath);
   return createFromProtobuf(proto);
 };

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -299,6 +299,8 @@ class SyncEngine {
 const fromNodeMetadataResponse = (response: protobufs.TrieNodeMetadataResponse): NodeMetadata => {
   const children = new Map<number, NodeMetadata>();
   for (let i = 0; i < response.children.length; i++) {
+    // Safety: i is controlled by the loop
+    // eslint-disable security/detect-object-injection
     const child = response.children[i];
 
     if (child && child.prefix.length > 0) {

--- a/apps/hubble/src/network/sync/trieNode.test.ts
+++ b/apps/hubble/src/network/sync/trieNode.test.ts
@@ -3,6 +3,9 @@ import { TIMESTAMP_LENGTH } from '~/network/sync/syncId';
 import { EMPTY_HASH, TrieNode } from '~/network/sync/trieNode';
 import { NetworkFactories } from '~/network/utils/factories';
 
+// Safety: fs inputs are always safe in tests
+/* eslint-disable security/detect-non-literal-fs-filename */
+
 const fid = Factories.Fid.build();
 const sharedDate = new Date(1665182332000);
 const sharedPrefixHashA = '09bc3dad4e7f2a77bbb2cccbecb06febfc6a4321';
@@ -131,7 +134,6 @@ describe('TrieNode', () => {
 
       root.delete(id2.syncId());
       expect(root.items).toEqual(1);
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(root.exists(id2.syncId())).toBeFalsy();
       expect(root.hash).toEqual(previousHash);
     });
@@ -169,6 +171,8 @@ describe('TrieNode', () => {
       const root = new TrieNode();
 
       for (let i = 0; i < ids.length; i++) {
+        // Safety: i is controlled by the loop and cannot be used to inject
+        // eslint-disable-next-line security/detect-object-injection
         root.insert(ids[i] as Uint8Array);
       }
 
@@ -179,9 +183,7 @@ describe('TrieNode', () => {
       root.delete(ids[0] as Uint8Array);
 
       // Expect the other two ids to be present
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(root.exists(ids[1] as Uint8Array)).toBeTruthy();
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(root.exists(ids[2] as Uint8Array)).toBeTruthy();
       expect(root.items).toEqual(2);
     });
@@ -195,7 +197,6 @@ describe('TrieNode', () => {
       root.insert(id.syncId());
       expect(root.items).toEqual(1);
 
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(root.exists(id.syncId())).toBeTruthy();
     });
 
@@ -207,7 +208,6 @@ describe('TrieNode', () => {
       expect(root.items).toEqual(1);
 
       root.delete(id.syncId());
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(root.exists(id.syncId())).toBeFalsy();
       expect(root.items).toEqual(0);
     });
@@ -224,7 +224,6 @@ describe('TrieNode', () => {
       root.insert(id1.syncId());
 
       // id2 shares the same prefix, but doesn't exist, so it should return undefined
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
       expect(root.exists(id2.syncId())).toBeFalsy();
     });
   });

--- a/apps/hubble/src/rpc/server/test/castService.test.ts
+++ b/apps/hubble/src/rpc/server/test/castService.test.ts
@@ -131,6 +131,8 @@ describe('getCast', () => {
       await engine.mergeMessage(castAdd);
       for (let i = 0; i < (castAdd.data?.castAddBody?.mentions.length as number); i++) {
         const casts = await client.getCastsByMention(
+          // Safety: i is controlled by the loop and cannot be used to inject
+          // eslint-disable-next-line security/detect-object-injection
           protobufs.FidRequest.create({ fid: castAdd.data?.castAddBody?.mentions[i] as number })
         );
         expect(protobufs.Message.toJSON(casts._unsafeUnwrap().messages.at(0) as protobufs.Message)).toEqual(
@@ -142,6 +144,8 @@ describe('getCast', () => {
     test('returns empty array without casts', async () => {
       for (let i = 0; i < (castAdd.data?.castAddBody?.mentions.length as number); i++) {
         const casts = await client.getCastsByMention(
+          // Safety: i is controlled by the loop and cannot be used to inject
+          // eslint-disable-next-line security/detect-object-injection
           protobufs.FidRequest.create({ fid: castAdd.data?.castAddBody?.mentions[i] as number })
         );
         expect(casts._unsafeUnwrap().messages).toEqual([]);

--- a/apps/hubble/src/rpc/server/test/eventService.test.ts
+++ b/apps/hubble/src/rpc/server/test/eventService.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as protobufs from '@farcaster/protobufs';
 import { Factories, getHubRpcClient, HubRpcClient } from '@farcaster/utils';
 import Server from '~/rpc/server';

--- a/apps/hubble/src/storage/db/rocksdb.test.ts
+++ b/apps/hubble/src/storage/db/rocksdb.test.ts
@@ -4,6 +4,9 @@ import { existsSync, mkdirSync, rmdirSync } from 'fs';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import RocksDB from '~/storage/db/rocksdb';
 
+//Safety: fs is safe to use in tests
+/* eslint-disable security/detect-non-literal-fs-filename */
+
 const randomDbName = () => `rocksdb.test.${faker.name.lastName().toLowerCase()}.${faker.random.alphaNumeric(8)}`;
 
 describe('open', () => {

--- a/apps/hubble/src/storage/db/rocksdb.ts
+++ b/apps/hubble/src/storage/db/rocksdb.ts
@@ -85,10 +85,10 @@ class RocksDB {
       } else if (this._db.status === 'open') {
         resolve(undefined);
       } else {
+        // NOTE: eslint falsely identifies `open(...)` as `fs.open`.
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
         mkdir(this._db.location, { recursive: true }, (fsErr: Error | null) => {
           if (fsErr) reject(parseError(fsErr));
-          // NOTE: eslint falsely identifies `open(...)` as `fs.open`.
-          // eslint-disable-next-line security/detect-non-literal-fs-filename
           this._db.open({ createIfMissing: true, errorIfExists: false }, (e?: Error) => {
             if (!e) {
               this._hasOpened = true;


### PR DESCRIPTION
## Motivation

Suppress false positive security warning, documenting the reasons for each

## Change Summary

See above

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
