### PR TITLE
feat: Persist Merkle Trie to DB

### DIFF
--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -40,6 +40,7 @@
     "fishery": "^2.2.2",
     "pino-pretty": "^9.1.1",
     "progress": "^2.0.3",
+    "@types/rwlock": "^5.0.3",
     "ts-mockito": "^2.6.1"
   },
   "dependencies": {
@@ -63,6 +64,7 @@
     "node-cron": "^3.0.2",
     "pino": "^8.6.1",
     "rocksdb": "^5.2.1",
+    "rwlock": "^5.0.0",
     "tiny-typed-emitter": "^2.1.0",
     "tsx": "^3.12.2"
   }

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -1,7 +1,18 @@
+// eslint-disable-file security/detect-non-literal-fs-filename
+import * as protobufs from '@farcaster/protobufs';
 import { blake3 } from '@noble/hashes/blake3';
 import { MerkleTrie } from '~/network/sync/merkleTrie';
 import { NetworkFactories } from '~/network/utils/factories';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import RocksDB from '~/storage/db/rocksdb';
+import { RootPrefix } from '~/storage/db/types';
+import { TIMESTAMP_LENGTH } from './syncId';
 import { EMPTY_HASH } from './trieNode';
+
+const TEST_TIMEOUT_LONG = 60 * 1000;
+
+const db = jestRocksDB('protobufs.network.merkleTrie.test');
+const db2 = jestRocksDB('protobufs.network.merkleTrie2.test');
 
 describe('MerkleTrie', () => {
   const trieWithIds = async (timestamps: number[]) => {
@@ -10,191 +21,337 @@ describe('MerkleTrie', () => {
         return await NetworkFactories.SyncId.create(undefined, { transient: { date: new Date(t * 1000) } });
       })
     );
-    const trie = new MerkleTrie();
-    syncIds.forEach((id) => trie.insert(id));
+    const trie = new MerkleTrie(db);
+    await Promise.all(syncIds.map((id) => trie.insert(id)));
     return trie;
+  };
+
+  const forEachDbItem = async (
+    db: RocksDB,
+    callback?: (i: number, key: Buffer, value: Buffer) => Promise<void>
+  ): Promise<number> => {
+    let count = 0;
+    for await (const [key, value] of db.iteratorByPrefix(Buffer.from([RootPrefix.SyncMerkleTrieNode]))) {
+      if (callback) {
+        await callback(count, key, value);
+      }
+      count++;
+    }
+
+    return count;
   };
 
   describe('insert', () => {
     test('succeeds inserting a single item', async () => {
-      const trie = new MerkleTrie();
+      const trie = new MerkleTrie(db);
       const syncId = await NetworkFactories.SyncId.create();
 
-      expect(trie.items).toEqual(0);
-      expect(trie.rootHash).toEqual('');
+      expect(await trie.items()).toEqual(0);
+      expect(await trie.rootHash()).toEqual('');
 
-      trie.insert(syncId);
+      await trie.insert(syncId);
 
-      expect(trie.items).toEqual(1);
-      expect(trie.rootHash).toBeTruthy();
+      expect(await trie.items()).toEqual(1);
+      expect(await trie.rootHash()).toBeTruthy();
     });
 
     test('inserts are idempotent', async () => {
       const syncId1 = await NetworkFactories.SyncId.create();
       const syncId2 = await NetworkFactories.SyncId.create();
 
-      const firstTrie = new MerkleTrie();
-      firstTrie.insert(syncId1);
-      firstTrie.insert(syncId2);
+      const firstTrie = new MerkleTrie(db);
+      await firstTrie.insert(syncId1);
+      await firstTrie.insert(syncId2);
 
-      const secondTrie = new MerkleTrie();
-      secondTrie.insert(syncId2);
-      secondTrie.insert(syncId1);
+      const secondTrie = new MerkleTrie(db2);
+      await secondTrie.insert(syncId2);
+      await secondTrie.insert(syncId1);
 
       // Order does not matter
-      expect(firstTrie.rootHash).toEqual(secondTrie.rootHash);
-      expect(firstTrie.items).toEqual(secondTrie.items);
-      expect(firstTrie.rootHash).toBeTruthy();
+      expect(await firstTrie.rootHash()).toEqual(await secondTrie.rootHash());
+      expect(await firstTrie.items()).toEqual(await secondTrie.items());
+      expect(await firstTrie.rootHash()).toBeTruthy();
 
-      firstTrie.insert(syncId2);
-      secondTrie.insert(syncId1);
+      await firstTrie.insert(syncId2);
+      await secondTrie.insert(syncId1);
 
       // Re-adding same item does not change the hash
-      expect(firstTrie.rootHash).toEqual(secondTrie.rootHash);
-      expect(firstTrie.items).toEqual(secondTrie.items);
-      expect(firstTrie.items).toEqual(2);
+      expect(await firstTrie.rootHash()).toEqual(await secondTrie.rootHash());
+      expect(await firstTrie.items()).toEqual(await secondTrie.items());
+      expect(await firstTrie.items()).toEqual(2);
     });
 
-    test('insert multiple items out of order results in the same root hash', async () => {
-      const syncIds = await NetworkFactories.SyncId.createList(25);
+    test(
+      'insert multiple items out of order results in the same root hash',
+      async () => {
+        const syncIds = await NetworkFactories.SyncId.createList(25);
 
-      const firstTrie = new MerkleTrie();
-      const secondTrie = new MerkleTrie();
+        const firstTrie = new MerkleTrie(db);
+        const secondTrie = new MerkleTrie(db2);
 
-      syncIds.forEach((syncId) => firstTrie.insert(syncId));
-      const shuffledIds = syncIds.sort(() => 0.5 - Math.random());
-      shuffledIds.forEach((syncId) => secondTrie.insert(syncId));
+        await Promise.all(syncIds.map(async (syncId) => firstTrie.insert(syncId)));
+        const shuffledIds = syncIds.sort(() => 0.5 - Math.random());
+        await Promise.all(shuffledIds.map(async (syncId) => secondTrie.insert(syncId)));
 
-      expect(firstTrie.rootHash).toEqual(secondTrie.rootHash);
-      expect(firstTrie.rootHash).toBeTruthy();
-      expect(firstTrie.items).toEqual(secondTrie.items);
-      expect(firstTrie.items).toEqual(25);
+        expect(await firstTrie.rootHash()).toEqual(await secondTrie.rootHash());
+        expect(await firstTrie.rootHash()).toBeTruthy();
+        expect(await firstTrie.items()).toEqual(await secondTrie.items());
+        expect(await firstTrie.items()).toEqual(25);
+      },
+      TEST_TIMEOUT_LONG
+    );
+
+    test('insert also inserts into the db', async () => {
+      const dt = new Date();
+      const syncId = await NetworkFactories.SyncId.create(undefined, { transient: { date: dt } });
+      const syncIdStr = Buffer.from(syncId.syncId()).toString('hex');
+
+      const trie = new MerkleTrie(db);
+      await trie.insert(syncId);
+
+      expect(await trie.exists(syncId)).toBeTruthy();
+
+      let leafs = 0;
+      let count = await forEachDbItem(db, async (i, key, value) => {
+        expect(key.slice(1).toString('hex')).toEqual(syncIdStr.slice(0, i * 2));
+
+        // Parse the value as a DbTriNode
+        const node = protobufs.DbTrieNode.decode(value);
+
+        // The last key should be the leaf node, so it's value should match the entire syncID
+        if (i === TIMESTAMP_LENGTH) {
+          expect(Buffer.from(node.key).toString('hex')).toEqual(syncIdStr);
+        }
+
+        if (node.key.length > 0) {
+          leafs += 1;
+        }
+      });
+
+      // Expect 1 node for each timestamp level + root prefix
+      expect(count).toEqual(1 + TIMESTAMP_LENGTH);
+      expect(leafs).toEqual(1);
+
+      // Add another item
+      const syncId2 = await NetworkFactories.SyncId.create(undefined, { transient: { date: dt } });
+      await trie.insert(syncId2);
+
+      expect(await trie.exists(syncId2)).toBeTruthy();
+
+      leafs = 0;
+      //eslint-disable-next-line @typescript-eslint/no-unused-vars
+      count = await forEachDbItem(db, async (i, key, value) => {
+        // Parse the value as a DbTriNode
+        const node = protobufs.DbTrieNode.decode(value);
+        if (node.key.length > 0) {
+          leafs += 1;
+        }
+      });
+
+      expect(leafs).toEqual(2);
+
+      const rootHash = await trie.rootHash();
+
+      // Unload the trie
+      (await trie.getNode(new Uint8Array()))?.unloadChildren();
+      // Reload the trie from DB and calculate the hash
+      await trie.recalculateHash();
+
+      // Expect the root hash to be the same
+      expect(await trie.rootHash()).toEqual(rootHash);
+      expect(await trie.items()).toEqual(2);
     });
+
+    test(
+      'Load trie from DB',
+      async () => {
+        const trie = new MerkleTrie(db);
+        const syncIds = await NetworkFactories.SyncId.createList(20);
+
+        await Promise.all(syncIds.map(async (syncId) => await trie.insert(syncId)));
+
+        // Now initialize a new merkle trie from the same DB
+        const trie2 = new MerkleTrie(db);
+
+        // expect the root hashes to be the same
+        expect(await trie.rootHash()).toEqual(await trie2.rootHash());
+        expect(await trie.items()).toEqual(await trie2.items());
+
+        // expect all the items to be in the trie
+        await Promise.all(syncIds.map(async (syncId) => expect(await trie2.exists(syncId)).toBeTruthy()));
+
+        // Delete half the items from the first trie
+        await Promise.all(syncIds.slice(0, syncIds.length / 2).map(async (syncId) => trie.delete(syncId)));
+
+        // Initialize a new trie from the same DB
+        const trie3 = new MerkleTrie(db);
+
+        // expect the root hashes to be the same
+        expect(await trie.rootHash()).toEqual(await trie3.rootHash());
+        expect(await trie.items()).toEqual(await trie3.items());
+
+        // Expect that the deleted items are not present
+        await Promise.all(
+          syncIds.slice(0, syncIds.length / 2).map(async (syncId) => expect(await trie3.exists(syncId)).toBeFalsy())
+        );
+
+        // expect all the items to be in the trie
+        await Promise.all(
+          syncIds.slice(syncIds.length / 2).map(async (syncId) => expect(await trie3.exists(syncId)).toBeTruthy())
+        );
+      },
+      TEST_TIMEOUT_LONG
+    );
   });
 
   describe('delete', () => {
     test('deletes an item', async () => {
       const syncId = await NetworkFactories.SyncId.create();
 
-      const trie = new MerkleTrie();
-      trie.insert(syncId);
-      expect(trie.items).toEqual(1);
-      expect(trie.rootHash).toBeTruthy();
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
-      expect(trie.exists(syncId)).toBeTruthy();
+      const trie = new MerkleTrie(db);
+      await trie.insert(syncId);
+      expect(await trie.items()).toEqual(1);
+      expect(await trie.rootHash()).toBeTruthy();
 
-      trie.delete(syncId);
-      expect(trie.items).toEqual(0);
-      expect(trie.rootHash).toEqual(EMPTY_HASH);
-      // eslint-disable-next-line security/detect-non-literal-fs-filename
-      expect(trie.exists(syncId)).toBeFalsy();
+      expect(await trie.exists(syncId)).toBeTruthy();
+
+      await trie.delete(syncId);
+      expect(await trie.items()).toEqual(0);
+      expect(await trie.rootHash()).toEqual(EMPTY_HASH);
+
+      expect(await trie.exists(syncId)).toBeFalsy();
     });
 
     test('deleting an item that does not exist does not change the trie', async () => {
       const syncId = await NetworkFactories.SyncId.create();
-      const trie = new MerkleTrie();
-      trie.insert(syncId);
+      const trie = new MerkleTrie(db);
+      expect(await trie.insert(syncId)).toBeTruthy();
 
-      const rootHashBeforeDelete = trie.rootHash;
+      const rootHashBeforeDelete = await trie.rootHash();
       const syncId2 = await NetworkFactories.SyncId.create();
-      trie.delete(syncId2);
+      expect(await trie.delete(syncId2)).toBeFalsy();
 
-      const rootHashAfterDelete = trie.rootHash;
+      const rootHashAfterDelete = await trie.rootHash();
       expect(rootHashAfterDelete).toEqual(rootHashBeforeDelete);
-      expect(trie.items).toEqual(1);
+      expect(await trie.items()).toEqual(1);
     });
 
     test('delete is an exact inverse of insert', async () => {
       const syncId1 = await NetworkFactories.SyncId.create();
       const syncId2 = await NetworkFactories.SyncId.create();
 
-      const trie = new MerkleTrie();
+      const trie = new MerkleTrie(db);
       trie.insert(syncId1);
-      const rootHashBeforeDelete = trie.rootHash;
+      const rootHashBeforeDelete = await trie.rootHash();
       trie.insert(syncId2);
 
       trie.delete(syncId2);
-      expect(trie.rootHash).toEqual(rootHashBeforeDelete);
+      expect(await trie.rootHash()).toEqual(rootHashBeforeDelete);
     });
 
     test('trie with a deleted item is the same as a trie with the item never added', async () => {
       const syncId1 = await NetworkFactories.SyncId.create();
       const syncId2 = await NetworkFactories.SyncId.create();
 
-      const firstTrie = new MerkleTrie();
-      firstTrie.insert(syncId1);
-      firstTrie.insert(syncId2);
+      const firstTrie = new MerkleTrie(db);
+      await firstTrie.insert(syncId1);
+      await firstTrie.insert(syncId2);
 
-      firstTrie.delete(syncId1);
+      await firstTrie.delete(syncId1);
 
-      const secondTrie = new MerkleTrie();
-      secondTrie.insert(syncId2);
+      const secondTrie = new MerkleTrie(db2);
+      await secondTrie.insert(syncId2);
 
-      expect(firstTrie.rootHash).toEqual(secondTrie.rootHash);
-      expect(firstTrie.rootHash).toBeTruthy();
-      expect(firstTrie.items).toEqual(secondTrie.items);
-      expect(firstTrie.items).toEqual(1);
+      expect(await firstTrie.rootHash()).toEqual(await secondTrie.rootHash());
+      expect(await firstTrie.rootHash()).toBeTruthy();
+      expect(await firstTrie.items()).toEqual(await secondTrie.items());
+      expect(await firstTrie.items()).toEqual(1);
     });
-  });
 
-  test('succeeds with single item', async () => {
-    const trie = new MerkleTrie();
-    const syncId = await NetworkFactories.SyncId.create();
+    test('Deleting single node deletes all nodes from the DB', async () => {
+      const trie = new MerkleTrie(db);
+      const id = await NetworkFactories.SyncId.create();
 
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
-    expect(trie.exists(syncId)).toBeFalsy();
+      await trie.insert(id);
+      expect(await trie.items()).toEqual(1);
 
-    trie.insert(syncId);
+      let count = await forEachDbItem(db);
+      expect(count).toEqual(1 + TIMESTAMP_LENGTH);
 
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
-    expect(trie.exists(syncId)).toBeTruthy();
-
-    const nonExistingSyncId = await NetworkFactories.SyncId.create();
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
-    expect(trie.exists(nonExistingSyncId)).toBeFalsy();
-  });
-
-  test('test multiple items with delete', async () => {
-    const trie = new MerkleTrie();
-    const syncIds = await NetworkFactories.SyncId.createList(20);
-
-    // Keep track of start time and memory used
-    syncIds.forEach((syncId) => trie.insert(syncId));
-
-    // Delete half of the items
-    syncIds.slice(0, syncIds.length / 2).forEach((syncId) => trie.delete(syncId));
-
-    // Check that the items are still there
-    syncIds.slice(0, syncIds.length / 2).forEach((syncId) => expect(trie.exists(syncId)).toBeFalsy());
-    syncIds.slice(syncIds.length / 2).forEach((syncId) => {
-      expect(trie.exists(syncId)).toBeTruthy();
+      // Delete
+      await trie.delete(id);
+      count = await forEachDbItem(db);
+      expect(count).toEqual(0);
     });
-  });
 
-  test('value is always undefined for non-leaf nodes', async () => {
-    const trie = new MerkleTrie();
-    const syncId = await NetworkFactories.SyncId.create();
+    test('Deleting one of two nodes leaves only 1 item in the DB', async () => {
+      const trie = new MerkleTrie(db);
+      const syncId1 = await NetworkFactories.SyncId.create();
+      const syncId2 = await NetworkFactories.SyncId.create();
 
-    trie.insert(syncId);
+      await trie.insert(syncId1);
+      await trie.insert(syncId2);
 
-    expect(trie.root.value).toBeFalsy();
+      let count = await forEachDbItem(db);
+      expect(count).toBeGreaterThan(1 + TIMESTAMP_LENGTH);
+
+      // Delete
+      await trie.delete(syncId1);
+      count = await forEachDbItem(db);
+      expect(count).toEqual(1 + TIMESTAMP_LENGTH);
+    });
+
+    test('succeeds with single item', async () => {
+      const trie = new MerkleTrie(db);
+      const syncId = await NetworkFactories.SyncId.create();
+
+      expect(await trie.exists(syncId)).toBeFalsy();
+
+      await trie.insert(syncId);
+
+      expect(await trie.exists(syncId)).toBeTruthy();
+
+      const nonExistingSyncId = await NetworkFactories.SyncId.create();
+
+      expect(await trie.exists(nonExistingSyncId)).toBeFalsy();
+    });
+
+    test('test multiple items with delete', async () => {
+      const trie = new MerkleTrie(db);
+      const syncIds = await NetworkFactories.SyncId.createList(20);
+
+      await Promise.all(syncIds.map(async (syncId) => trie.insert(syncId)));
+
+      // Delete half of the items
+      await Promise.all(syncIds.slice(0, syncIds.length / 2).map(async (syncId) => trie.delete(syncId)));
+
+      // Check that the items are still there
+      await Promise.all(
+        syncIds.slice(0, syncIds.length / 2).map(async (syncId) => expect(await trie.exists(syncId)).toBeFalsy())
+      );
+      await Promise.all(
+        syncIds.slice(syncIds.length / 2).map(async (syncId) => {
+          expect(await trie.exists(syncId)).toBeTruthy();
+        })
+      );
+    });
   });
 
   describe('getNodeMetadata', () => {
     test('returns undefined if prefix is not present', async () => {
       const syncId = await NetworkFactories.SyncId.create(undefined, { transient: { date: new Date(1665182332000) } });
-      const trie = new MerkleTrie();
-      trie.insert(syncId);
+      const trie = new MerkleTrie(db);
+      await trie.insert(syncId);
 
-      expect(trie.getTrieNodeMetadata(Buffer.from('166518234'))).toBeUndefined();
+      expect(await trie.getTrieNodeMetadata(Buffer.from('166518234'))).toBeUndefined();
     });
 
     test('returns the root metadata if the prefix is empty', async () => {
       const syncId = await NetworkFactories.SyncId.create(undefined, { transient: { date: new Date(1665182332000) } });
-      const trie = new MerkleTrie();
+      const trie = new MerkleTrie(db);
       trie.insert(syncId);
 
-      const nodeMetadata = trie.getTrieNodeMetadata(new Uint8Array());
+      const nodeMetadata = await trie.getTrieNodeMetadata(new Uint8Array());
       expect(nodeMetadata).toBeDefined();
       expect(nodeMetadata?.numMessages).toEqual(1);
       expect(nodeMetadata?.prefix).toEqual(new Uint8Array());
@@ -204,7 +361,7 @@ describe('MerkleTrie', () => {
 
     test('returns the correct metadata if prefix is present', async () => {
       const trie = await trieWithIds([1665182332, 1665182343]);
-      const nodeMetadata = trie.getTrieNodeMetadata(Buffer.from('16651823'));
+      const nodeMetadata = await trie.getTrieNodeMetadata(Buffer.from('16651823'));
 
       expect(nodeMetadata).toBeDefined();
       expect(nodeMetadata?.numMessages).toEqual(2);
@@ -219,7 +376,7 @@ describe('MerkleTrie', () => {
     test('returns basic information', async () => {
       const trie = await trieWithIds([1665182332, 1665182343]);
 
-      const snapshot = trie.getSnapshot(Buffer.from('1665182343'));
+      const snapshot = await trie.getSnapshot(Buffer.from('1665182343'));
       expect(snapshot.prefix).toEqual(Buffer.from('1665182343'));
       expect(snapshot.numMessages).toEqual(1);
       expect(snapshot.excludedHashes.length).toEqual('1665182343'.length);
@@ -228,7 +385,7 @@ describe('MerkleTrie', () => {
     test('returns early when prefix is only partially present', async () => {
       const trie = await trieWithIds([1665182332, 1665182343]);
 
-      const snapshot = trie.getSnapshot(Buffer.from('1677123'));
+      const snapshot = await trie.getSnapshot(Buffer.from('1677123'));
       expect(snapshot.prefix).toEqual(Buffer.from('167'));
       expect(snapshot.numMessages).toEqual(2);
       expect(snapshot.excludedHashes.length).toEqual('167'.length);
@@ -236,8 +393,8 @@ describe('MerkleTrie', () => {
 
     test('excluded hashes excludes the prefix char at every level', async () => {
       const trie = await trieWithIds([1665182332, 1665182343, 1665182345, 1665182351]);
-      let snapshot = trie.getSnapshot(Buffer.from('1665182351'));
-      let node = trie.getTrieNodeMetadata(Buffer.from('16651823'));
+      let snapshot = await trie.getSnapshot(Buffer.from('1665182351'));
+      let node = await trie.getTrieNodeMetadata(Buffer.from('16651823'));
       // We expect the excluded hash to be the hash of the 3 and 4 child nodes, and excludes the 5 child node
       const expectedHash = Buffer.from(
         blake3
@@ -259,12 +416,12 @@ describe('MerkleTrie', () => {
         EMPTY_HASH, // 1
       ]);
 
-      snapshot = trie.getSnapshot(Buffer.from('1665182343'));
-      node = trie.getTrieNodeMetadata(Buffer.from('166518234'));
+      snapshot = await trie.getSnapshot(Buffer.from('1665182343'));
+      node = await trie.getTrieNodeMetadata(Buffer.from('166518234'));
       const expectedLastHash = Buffer.from(
         blake3(Buffer.from(node?.children?.get(Buffer.from('5')[0] as number)?.hash || '', 'hex'), { dkLen: 20 })
       ).toString('hex');
-      node = trie.getTrieNodeMetadata(Buffer.from('16651823'));
+      node = await trie.getTrieNodeMetadata(Buffer.from('16651823'));
       const expectedPenultimateHash = Buffer.from(
         blake3
           .create({ dkLen: 20 })
@@ -290,9 +447,9 @@ describe('MerkleTrie', () => {
   test('getAllValues returns all values for child nodes', async () => {
     const trie = await trieWithIds([1665182332, 1665182343, 1665182345]);
 
-    let values = trie.root.getNode(Buffer.from('16651823'))?.getAllValues();
+    let values = await trie.getAllValues(Buffer.from('16651823'));
     expect(values?.length).toEqual(3);
-    values = trie.root.getNode(Buffer.from('166518233'))?.getAllValues();
+    values = await trie.getAllValues(Buffer.from('166518233'));
     expect(values?.length).toEqual(1);
   });
 
@@ -300,25 +457,25 @@ describe('MerkleTrie', () => {
     test('returns the prefix with the most common excluded hashes', async () => {
       const trie = await trieWithIds([1665182332, 1665182343, 1665182345]);
       const prefixToTest = Buffer.from('1665182343');
-      const oldSnapshot = trie.getSnapshot(prefixToTest);
+      const oldSnapshot = await trie.getSnapshot(prefixToTest);
       trie.insert(await NetworkFactories.SyncId.create(undefined, { transient: { date: new Date(1665182353000) } }));
 
       // Since message above was added at 1665182353, the two tries diverged at 16651823 for our prefix
-      let divergencePrefix = trie.getDivergencePrefix(prefixToTest, oldSnapshot.excludedHashes);
+      let divergencePrefix = await trie.getDivergencePrefix(prefixToTest, oldSnapshot.excludedHashes);
       expect(divergencePrefix).toEqual(Buffer.from('16651823'));
 
       // divergence prefix should be the full prefix, if snapshots are the same
-      const currentSnapshot = trie.getSnapshot(prefixToTest);
-      divergencePrefix = trie.getDivergencePrefix(prefixToTest, currentSnapshot.excludedHashes);
+      const currentSnapshot = await trie.getSnapshot(prefixToTest);
+      divergencePrefix = await trie.getDivergencePrefix(prefixToTest, currentSnapshot.excludedHashes);
       expect(divergencePrefix).toEqual(prefixToTest);
 
       // divergence prefix should empty if excluded hashes are empty
-      divergencePrefix = trie.getDivergencePrefix(prefixToTest, []);
+      divergencePrefix = await trie.getDivergencePrefix(prefixToTest, []);
       expect(divergencePrefix.length).toEqual(0);
 
       // divergence prefix should be our prefix if provided hashes are longer
       const with5 = Buffer.concat([prefixToTest, Buffer.from('5')]);
-      divergencePrefix = trie.getDivergencePrefix(with5, [...currentSnapshot.excludedHashes, 'different']);
+      divergencePrefix = await trie.getDivergencePrefix(with5, [...currentSnapshot.excludedHashes, 'different']);
       expect(divergencePrefix).toEqual(prefixToTest);
     });
   });

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -1,5 +1,8 @@
+import ReadWriteLock from 'rwlock';
 import { SyncId } from '~/network/sync/syncId';
 import { TrieNode, TrieSnapshot } from '~/network/sync/trieNode';
+import RocksDB from '~/storage/db/rocksdb';
+import { logger } from '~/utils/logger';
 
 /**
  * Represents a node in the trie, and it's immediate children
@@ -16,6 +19,10 @@ export type NodeMetadata = {
   children?: Map<number, NodeMetadata>;
 };
 
+const log = logger.child({
+  component: 'SyncMerkleTrie',
+});
+
 /**
  * MerkleTrie is a trie that contains Farcaster Messages SyncId and is used to diff the state of
  * two hubs on the network.
@@ -30,28 +37,97 @@ export type NodeMetadata = {
  * methods. DO NOT add async methods without considering impact on concurrency-safety.
  */
 class MerkleTrie {
-  private readonly _root: TrieNode;
+  private _root: TrieNode;
+  private _db: RocksDB;
+  private _lock: ReadWriteLock;
 
-  constructor() {
+  constructor(rocksDb: RocksDB) {
+    this._db = rocksDb;
+    this._lock = new ReadWriteLock();
+
+    // TODO If the root node is available in the DB load it from there
     this._root = new TrieNode();
+    this._lock.writeLock(async (release) => {
+      try {
+        const rootBytes = await this._db.get(TrieNode.makePrimaryKey(new Uint8Array()));
+        if (rootBytes && rootBytes.length > 0) {
+          this._root = TrieNode.deserialize(rootBytes);
+          log.info({}, 'Loaded MerkleTrie root from DB. Reclculating hash');
+          await this._root.recalculateHash(new Uint8Array(), this._db);
+          log.info({ rootHash: this._root.hash, items: this.items }, 'Merkle Trie loaded from DB');
+        }
+      } catch {
+        // There is no Root node in the DB, just use an empty one
+        this._root = new TrieNode();
+      }
+
+      release();
+    });
   }
 
-  public insert(id: SyncId): boolean {
-    return this._root.insert(id.syncId());
+  public async insert(id: SyncId): Promise<boolean> {
+    return new Promise((resolve) => {
+      this._lock.writeLock(async (release) => {
+        try {
+          // Create a new DB transaction
+          const { status, txn } = await this._root.insert(id.syncId(), this._db, this._db.transaction());
+
+          // Write the transaction to the DB
+          await this._db.commit(txn);
+
+          release();
+          resolve(status);
+        } catch (e) {
+          log.error('Insert Error', e);
+
+          release();
+          resolve(false);
+        }
+      });
+    });
   }
 
-  public delete(id: SyncId): boolean {
-    return this._root.delete(id.syncId());
+  public async delete(id: SyncId): Promise<boolean> {
+    return new Promise((resolve) => {
+      this._lock.writeLock(async (release) => {
+        try {
+          // Create a new DB transaction
+          const { status, txn } = await this._root.delete(id.syncId(), this._db, this._db.transaction());
+
+          // Write the transaction to the DB
+          await this._db.commit(txn);
+
+          release();
+          resolve(status);
+        } catch (e) {
+          log.error('Delete Error', e);
+
+          release();
+          resolve(false);
+        }
+      });
+    });
   }
 
-  public exists(id: SyncId): boolean {
-    // NOTE: eslint falsely identifies as `fs.exists`.
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
-    return this._root.exists(id.syncId());
+  public async exists(id: SyncId): Promise<boolean> {
+    return new Promise((resolve) => {
+      this._lock.readLock(async (release) => {
+        // eslint-disable-next-line security/detect-non-literal-fs-filename
+        const r = await this._root.exists(id.syncId(), this._db);
+        release();
+        resolve(r);
+      });
+    });
   }
 
-  public getSnapshot(prefix: Uint8Array): TrieSnapshot {
-    return this._root.getSnapshot(prefix);
+  public async getSnapshot(prefix: Uint8Array): Promise<TrieSnapshot> {
+    return new Promise((resolve) => {
+      this._lock.readLock(async (release) => {
+        const r = await this._root.getSnapshot(prefix, this._db);
+        release();
+        resolve(r);
+      });
+    });
   }
 
   /**
@@ -60,46 +136,92 @@ class MerkleTrie {
    * @param prefix - the prefix of the external trie.
    * @param excludedHashes - the excluded hashes of the external trie.
    */
-  public getDivergencePrefix(prefix: Uint8Array, excludedHashes: string[]): Uint8Array {
-    const ourExcludedHashes = this.getSnapshot(prefix).excludedHashes;
-    for (let i = 0; i < prefix.length; i++) {
-      // NOTE: `i` is controlled by for loop and hence not at risk of object injection.
-      // eslint-disable-next-line security/detect-object-injection
-      if (ourExcludedHashes[i] !== excludedHashes[i]) {
-        return prefix.slice(0, i);
-      }
-    }
-    return prefix;
-  }
-
-  public getTrieNodeMetadata(prefix: Uint8Array): NodeMetadata | undefined {
-    const node = this._root.getNode(prefix);
-    if (node === undefined) {
-      return undefined;
-    }
-    const children = node?.children || new Map();
-    const result = new Map<number, NodeMetadata>();
-    for (const [char, child] of children) {
-      const newPrefix = Buffer.concat([prefix, Buffer.from([char])]);
-      result.set(char, {
-        numMessages: child.items,
-        prefix: newPrefix,
-        hash: child.hash,
+  public async getDivergencePrefix(prefix: Uint8Array, excludedHashes: string[]): Promise<Uint8Array> {
+    return new Promise((resolve) => {
+      this._lock.readLock(async (release) => {
+        const ourExcludedHashes = (await this.getSnapshot(prefix)).excludedHashes;
+        for (let i = 0; i < prefix.length; i++) {
+          // NOTE: `i` is controlled by for loop and hence not at risk of object injection.
+          // eslint-disable-next-line security/detect-object-injection
+          if (ourExcludedHashes[i] !== excludedHashes[i]) {
+            release();
+            resolve(prefix.slice(0, i));
+          }
+        }
+        release();
+        resolve(prefix);
       });
-    }
-    return { prefix, children: result, numMessages: node.items, hash: node.hash };
+    });
   }
 
-  public get root(): TrieNode {
-    return this._root;
+  public async getTrieNodeMetadata(prefix: Uint8Array): Promise<NodeMetadata | undefined> {
+    return new Promise((resolve) => {
+      this._lock.readLock(async (release) => {
+        const node = await this._root.getNode(prefix, this._db);
+        if (node === undefined) {
+          release();
+          resolve(undefined);
+        } else {
+          const md = await node.getNodeMetadata(prefix, this._db);
+          release();
+          resolve(md);
+        }
+      });
+    });
   }
 
-  public get items(): number {
-    return this._root.items;
+  public async recalculateHash(): Promise<Uint8Array> {
+    return new Promise((resolve) => {
+      this._lock.writeLock(async (release) => {
+        const r = await this._root.recalculateHash(new Uint8Array(), this._db);
+        release();
+        resolve(r);
+      });
+    });
   }
 
-  public get rootHash(): string {
-    return this._root.hash;
+  public async getNode(prefix: Uint8Array): Promise<TrieNode | undefined> {
+    return new Promise((resolve) => {
+      this._lock.readLock(async (release) => {
+        const r = await this._root.getNode(prefix, this._db);
+        release();
+        resolve(r);
+      });
+    });
+  }
+
+  public async getAllValues(prefix: Uint8Array): Promise<Uint8Array[]> {
+    return new Promise((resolve) => {
+      this._lock.readLock(async (release) => {
+        const node = await this._root.getNode(prefix, this._db);
+        if (node === undefined) {
+          release();
+          resolve([]);
+        } else {
+          const r = await node.getAllValues(prefix, this._db);
+          release();
+          resolve(r);
+        }
+      });
+    });
+  }
+
+  public async items(): Promise<number> {
+    return new Promise((resolve) => {
+      this._lock.readLock(async (release) => {
+        release();
+        resolve(this._root.items);
+      });
+    });
+  }
+
+  public async rootHash(): Promise<string> {
+    return new Promise((resolve) => {
+      this._lock.readLock(async (release) => {
+        release();
+        resolve(Buffer.from(this._root.hash).toString('hex'));
+      });
+    });
   }
 }
 

--- a/apps/hubble/src/network/sync/trieNode.test.ts
+++ b/apps/hubble/src/network/sync/trieNode.test.ts
@@ -2,6 +2,7 @@ import { Factories, hexStringToBytes } from '@farcaster/utils';
 import { TIMESTAMP_LENGTH } from '~/network/sync/syncId';
 import { EMPTY_HASH, TrieNode } from '~/network/sync/trieNode';
 import { NetworkFactories } from '~/network/utils/factories';
+import { jestRocksDB } from '~/storage/db/jestUtils';
 
 // Safety: fs inputs are always safe in tests
 /* eslint-disable security/detect-non-literal-fs-filename */
@@ -10,6 +11,8 @@ const fid = Factories.Fid.build();
 const sharedDate = new Date(1665182332000);
 const sharedPrefixHashA = '09bc3dad4e7f2a77bbb2cccbecb06febfc6a4321';
 const sharedPrefixHashB = '09bc3dad4e7f2a77bbb2cccbecb06febfc6b1234';
+
+const db = jestRocksDB('protobufs.network.trienode.test');
 
 describe('TrieNode', () => {
   // Traverse the node until we find a leaf or path splits into multiple choices
@@ -30,9 +33,9 @@ describe('TrieNode', () => {
       const id = await NetworkFactories.SyncId.create();
 
       expect(root.items).toEqual(0);
-      expect(root.hash).toEqual('');
+      expect(root.hash.length).toEqual(0);
 
-      root.insert(id.syncId());
+      await root.insert(id.syncId(), db, db.transaction());
 
       expect(root.items).toEqual(1);
       expect(root.hash).toBeTruthy();
@@ -42,20 +45,29 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await NetworkFactories.SyncId.create();
 
-      root.insert(id.syncId());
+      await root.insert(id.syncId(), db, db.transaction());
       expect(root.items).toEqual(1);
       const previousHash = root.hash;
-      root.insert(id.syncId());
+      await root.insert(id.syncId(), db, db.transaction());
 
       expect(root.hash).toEqual(previousHash);
       expect(root.items).toEqual(1);
+    });
+
+    test('value is always undefined for non-leaf nodes', async () => {
+      const trie = new TrieNode();
+      const syncId = await NetworkFactories.SyncId.create();
+
+      await trie.insert(syncId.syncId(), db, db.transaction());
+
+      expect(trie.value).toBeFalsy();
     });
 
     test('insert compacts hashstring component of syncid to single node for efficiency', async () => {
       const root = new TrieNode();
       const id = await NetworkFactories.SyncId.create();
 
-      root.insert(id.syncId());
+      await root.insert(id.syncId(), db, db.transaction());
       let node = root;
       // Timestamp portion of the key is not collapsed, but the hash portion is
       for (let i = 0; i < TIMESTAMP_LENGTH; i++) {
@@ -87,8 +99,8 @@ describe('TrieNode', () => {
       const firstDiffPos = hash1.findIndex((c, i) => c !== hash2[i]);
 
       const root = new TrieNode();
-      root.insert(id1.syncId());
-      root.insert(id2.syncId());
+      await root.insert(id1.syncId(), db, db.transaction());
+      await root.insert(id2.syncId(), db, db.transaction());
 
       const splitNode = traverse(root);
       expect(splitNode.items).toEqual(2);
@@ -114,12 +126,12 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await NetworkFactories.SyncId.create();
 
-      root.insert(id.syncId());
+      await root.insert(id.syncId(), db, db.transaction());
       expect(root.items).toEqual(1);
 
-      root.delete(id.syncId());
+      await root.delete(id.syncId(), db, db.transaction());
       expect(root.items).toEqual(0);
-      expect(root.hash).toEqual(EMPTY_HASH);
+      expect(Buffer.from(root.hash).toString('hex')).toEqual(EMPTY_HASH);
     });
 
     test('deleting a single item from a node with multiple items removes the item', async () => {
@@ -127,14 +139,14 @@ describe('TrieNode', () => {
       const id1 = await NetworkFactories.SyncId.create(undefined, { transient: { date: sharedDate } });
       const id2 = await NetworkFactories.SyncId.create(undefined, { transient: { date: sharedDate } });
 
-      root.insert(id1.syncId());
+      await root.insert(id1.syncId(), db, db.transaction());
       const previousHash = root.hash;
-      root.insert(id2.syncId());
+      await root.insert(id2.syncId(), db, db.transaction());
       expect(root.items).toEqual(2);
 
-      root.delete(id2.syncId());
+      await root.delete(id2.syncId(), db, db.transaction());
       expect(root.items).toEqual(1);
-      expect(root.exists(id2.syncId())).toBeFalsy();
+      expect(await root.exists(id2.syncId(), db)).toBeFalsy();
       expect(root.hash).toEqual(previousHash);
     });
 
@@ -147,14 +159,14 @@ describe('TrieNode', () => {
       });
 
       const root = new TrieNode();
-      root.insert(id1.syncId());
+      await root.insert(id1.syncId(), db, db.transaction());
       const previousRootHash = root.hash;
       const leafNode = traverse(root);
-      root.insert(id2.syncId());
+      await root.insert(id2.syncId(), db, db.transaction());
 
       expect(root.hash).not.toEqual(previousRootHash);
 
-      root.delete(id2.syncId());
+      await root.delete(id2.syncId(), db, db.transaction());
 
       const newLeafNode = traverse(root);
       expect(newLeafNode).toEqual(leafNode);
@@ -173,18 +185,20 @@ describe('TrieNode', () => {
       for (let i = 0; i < ids.length; i++) {
         // Safety: i is controlled by the loop and cannot be used to inject
         // eslint-disable-next-line security/detect-object-injection
-        root.insert(ids[i] as Uint8Array);
+        await root.insert(ids[i] as Uint8Array, db, db.transaction());
       }
 
       // Except the recalculatedHash to match the root hash
-      expect(root.hash).toEqual(Buffer.from(root.recalculateHash()).toString('hex'));
+      expect(Buffer.from(root.hash).toString('hex')).toEqual(
+        Buffer.from(await root.recalculateHash(new Uint8Array(), db)).toString('hex')
+      );
 
       // Remove the first id
-      root.delete(ids[0] as Uint8Array);
+      await root.delete(ids[0] as Uint8Array, db, db.transaction());
 
       // Expect the other two ids to be present
-      expect(root.exists(ids[1] as Uint8Array)).toBeTruthy();
-      expect(root.exists(ids[2] as Uint8Array)).toBeTruthy();
+      expect(await root.exists(ids[1] as Uint8Array, db)).toBeTruthy();
+      expect(await root.exists(ids[2] as Uint8Array, db)).toBeTruthy();
       expect(root.items).toEqual(2);
     });
   });
@@ -194,21 +208,21 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await NetworkFactories.SyncId.create();
 
-      root.insert(id.syncId());
+      await root.insert(id.syncId(), db, db.transaction());
       expect(root.items).toEqual(1);
 
-      expect(root.exists(id.syncId())).toBeTruthy();
+      expect(await root.exists(id.syncId(), db)).toBeTruthy();
     });
 
     test('getting an item after deleting it returns undefined', async () => {
       const root = new TrieNode();
       const id = await NetworkFactories.SyncId.create();
 
-      root.insert(id.syncId());
+      await root.insert(id.syncId(), db, db.transaction());
       expect(root.items).toEqual(1);
 
-      root.delete(id.syncId());
-      expect(root.exists(id.syncId())).toBeFalsy();
+      await root.delete(id.syncId(), db, db.transaction());
+      expect(await root.exists(id.syncId(), db)).toBeFalsy();
       expect(root.items).toEqual(0);
     });
 
@@ -221,10 +235,11 @@ describe('TrieNode', () => {
       });
 
       const root = new TrieNode();
-      root.insert(id1.syncId());
+      await root.insert(id1.syncId(), db, db.transaction());
 
       // id2 shares the same prefix, but doesn't exist, so it should return undefined
-      expect(root.exists(id2.syncId())).toBeFalsy();
+
+      expect(await root.exists(id2.syncId(), db)).toBeFalsy();
     });
   });
 });

--- a/apps/hubble/src/network/sync/trieNode.ts
+++ b/apps/hubble/src/network/sync/trieNode.ts
@@ -1,8 +1,13 @@
+import * as protobufs from '@farcaster/protobufs';
 import { bytesCompare, HubError } from '@farcaster/utils';
 import { blake3 } from '@noble/hashes/blake3';
 import { assert } from 'console';
+import { ResultAsync } from 'neverthrow';
 import { TIMESTAMP_LENGTH } from '~/network/sync/syncId';
+import RocksDB, { Transaction } from '~/storage/db/rocksdb';
+import { RootPrefix } from '~/storage/db/types';
 import { blake3Truncate160, BLAKE3TRUNCATE160_EMPTY_HASH } from '~/utils/crypto';
+import { NodeMetadata } from './merkleTrie';
 
 export const EMPTY_HASH = BLAKE3TRUNCATE160_EMPTY_HASH.toString('hex');
 
@@ -20,18 +25,34 @@ export type TrieSnapshot = {
   numMessages: number;
 };
 
+type TrieNodeOpResult = {
+  status: boolean;
+  txn: Transaction;
+};
+
+// An empty type that represents a serialized trie node, which will need to be loaded from the db
+class SerializedTrieNode {
+  hash?: Uint8Array;
+
+  constructor(hash?: Uint8Array) {
+    if (hash) {
+      this.hash = hash;
+    }
+  }
+}
+
 /**
  * Represents a node in a MerkleTrie. Automatically updates the hashes when items are added,
  * and keeps track of the number of items in the subtree.
  */
 class TrieNode {
-  private _hash: string;
+  private _hash: Uint8Array;
   private _items: number;
-  private _children: Map<number, TrieNode>;
+  private _children: Map<number, TrieNode | SerializedTrieNode>;
   private _key: Uint8Array | undefined;
 
   constructor() {
-    this._hash = '';
+    this._hash = new Uint8Array();
     this._items = 0;
     this._children = new Map();
     this._key = undefined;
@@ -48,7 +69,7 @@ class TrieNode {
    * Recursively traverses the trie by prefix and inserts the value at the end. Updates the hashes for
    * every node that was traversed.
    */
-  public insert(key: Uint8Array, current_index = 0): boolean {
+  public async insert(key: Uint8Array, db: RocksDB, txn: Transaction, current_index = 0): Promise<TrieNodeOpResult> {
     assert(current_index < key.length, 'Key length exceeded');
     if (current_index >= key.length) {
       throw 'Key length exceeded';
@@ -58,18 +79,27 @@ class TrieNode {
     // Do not compact the timestamp portion of the trie, since it is used to compare snapshots
     if (current_index >= TIMESTAMP_LENGTH && this.isLeaf && !this._key) {
       // Reached a leaf node with no value, insert it
-      this._setKeyValue(key);
+
+      // The key is copied to a new Uint8Array to avoid using Buffer's shared memory pool. Since
+      // TrieNode are long-lived objects, referencing shared memory pool will prevent them from being
+      // freed and leak memory.
+      this._key = key === undefined ? undefined : new Uint8Array(key);
+
+      // Also save to db
+      txn = this.saveToDBTx(txn, key.slice(0, current_index));
+
+      await this._updateHash(key.slice(0, current_index), db);
       this._items += 1;
-      return true;
+      return { status: true, txn };
     }
 
     if (current_index >= TIMESTAMP_LENGTH && this.isLeaf) {
       if (bytesCompare(this._key ?? new Uint8Array(), key) === 0) {
         // If the same key exists, do nothing
-        return false;
+        return { status: false, txn };
       }
       // If the key is different, and a value exists, then split the node
-      this._splitLeafNode(current_index);
+      txn = await this._splitLeafNode(current_index, db, txn);
     }
 
     if (!this._children.has(char)) {
@@ -77,14 +107,22 @@ class TrieNode {
     }
 
     // Recurse into a non-leaf node and instruct it to insert the value
-    const success = this._children.get(char)?.insert(key, current_index + 1);
-    if (success) {
+    const child = await this._getOrLoadChild(key.slice(0, current_index), char, db);
+    const result = await child.insert(key, db, txn, current_index + 1);
+
+    const status = result.status;
+    txn = result.txn;
+
+    // Save the current node to DB
+    txn = this.saveToDBTx(txn, key.slice(0, current_index));
+
+    if (status) {
       this._items += 1;
-      this._updateHash();
-      return true;
+      await this._updateHash(key.slice(0, current_index), db);
+      return { status: true, txn };
     }
 
-    return false;
+    return { status: false, txn };
   }
 
   /**
@@ -96,14 +134,17 @@ class TrieNode {
    * Ensures that there are no empty nodes after deletion. This is important to make sure the hashes
    * will match exactly with another trie that never had the value (e.g. in another hub).
    */
-  public delete(key: Uint8Array, current_index = 0): boolean {
+  public async delete(key: Uint8Array, db: RocksDB, txn: Transaction, current_index = 0): Promise<TrieNodeOpResult> {
     if (this.isLeaf) {
       if (bytesCompare(this._key ?? new Uint8Array(), key) === 0) {
         this._items -= 1;
-        this._setKeyValue(undefined);
-        return true;
+        this._key = undefined;
+        txn = this.deleteFromDbTx(txn, key.slice(0, current_index));
+
+        await this._updateHash(key.slice(0, current_index), db);
+        return { status: true, txn };
       } else {
-        return false;
+        return { status: false, txn };
       }
     }
 
@@ -113,32 +154,52 @@ class TrieNode {
     }
     const char = key.at(current_index) as number;
     if (!this._children.has(char)) {
-      return false;
+      return { status: false, txn };
     }
 
-    const success = this._children.get(char)?.delete(key, current_index + 1);
+    const childTrieNode = await this._getOrLoadChild(key.slice(0, current_index), char, db);
+    const result = await childTrieNode.delete(key, db, txn, current_index + 1);
+
+    const success = result.status;
+    txn = result.txn;
+
     if (success) {
       this._items -= 1;
       // Delete the child if it's empty. This is required to make sure the hash will be the same
       // as another trie that doesn't have this node in the first place.
-      if (this._children.get(char)?.items === 0) {
+      if (childTrieNode.items === 0) {
         this._children.delete(char);
+
+        if (this._items === 0) {
+          // Delete this node
+          txn = this.deleteFromDbTx(txn, key.slice(0, current_index));
+        } else {
+          // Update the current node because a child char is now gone
+          txn = this.saveToDBTx(txn, key.slice(0, current_index));
+        }
       }
 
       if (this._items === 1 && this._children.size === 1 && current_index >= TIMESTAMP_LENGTH) {
         // Compact the node if it has only one child
-        const [char, child] = this._children.entries().next().value;
+        const [char, child]: [number, TrieNode] = this._children.entries().next().value;
         if (child._key) {
-          this._setKeyValue(child._key);
+          this._key = child._key;
+          await this._updateHash(key.slice(0, current_index), db);
           this._children.delete(char);
+
+          // Delete child
+          const childPrefix = Buffer.concat([key.slice(0, current_index), new Uint8Array([char])]);
+          txn = child.deleteFromDbTx(txn, childPrefix);
+          // Update the current node because a child char is now gone
+          txn = this.saveToDBTx(txn, key.slice(0, current_index));
         }
       }
 
-      this._updateHash();
-      return true;
+      await this._updateHash(key.slice(0, current_index), db);
+      return { status: true, txn };
     }
 
-    return false;
+    return { status: false, txn };
   }
 
   /**
@@ -146,7 +207,7 @@ class TrieNode {
    * @param key - The key to look for
    * @param current_index - The index of the current character in the key (only used internally)
    */
-  public exists(key: Uint8Array, current_index = 0): boolean {
+  public async exists(key: Uint8Array, db: RocksDB, current_index = 0): Promise<boolean> {
     if (this.isLeaf && bytesCompare(this._key ?? new Uint8Array(), key) === 0) {
       return true;
     }
@@ -162,15 +223,16 @@ class TrieNode {
 
     // NOTE: eslint falsely identifies as `fs.exists`.
     // eslint-disable-next-line security/detect-non-literal-fs-filename
-    return this._children.get(char)?.exists(key, current_index + 1) || false;
+    const child = await this._getOrLoadChild(key.slice(0, current_index), char, db);
+    return child.exists(key, db, current_index + 1) || false;
   }
 
   // Generates a snapshot for the current node and below. current_index is the index of the prefix the method
   // is operating on
-  public getSnapshot(prefix: Uint8Array, current_index = 0): TrieSnapshot {
+  public async getSnapshot(prefix: Uint8Array, db: RocksDB, current_index = 0): Promise<TrieSnapshot> {
     const char = prefix.at(current_index) as number;
     if (current_index === prefix.length - 1) {
-      const excludedHash = this._excludedHash(char);
+      const excludedHash = await this._excludedHash(prefix, char, db);
       return {
         prefix: prefix,
         excludedHashes: [excludedHash.hash],
@@ -178,8 +240,16 @@ class TrieNode {
       };
     }
 
-    const innerSnapshot = this._children.get(char)?.getSnapshot(prefix, current_index + 1);
-    const excludedHash = this._excludedHash(char);
+    // Check if child is present
+    let innerSnapshot: TrieSnapshot | undefined = undefined;
+    if (this._children.has(char)) {
+      innerSnapshot = await (
+        await this._getOrLoadChild(prefix.slice(0, current_index), char, db)
+      ).getSnapshot(prefix, db, current_index + 1);
+    }
+
+    const excludedHash = await this._excludedHash(prefix, char, db);
+
     return {
       prefix: innerSnapshot?.prefix || prefix.subarray(0, current_index + 1),
       excludedHashes: [excludedHash.hash, ...(innerSnapshot?.excludedHashes || [])],
@@ -191,7 +261,7 @@ class TrieNode {
     return this._items;
   }
 
-  public get hash(): string {
+  public get hash(): Uint8Array {
     return this._hash;
   }
 
@@ -207,60 +277,158 @@ class TrieNode {
     return undefined;
   }
 
-  public getNode(prefix: Uint8Array): TrieNode | undefined {
-    if (prefix.length === 0) {
+  public async getNode(prefix: Uint8Array, db: RocksDB, current_index = 0): Promise<TrieNode | undefined> {
+    if (current_index === prefix.length) {
       return this;
     }
-    const char = prefix.at(0) as number;
+    const char = prefix.at(current_index) as number;
     if (!this._children.has(char)) {
       return undefined;
     }
-    return this._children.get(char)?.getNode(prefix.slice(1));
+    const child = await this._getOrLoadChild(prefix.slice(0, current_index), char, db);
+    return await child.getNode(prefix, db, current_index + 1);
   }
 
-  public get children(): IterableIterator<[number, TrieNode]> {
+  public async getNodeMetadata(prefix: Uint8Array, db: RocksDB): Promise<NodeMetadata> {
+    const children = this.children || new Map();
+    const result = new Map<number, NodeMetadata>();
+    for (const [char] of children) {
+      const child = await this._getOrLoadChild(prefix, char, db);
+      const newPrefix = Buffer.concat([prefix, Buffer.from([char])]);
+      result.set(char, {
+        numMessages: child.items,
+        prefix: newPrefix,
+        hash: Buffer.from(child.hash).toString('hex'),
+      });
+    }
+    return { prefix, children: result, numMessages: this.items, hash: Buffer.from(this.hash).toString('hex') };
+  }
+
+  public get children(): IterableIterator<[number, TrieNode | SerializedTrieNode]> {
     return this._children.entries();
   }
 
-  public getAllValues(): Uint8Array[] {
+  public async getAllValues(key: Uint8Array, db: RocksDB, current_index = 0): Promise<Uint8Array[]> {
     if (this.isLeaf) {
       return this._key ? [this._key] : [];
     }
     const values: Uint8Array[] = [];
-    this._children.forEach((child) => {
-      values.push(...child.getAllValues());
-    });
+    for (const [char] of this._children) {
+      const child = await this._getOrLoadChild(key.slice(0, current_index), char, db);
+      values.push(...(await child.getAllValues(key, db, current_index + 1)));
+    }
     return values;
   }
 
-  public recalculateHash(): Uint8Array {
-    let digest;
+  public async recalculateHash(prefix: Uint8Array, db: RocksDB): Promise<Uint8Array> {
+    // TODO: Recalculate only if the hash is absent.
+    let digest: Uint8Array;
     if (this.isLeaf) {
       digest = blake3Truncate160(this.value);
+      this._items = 1;
     } else {
       const hash = blake3.create({ dkLen: 20 });
-      this._children.forEach((child) => {
-        hash.update(child.recalculateHash());
-      });
+      let childItems = 0;
+      for (const [char] of this._children) {
+        const child = await this._getOrLoadChild(prefix, char, db);
+        const newPrefix = Buffer.concat([prefix, Buffer.from([char])]);
+        hash.update(await child.recalculateHash(newPrefix, db));
+        childItems += child.items;
+      }
       digest = hash.digest();
+      this._items = childItems;
     }
-    if (!this._hash) {
-      this._hash = Buffer.from(digest.buffer, digest.byteOffset, digest.byteLength).toString('hex');
-    }
+
+    this._hash = digest;
+
     return digest;
   }
 
-  /* Private methods */
+  public unloadChildren() {
+    // Replace all the children with SerializedTrieNodes. Make sure it include the hashes.
 
-  private _excludedHash(char: number): { items: number; hash: string } {
+    // Collect all child chars
+    const childChars = Array.from(this._children.keys());
+    for (const char of childChars) {
+      const child = this._children.get(char);
+      this._children.set(char, new SerializedTrieNode(child?.hash));
+    }
+    // Sort the child chars
+    this._children = new Map([...this._children.entries()].sort());
+  }
+
+  static makePrimaryKey(prefix: Uint8Array): Buffer {
+    return Buffer.concat([Buffer.from([RootPrefix.SyncMerkleTrieNode]), prefix]);
+  }
+
+  static deserialize(serialized: Uint8Array): TrieNode {
+    const dbtrieNode = protobufs.DbTrieNode.decode(serialized);
+
+    const trieNode = new TrieNode();
+    trieNode._key = dbtrieNode.key.length === 0 ? undefined : dbtrieNode.key;
+
+    for (let i = 0; i < dbtrieNode.childChars.length; i++) {
+      trieNode._children.set(dbtrieNode.childChars[i] as number, new SerializedTrieNode());
+    }
+
+    return trieNode;
+  }
+
+  /* Private methods */
+  private serialize(): Buffer {
+    const dbtrieNode = protobufs.DbTrieNode.create({
+      key: this._key ?? new Uint8Array(),
+      childChars: Array.from(this._children.keys()),
+    });
+
+    return Buffer.from(protobufs.DbTrieNode.encode(dbtrieNode).finish());
+  }
+
+  private saveToDBTx(tx: Transaction, prefix: Uint8Array): Transaction {
+    return tx.put(TrieNode.makePrimaryKey(prefix), this.serialize());
+  }
+
+  private deleteFromDbTx(tx: Transaction, prefix: Uint8Array): Transaction {
+    return tx.del(TrieNode.makePrimaryKey(prefix));
+  }
+
+  private async _getOrLoadChild(prefix: Uint8Array, char: number, db: RocksDB): Promise<TrieNode> {
+    const child = this._children.get(char);
+    if (child instanceof TrieNode) {
+      return child as TrieNode;
+    } else {
+      // The key to load is this node's key + the char
+      const childPrefix = Buffer.concat([prefix, Buffer.from([char])]);
+      const childKey = TrieNode.makePrimaryKey(childPrefix);
+      const childBytes = await ResultAsync.fromPromise(db.get(childKey), (e) => {
+        return new Error(`Failed to load child node: ${e}`);
+      });
+      if (childBytes.isErr()) {
+        // TODO: Should we throw here?
+        throw childBytes.error;
+      } else {
+        const childNode = TrieNode.deserialize(childBytes.value);
+        this._children.set(char, childNode);
+        return childNode;
+      }
+    }
+  }
+
+  private async _excludedHash(
+    prefix: Uint8Array,
+    prefixChar: number,
+    db: RocksDB
+  ): Promise<{ items: number; hash: string }> {
     const hash = blake3.create({ dkLen: 20 });
     let excludedItems = 0;
-    this._children.forEach((child, key) => {
-      if (key !== char) {
-        hash.update(Buffer.from(child.hash, 'hex'));
+    for (const [char] of this._children) {
+      const child = await this._getOrLoadChild(prefix, char, db);
+      if (prefixChar !== char) {
+        hash.update(child.hash);
         excludedItems += child.items;
       }
-    });
+    }
+
     const digest = hash.digest();
     return {
       hash: Buffer.from(digest.buffer, digest.byteOffset, digest.byteLength).toString('hex'),
@@ -275,17 +443,9 @@ class TrieNode {
     this._children = new Map([...this._children.entries()].sort());
   }
 
-  private _setKeyValue(key: Uint8Array | undefined) {
-    // The key is copied to a new Uint8Array to avoid using Buffer's shared memory pool. Since
-    // TrieNode are long-lived objects, referencing shared memory pool will prevent them from being
-    // freed and leak memory.
-    this._key = key === undefined ? undefined : new Uint8Array(key);
-    this._updateHash();
-  }
-
   // Splits a leaf node into a non-leaf node by clearing its key/value and adding a child for
   // the next char in its key
-  private _splitLeafNode(current_index: number) {
+  private async _splitLeafNode(current_index: number, db: RocksDB, txn: Transaction): Promise<Transaction> {
     if (!this._key) {
       // This should never happen, check is here for type safety
       throw new HubError('bad_request', 'Cannot split a leaf node without a key and value');
@@ -295,22 +455,41 @@ class TrieNode {
 
     const newChildChar = this._key.at(current_index) as number;
     this._addChild(newChildChar);
-    this._children.get(newChildChar)?.insert(this._key, current_index + 1);
-    this._setKeyValue(undefined);
+    const newChild = await this._getOrLoadChild(this._key.slice(0, current_index), newChildChar, db);
+    const result = await newChild.insert(this._key, db, txn, current_index + 1);
+
+    txn = result.txn;
+    const prefix = this._key.slice(0, current_index);
+
+    // Save the current node to the DB
+    txn = this.saveToDBTx(txn, this._key.slice(0, current_index));
+
+    // Update our hash
+    this._key = undefined;
+    await this._updateHash(prefix, db);
+
+    return txn;
   }
 
-  private _updateHash() {
-    let digest;
+  private async _updateHash(prefix: Uint8Array, db: RocksDB) {
+    let digest: Uint8Array;
     if (this.isLeaf) {
       digest = blake3Truncate160(this.value);
     } else {
       const hash = blake3.create({ dkLen: 20 });
-      this._children.forEach((child) => {
-        hash.update(Buffer.from(child.hash, 'hex'));
-      });
+      for (const [char] of this._children) {
+        // If the child hash is available, use it, else load the child and get its hash
+        const childHash = this._children.get(char)?.hash;
+        if (childHash) {
+          hash.update(childHash);
+        } else {
+          const child = await this._getOrLoadChild(prefix, char, db);
+          hash.update(child.hash);
+        }
+      }
       digest = hash.digest();
     }
-    this._hash = Buffer.from(digest.buffer, digest.byteOffset, digest.byteLength).toString('hex');
+    this._hash = digest;
   }
 }
 

--- a/apps/hubble/src/rpc/server/test/ampService.test.ts
+++ b/apps/hubble/src/rpc/server/test/ampService.test.ts
@@ -15,7 +15,7 @@ let server: Server;
 let client: HubRpcClient;
 
 beforeAll(async () => {
-  server = new Server(hub, engine, new SyncEngine(engine));
+  server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
   client = getHubRpcClient(`127.0.0.1:${port}`);
 });

--- a/apps/hubble/src/rpc/server/test/bulkService.test.ts
+++ b/apps/hubble/src/rpc/server/test/bulkService.test.ts
@@ -15,7 +15,7 @@ let server: Server;
 let client: HubRpcClient;
 
 beforeAll(async () => {
-  server = new Server(hub, engine, new SyncEngine(engine));
+  server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
   client = getHubRpcClient(`127.0.0.1:${port}`);
 });
@@ -214,7 +214,7 @@ describe('getAllUserDataMessagesByFid', () => {
     await engine.mergeMessage(userDataAdd);
     const result = await client.getAllUserDataMessagesByFid(protobufs.FidRequest.create({ fid }));
     assertMessagesMatchResult(result, [userDataAdd]);
-  });
+  }, 5000000);
 
   test('returns empty array without messages', async () => {
     const result = await client.getAllUserDataMessagesByFid(protobufs.FidRequest.create({ fid }));

--- a/apps/hubble/src/rpc/server/test/castService.test.ts
+++ b/apps/hubble/src/rpc/server/test/castService.test.ts
@@ -15,7 +15,7 @@ let server: Server;
 let client: HubRpcClient;
 
 beforeAll(async () => {
-  server = new Server(hub, engine, new SyncEngine(engine));
+  server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
   client = getHubRpcClient(`127.0.0.1:${port}`);
 });

--- a/apps/hubble/src/rpc/server/test/concurrency.test.ts
+++ b/apps/hubble/src/rpc/server/test/concurrency.test.ts
@@ -18,7 +18,7 @@ let client2: HubRpcClient;
 let client3: HubRpcClient;
 
 beforeAll(async () => {
-  server = new Server(hub, engine, new SyncEngine(engine));
+  server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
   client1 = getHubRpcClient(`127.0.0.1:${port}`);
   client2 = getHubRpcClient(`127.0.0.1:${port}`);

--- a/apps/hubble/src/rpc/server/test/reactionService.test.ts
+++ b/apps/hubble/src/rpc/server/test/reactionService.test.ts
@@ -15,7 +15,7 @@ let server: Server;
 let client: HubRpcClient;
 
 beforeAll(async () => {
-  server = new Server(hub, engine, new SyncEngine(engine));
+  server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
   client = getHubRpcClient(`127.0.0.1:${port}`);
 });

--- a/apps/hubble/src/rpc/server/test/signerService.test.ts
+++ b/apps/hubble/src/rpc/server/test/signerService.test.ts
@@ -15,7 +15,7 @@ let server: Server;
 let client: HubRpcClient;
 
 beforeAll(async () => {
-  server = new Server(hub, engine, new SyncEngine(engine));
+  server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
   client = getHubRpcClient(`127.0.0.1:${port}`);
 });

--- a/apps/hubble/src/rpc/server/test/submitService.test.ts
+++ b/apps/hubble/src/rpc/server/test/submitService.test.ts
@@ -17,7 +17,7 @@ let server: Server;
 let client: HubRpcClient;
 
 beforeAll(async () => {
-  server = new Server(hub, engine, new SyncEngine(engine));
+  server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
   client = getHubRpcClient(`127.0.0.1:${port}`);
 });

--- a/apps/hubble/src/rpc/server/test/userDataService.test.ts
+++ b/apps/hubble/src/rpc/server/test/userDataService.test.ts
@@ -16,7 +16,7 @@ let server: Server;
 let client: HubRpcClient;
 
 beforeAll(async () => {
-  server = new Server(hub, engine, new SyncEngine(engine));
+  server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
   client = getHubRpcClient(`127.0.0.1:${port}`);
 });

--- a/apps/hubble/src/rpc/server/test/verificationService.test.ts
+++ b/apps/hubble/src/rpc/server/test/verificationService.test.ts
@@ -15,7 +15,7 @@ let server: Server;
 let client: HubRpcClient;
 
 beforeAll(async () => {
-  server = new Server(hub, engine, new SyncEngine(engine));
+  server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
   client = getHubRpcClient(`127.0.0.1:${port}`);
 });

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -31,6 +31,8 @@ export enum RootPrefix {
   HubState = 9,
   /* Revoke signer jobs */
   JobRevokeSigner = 10,
+  /* Sync Merkle Trie Node */
+  SyncMerkleTrieNode = 11,
 }
 
 /**

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -120,7 +120,7 @@ class Engine {
   /*                             Sync Methods                                   */
   /* -------------------------------------------------------------------------- */
 
-  async forEachMessage(callback: (message: protobufs.Message) => void): Promise<void> {
+  async forEachMessage(callback: (message: protobufs.Message) => Promise<void>): Promise<void> {
     const allUserPrefix = Buffer.from([RootPrefix.User]);
 
     for await (const [key, value] of this._db.iteratorByPrefix(allUserPrefix, { keys: true, valueAsBuffer: true })) {
@@ -150,7 +150,7 @@ class Engine {
 
       const message = protobufs.Message.decode(new Uint8Array(value));
 
-      callback(message);
+      await callback(message);
     }
   }
   async getAllMessagesBySyncIds(syncIds: Uint8Array[]): HubAsyncResult<protobufs.Message[]> {

--- a/apps/hubble/src/test/bench/merkleTrie.ts
+++ b/apps/hubble/src/test/bench/merkleTrie.ts
@@ -10,6 +10,7 @@ import ProgressBar from 'progress';
 
 import { MerkleTrie } from '~/network/sync/merkleTrie';
 
+import { jestRocksDB } from '~/storage/db/jestUtils';
 import { generateSyncIds } from './helpers';
 import { yieldToEventLoop } from './utils';
 
@@ -55,7 +56,9 @@ export const benchMerkleTrie = async ({
   });
 
   const syncIds = generateSyncIds(count, 100_000, 300);
-  const trie = new MerkleTrie();
+  const db = jestRocksDB('protobufs.bench.merkleTrie.test');
+
+  const trie = new MerkleTrie(db);
 
   let i = 0;
   progress.tick(0);

--- a/apps/hubble/src/utils/crypto.ts
+++ b/apps/hubble/src/utils/crypto.ts
@@ -8,6 +8,21 @@ export const sleep = (ms: number) => {
   });
 };
 
+export const sleepWhile = (condition: () => boolean, timeoutMs: number): Promise<void> => {
+  return new Promise((resolve) => {
+    const interval = setInterval(() => {
+      if (!condition()) {
+        clearInterval(interval);
+        resolve();
+      }
+    }, 10);
+    setTimeout(() => {
+      clearInterval(interval);
+      resolve();
+    }, timeoutMs);
+  });
+};
+
 /**
  * Compute Blake3-Truncate-160 digest.
  *

--- a/packages/protobufs/src/generated/sync_trie.ts
+++ b/packages/protobufs/src/generated/sync_trie.ts
@@ -1,0 +1,142 @@
+/* eslint-disable */
+import _m0 from "protobufjs/minimal";
+
+export interface DbTrieNode {
+  key: Uint8Array;
+  childChars: number[];
+}
+
+function createBaseDbTrieNode(): DbTrieNode {
+  return { key: new Uint8Array(), childChars: [] };
+}
+
+export const DbTrieNode = {
+  encode(message: DbTrieNode, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.key.length !== 0) {
+      writer.uint32(10).bytes(message.key);
+    }
+    writer.uint32(18).fork();
+    for (const v of message.childChars) {
+      writer.uint32(v);
+    }
+    writer.ldelim();
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): DbTrieNode {
+    const reader = input instanceof _m0.Reader ? input : new _m0.Reader(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseDbTrieNode();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          message.key = reader.bytes();
+          break;
+        case 2:
+          if ((tag & 7) === 2) {
+            const end2 = reader.uint32() + reader.pos;
+            while (reader.pos < end2) {
+              message.childChars.push(reader.uint32());
+            }
+          } else {
+            message.childChars.push(reader.uint32());
+          }
+          break;
+        default:
+          reader.skipType(tag & 7);
+          break;
+      }
+    }
+    return message;
+  },
+
+  fromJSON(object: any): DbTrieNode {
+    return {
+      key: isSet(object.key) ? bytesFromBase64(object.key) : new Uint8Array(),
+      childChars: Array.isArray(object?.childChars) ? object.childChars.map((e: any) => Number(e)) : [],
+    };
+  },
+
+  toJSON(message: DbTrieNode): unknown {
+    const obj: any = {};
+    message.key !== undefined &&
+      (obj.key = base64FromBytes(message.key !== undefined ? message.key : new Uint8Array()));
+    if (message.childChars) {
+      obj.childChars = message.childChars.map((e) => Math.round(e));
+    } else {
+      obj.childChars = [];
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<DbTrieNode>, I>>(base?: I): DbTrieNode {
+    return DbTrieNode.fromPartial(base ?? {});
+  },
+
+  fromPartial<I extends Exact<DeepPartial<DbTrieNode>, I>>(object: I): DbTrieNode {
+    const message = createBaseDbTrieNode();
+    message.key = object.key ?? new Uint8Array();
+    message.childChars = object.childChars?.map((e) => e) || [];
+    return message;
+  },
+};
+
+declare var self: any | undefined;
+declare var window: any | undefined;
+declare var global: any | undefined;
+var tsProtoGlobalThis: any = (() => {
+  if (typeof globalThis !== "undefined") {
+    return globalThis;
+  }
+  if (typeof self !== "undefined") {
+    return self;
+  }
+  if (typeof window !== "undefined") {
+    return window;
+  }
+  if (typeof global !== "undefined") {
+    return global;
+  }
+  throw "Unable to locate global object";
+})();
+
+function bytesFromBase64(b64: string): Uint8Array {
+  if (tsProtoGlobalThis.Buffer) {
+    return Uint8Array.from(tsProtoGlobalThis.Buffer.from(b64, "base64"));
+  } else {
+    const bin = tsProtoGlobalThis.atob(b64);
+    const arr = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; ++i) {
+      arr[i] = bin.charCodeAt(i);
+    }
+    return arr;
+  }
+}
+
+function base64FromBytes(arr: Uint8Array): string {
+  if (tsProtoGlobalThis.Buffer) {
+    return tsProtoGlobalThis.Buffer.from(arr).toString("base64");
+  } else {
+    const bin: string[] = [];
+    arr.forEach((byte) => {
+      bin.push(String.fromCharCode(byte));
+    });
+    return tsProtoGlobalThis.btoa(bin.join(""));
+  }
+}
+
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
+type DeepPartial<T> = T extends Builtin ? T
+  : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/packages/protobufs/src/index.ts
+++ b/packages/protobufs/src/index.ts
@@ -10,6 +10,7 @@ export * from './generated/job';
 export * from './generated/message';
 export * from './generated/name_registry_event';
 export * from './generated/rpc';
+export * from './generated/sync_trie';
 export * from './typeguards';
 export * from './types';
 

--- a/packages/protobufs/src/schemas/sync_trie.proto
+++ b/packages/protobufs/src/schemas/sync_trie.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+message DbTrieNode {
+  bytes key = 1;
+  repeated uint32 childChars = 2;
+}
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2518,6 +2518,11 @@
   resolved "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
   integrity sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==
 
+"@types/rwlock@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.npmjs.org/@types/rwlock/-/rwlock-5.0.3.tgz#6e869fbede0b3bc441a046c4a447c2e3658960ad"
+  integrity sha512-R30oM++aVJ0Lcv4pHPTJWV8HvikNDroDbLxoRX9d5piGyhZzRAENXTBIMtceWKcnmscKfASk1Yg6Gr9+X5CTBw==
+
 "@types/semver@^6.0.0":
   version "6.2.3"
   resolved "https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz#5798ecf1bec94eaa64db39ee52808ec0693315aa"
@@ -6963,6 +6968,11 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+rwlock@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/rwlock/-/rwlock-5.0.0.tgz#888d6a77a3351cc1a209204ef2ee1722093836cf"
+  integrity sha512-XgzRqLMfCcm9QfZuPav9cV3Xin5TRcIlp4X/SH3CvB+x5D2AakdlEepfJKDd8ByncvfpcxNWdRZVUl38PS6ZJg==
 
 rxjs@^7.5.7:
   version "7.8.0"


### PR DESCRIPTION
## Motivation

Persist the Merkle Trie into the Rocks DB

## Change Summary

- Persist every node in the Merkle Trie into the DB, key'd by it's prefix
- Update insert / delete to delete from DB when deleted from trie
- Allow partially unloading the trie to save RAM, load from DB on demand.
- Update tests
- Load trie from DB when Hub starts

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
