### PR TITLE
feat: Backpressure for merging

### DIFF
--- a/apps/hubble/src/storage/stores/sequentialMergeStore.ts
+++ b/apps/hubble/src/storage/stores/sequentialMergeStore.ts
@@ -4,7 +4,8 @@ import { ResultAsync, err, ok } from 'neverthrow';
 import { TypedEmitter } from 'tiny-typed-emitter';
 
 const MIN_NONCE = 1;
-const MERGE_TIMEOUT = 10 * 1000; // 10 seconds
+export const MERGE_TIMEOUT = 10 * 1000; // 10 seconds
+export const MAX_QUEUE_SIZE = 1000;
 
 export type MergeProcessingEvents = {
   processed: (messageId: string, result?: HubResult<void>) => void;
@@ -28,6 +29,10 @@ abstract class SequentialMergeStore extends TypedEmitter<MergeProcessingEvents> 
     this._mergeIdsStore = new Map();
     this._mergeIsProcessing = false;
     this.setMaxListeners(1_000);
+  }
+
+  public queueSize(): number {
+    return this._mergeIdsQueue.length;
   }
 
   /**


### PR DESCRIPTION
## Motivation

Block the `merge` call for a while if the merge queue is full. This will block any caller (rpc, sync, gossip) for up to 10s if the merge queue is full. 

This PR demonstrates it only for castStore, if we decided to do this, we'll have to do this for all stores.

## Change Summary

- Add sleepWhile() if the queue is full. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
