### PR TITLE
fix: Use other snapshot prefix when syncing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ yarn-error.log*
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 build
+.history 
+.hub_history
 
 # Dependency directories
 node_modules/

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -366,7 +366,7 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
     }
 
     const peerState = peerStateResult.value;
-    const shouldSync = await this.syncEngine.shouldSync(peerState.excludedHashes);
+    const shouldSync = await this.syncEngine.shouldSync(peerState);
     if (shouldSync.isErr()) {
       log.warn(`Failed to get shouldSync`);
       this.emit('syncComplete', false);
@@ -375,7 +375,7 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
 
     if (shouldSync.value === true) {
       log.info(`Syncing with peer`);
-      await this.syncEngine.performSync(peerState.excludedHashes, rpcClient);
+      await this.syncEngine.performSync(peerState, rpcClient);
     } else {
       log.info(`No need to sync`);
       this.emit('syncComplete', false);

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -141,18 +141,18 @@ describe('Multi peer sync engine', () => {
 
       // Engine 2 should sync with engine1
       expect(
-        (await syncEngine2.shouldSync((await syncEngine1.getSnapshot())._unsafeUnwrap().excludedHashes))._unsafeUnwrap()
+        (await syncEngine2.shouldSync((await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap()
       ).toBeTruthy();
 
       // Sync engine 2 with engine 1
-      await syncEngine2.performSync((await syncEngine1.getSnapshot())._unsafeUnwrap().excludedHashes, clientForServer1);
+      await syncEngine2.performSync((await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
 
       // Make sure root hash matches
       expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
 
       // Should sync should now be false with the new excluded hashes
       expect(
-        (await syncEngine2.shouldSync((await syncEngine1.getSnapshot())._unsafeUnwrap().excludedHashes))._unsafeUnwrap()
+        (await syncEngine2.shouldSync((await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap()
       ).toBeFalsy();
 
       // Add more messages
@@ -170,10 +170,10 @@ describe('Multi peer sync engine', () => {
       expect(await syncEngine1.trie.rootHash()).toEqual(newSnapshot.rootHash);
 
       // Should sync should now be true
-      expect((await syncEngine2.shouldSync(newSnapshot.excludedHashes))._unsafeUnwrap()).toBeTruthy();
+      expect((await syncEngine2.shouldSync(newSnapshot))._unsafeUnwrap()).toBeTruthy();
 
       // Do the sync again
-      await syncEngine2.performSync(newSnapshot.excludedHashes, clientForServer1);
+      await syncEngine2.performSync(newSnapshot, clientForServer1);
 
       // Make sure root hash matches
       expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
@@ -193,7 +193,7 @@ describe('Multi peer sync engine', () => {
     const engine2 = new Engine(testDb2, network);
     const syncEngine2 = new SyncEngine(engine2, testDb2);
     // Sync engine 2 with engine 1
-    await syncEngine2.performSync([], clientForServer1);
+    await syncEngine2.performSync((await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
 
     // Make sure the castAdd is in the trie
     // eslint-disable-next-line security/detect-non-literal-fs-filename
@@ -233,7 +233,7 @@ describe('Multi peer sync engine', () => {
       const clientForServer2 = getHubRpcClient(`127.0.0.1:${port2}`);
       const engine1RootHashBefore = await syncEngine1.trie.rootHash();
 
-      await syncEngine1.performSync((await syncEngine2.getSnapshot())._unsafeUnwrap().excludedHashes, clientForServer2);
+      await syncEngine1.performSync((await syncEngine2.getSnapshot())._unsafeUnwrap(), clientForServer2);
       expect(await syncEngine1.trie.rootHash()).toEqual(engine1RootHashBefore);
 
       clientForServer2.$.close();
@@ -245,7 +245,7 @@ describe('Multi peer sync engine', () => {
     expect(await syncEngine2.trie.exists(castRemoveId)).toBeFalsy();
 
     // Syncing engine2 with engine1 should delete the castAdd from the trie and add the castRemove
-    await syncEngine2.performSync((await syncEngine1.getSnapshot())._unsafeUnwrap().excludedHashes, clientForServer1);
+    await syncEngine2.performSync((await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
 
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     expect(await syncEngine2.trie.exists(castRemoveId)).toBeTruthy();
@@ -324,7 +324,7 @@ describe('Multi peer sync engine', () => {
 
       // Engine 2 should sync with engine1
       expect(
-        (await syncEngine2.shouldSync((await syncEngine1.getSnapshot())._unsafeUnwrap().excludedHashes))._unsafeUnwrap()
+        (await syncEngine2.shouldSync((await syncEngine1.getSnapshot())._unsafeUnwrap()))._unsafeUnwrap()
       ).toBeTruthy();
 
       await engine2.mergeIdRegistryEvent(custodyEvent);
@@ -332,10 +332,7 @@ describe('Multi peer sync engine', () => {
 
       // Sync engine 2 with engine 1, and measure the time taken
       totalTime = await timedTest(async () => {
-        await syncEngine2.performSync(
-          (await syncEngine1.getSnapshot())._unsafeUnwrap().excludedHashes,
-          clientForServer1
-        );
+        await syncEngine2.performSync((await syncEngine1.getSnapshot())._unsafeUnwrap(), clientForServer1);
       });
 
       expect(totalTime).toBeGreaterThan(0);

--- a/apps/hubble/src/network/sync/syncEnginePerf.test.ts
+++ b/apps/hubble/src/network/sync/syncEnginePerf.test.ts
@@ -1,0 +1,164 @@
+// eslint-disable-file security/detect-non-literal-fs-filename
+
+import * as protobufs from '@farcaster/protobufs';
+import { FarcasterNetwork } from '@farcaster/protobufs';
+import { Factories, HubResult, HubRpcClient } from '@farcaster/utils';
+import { ok } from 'neverthrow';
+import SyncEngine from '~/network/sync/syncEngine';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import Engine from '~/storage/engine';
+import { NodeMetadata } from './merkleTrie';
+
+const testDb = jestRocksDB(`engine.syncEnginePerf.test`);
+const testDb2 = jestRocksDB(`engine2.syncEnginePerf.test`);
+
+const network = protobufs.FarcasterNetwork.FARCASTER_NETWORK_TESTNET;
+
+const fid = Factories.Fid.build();
+const custodySigner = Factories.Eip712Signer.build();
+const signer = Factories.Ed25519Signer.build();
+
+let custodyEvent: protobufs.IdRegistryEvent;
+let signerAdd: protobufs.Message;
+
+beforeAll(async () => {
+  custodyEvent = Factories.IdRegistryEvent.build({ fid, to: custodySigner.signerKey });
+
+  signerAdd = await Factories.SignerAddMessage.create(
+    { data: { fid, network, signerBody: { signer: signer.signerKey } } },
+    { transient: { signer: custodySigner } }
+  );
+});
+
+describe('SyncEngine', () => {
+  let engine: Engine;
+
+  beforeEach(async () => {
+    await testDb.clear();
+    engine = new Engine(testDb, FarcasterNetwork.FARCASTER_NETWORK_TESTNET);
+  });
+
+  const addMessagesWithTimestamps = async (timestamps: number[], mergeEngine?: Engine) => {
+    return await Promise.all(
+      timestamps.map(async (t) => {
+        const cast = await Factories.CastAddMessage.create(
+          { data: { fid, network, timestamp: t } },
+          { transient: { signer } }
+        );
+
+        const result = await (mergeEngine || engine).mergeMessage(cast);
+        expect(result.isOk()).toBeTruthy();
+        return Promise.resolve(cast);
+      })
+    );
+  };
+
+  test('should not fetch all messages when snapshot contains non-existent prefix', async () => {
+    const nowOrig = Date.now;
+    try {
+      testDb.clear();
+      testDb2.clear();
+
+      const engine1 = new Engine(testDb, FarcasterNetwork.FARCASTER_NETWORK_TESTNET);
+      const syncEngine1 = new SyncEngine(engine1, testDb);
+      const engine2 = new Engine(testDb2, FarcasterNetwork.FARCASTER_NETWORK_TESTNET);
+      const syncEngine2 = new SyncEngine(engine2, testDb2);
+
+      await engine1.mergeIdRegistryEvent(custodyEvent);
+      await engine1.mergeMessage(signerAdd);
+      await engine2.mergeIdRegistryEvent(custodyEvent);
+      await engine2.mergeMessage(signerAdd);
+
+      const messages = await addMessagesWithTimestamps([30662167, 30662169, 30662172], engine1);
+      for (const message of messages) {
+        await engine2.mergeMessage(message);
+      }
+
+      // Sanity check, they should equal
+      expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
+
+      Date.now = () => 1640995200000 + 30662200 * 1000;
+
+      const snapshot2 = (await syncEngine2.getSnapshot())._unsafeUnwrap();
+      expect((snapshot2.prefix as Buffer).toString('utf8')).toEqual('00306622');
+
+      const rpcClient = new MockRpcClient(engine2, syncEngine2);
+      await syncEngine1.performSync(snapshot2, rpcClient as unknown as HubRpcClient);
+      expect(rpcClient.getAllSyncIdsByPrefixCalls.length).toEqual(1);
+      expect(rpcClient.getAllSyncIdsByPrefixCalls[0].prefix.toString('utf8')).toEqual('');
+      expect(rpcClient.getAllMessagesBySyncIdsCalls.length).toEqual(1);
+      expect(rpcClient.getAllMessagesBySyncIdsCalls[0].syncIds.length).toEqual(4);
+    } finally {
+      Date.now = nowOrig;
+    }
+  });
+});
+
+class MockRpcClient {
+  engine: Engine;
+  syncEngine: SyncEngine;
+
+  getSyncMetadataByPrefixCalls: Array<any> = [];
+  getAllSyncIdsByPrefixCalls: Array<any> = [];
+  getAllMessagesBySyncIdsCalls: Array<any> = [];
+
+  constructor(engine: Engine, syncEngine: SyncEngine) {
+    this.engine = engine;
+    this.syncEngine = syncEngine;
+  }
+
+  async getSyncMetadataByPrefix(
+    request: protobufs.TrieNodePrefix
+  ): Promise<HubResult<protobufs.TrieNodeMetadataResponse>> {
+    this.getSyncMetadataByPrefixCalls.push(request);
+    const toTrieNodeMetadataResponse = (metadata?: NodeMetadata): protobufs.TrieNodeMetadataResponse => {
+      const childrenTrie = [];
+
+      if (!metadata) {
+        return protobufs.TrieNodeMetadataResponse.create({});
+      }
+
+      if (metadata.children) {
+        for (const [, child] of metadata.children) {
+          childrenTrie.push(
+            protobufs.TrieNodeMetadataResponse.create({
+              prefix: child.prefix,
+              numMessages: child.numMessages,
+              hash: child.hash,
+              children: [],
+            })
+          );
+        }
+      }
+
+      const metadataResponse = protobufs.TrieNodeMetadataResponse.create({
+        prefix: metadata.prefix,
+        numMessages: metadata.numMessages,
+        hash: metadata.hash,
+        children: childrenTrie,
+      });
+
+      return metadataResponse;
+    };
+
+    const metadata = await this.syncEngine.getTrieNodeMetadata(request.prefix);
+    return ok(toTrieNodeMetadataResponse(metadata));
+  }
+
+  async getAllSyncIdsByPrefix(request: protobufs.TrieNodePrefix): Promise<HubResult<protobufs.SyncIds>> {
+    this.getAllSyncIdsByPrefixCalls.push(request);
+    return ok(
+      protobufs.SyncIds.create({
+        syncIds: await this.syncEngine.getAllSyncIdsByPrefix(request.prefix),
+      })
+    );
+  }
+
+  async getAllMessagesBySyncIds(request: protobufs.SyncIds): Promise<HubResult<protobufs.MessagesResponse>> {
+    this.getAllMessagesBySyncIdsCalls.push(request);
+    const messagesResult = await this.engine.getAllMessagesBySyncIds(request.syncIds);
+    return messagesResult.map((messages) => {
+      return protobufs.MessagesResponse.create({ messages: messages ?? [] });
+    });
+  }
+}

--- a/apps/hubble/src/network/sync/trieNode.ts
+++ b/apps/hubble/src/network/sync/trieNode.ts
@@ -409,6 +409,7 @@ class TrieNode {
     trieNode._hash = dbtrieNode.hash;
 
     for (let i = 0; i < dbtrieNode.childChars.length; i++) {
+      // eslint-disable-next-line security/detect-object-injection
       trieNode._children.set(dbtrieNode.childChars[i] as number, new SerializedTrieNode());
     }
 


### PR DESCRIPTION
Addresses some of the issues in #536. Cherry-picked test from @kcchu 

## Motivation

When syncing, use the same prefix as the remote snapshot to make sure we don't have any time differences.

## Change Summary

- `performSync` and `shouldSync` now use the same prefix as the remote snapshot's to make sure there are no time discrepencies
- Cherry pick tests from @kcchu to check num of calls to fetch messages.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
