### PR TITLE
fix: Init DB before loading Merkle Trie

### DIFF
--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -169,6 +169,7 @@ describe('MerkleTrie', () => {
 
         // Now initialize a new merkle trie from the same DB
         const trie2 = new MerkleTrie(db);
+        await trie2.initialize();
 
         // expect the root hashes to be the same
         expect(await trie.rootHash()).toEqual(await trie2.rootHash());
@@ -182,6 +183,7 @@ describe('MerkleTrie', () => {
 
         // Initialize a new trie from the same DB
         const trie3 = new MerkleTrie(db);
+        await trie3.initialize();
 
         // expect the root hashes to be the same
         expect(await trie.rootHash()).toEqual(await trie3.rootHash());
@@ -345,6 +347,8 @@ describe('MerkleTrie', () => {
       const rootHash = await trie.rootHash();
 
       const trie2 = new MerkleTrie(db);
+      await trie2.initialize();
+
       expect(await trie2.rootHash()).toEqual(rootHash);
 
       expect(await trie2.delete(syncId1)).toBeTruthy();

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -46,6 +46,9 @@ class MerkleTrie {
     this._lock = new ReadWriteLock();
 
     this._root = new TrieNode();
+  }
+
+  public async initialize(): Promise<void> {
     this._lock.writeLock(async (release) => {
       try {
         const rootBytes = await this._db.get(TrieNode.makePrimaryKey(new Uint8Array()));
@@ -55,7 +58,6 @@ class MerkleTrie {
         }
       } catch {
         // There is no Root node in the DB, just use an empty one
-        this._root = new TrieNode();
       }
 
       release();

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -66,6 +66,7 @@ class SyncEngine {
 
   public async initialize() {
     // Wait for the Merkle trie to be fully loaded
+    await this._trie.initialize();
     const rootHash = await this._trie.rootHash();
     log.info({ rootHash }, 'Sync engine initialized');
   }


### PR DESCRIPTION
## Motivation

Init DB before loading Merkle Trie

## Change Summary

- Init DB first, move loading merkle trie to `initialize()`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
