### PR TITLE
fix: e2e tests should validate a network of 10 nodes

### DIFF
--- a/apps/hubble/src/test/e2e/gossipNetwork.test.ts
+++ b/apps/hubble/src/test/e2e/gossipNetwork.test.ts
@@ -4,8 +4,7 @@ import { NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
 import { sleep } from '~/utils/crypto';
 import { NetworkFactories } from '../../network/utils/factories';
 
-// TODO: fix, why do we fail at anything above 6?
-const NUM_NODES = 6;
+const NUM_NODES = 10;
 const PROPAGATION_DELAY = 3 * 1000; // between 2 and 3 full heartbeat ticks
 
 const TEST_TIMEOUT_LONG = 60 * 1000;
@@ -37,8 +36,12 @@ describe('gossip network tests', () => {
     'broadcast a message via gossip to other nodes',
     async () => {
       // Connect the first node to every other node by dialing them manually
-      const connectResults = await Promise.all(nodes.slice(1).map((n) => n.connect(nodes[0] as GossipNode)));
-      connectResults.forEach((r) => expect(r?.isOk()).toBeTruthy());
+      for (const n of nodes.slice(1)) {
+        // sleep to stay under the rate limit of 5 connections per second
+        await sleep(200);
+        const result = await n.connect(nodes[0] as GossipNode);
+        expect(result.isOk()).toBeTruthy();
+      }
 
       // Subscribe each node to the test topic
       nodes.forEach((n) => n.gossip?.subscribe(NETWORK_TOPIC_PRIMARY));


### PR DESCRIPTION
## Motivation

The [inbound connection limit change](https://discuss.libp2p.io/t/dialing-a-node-from-5-nodes-stopped-working-between-0-39-5-and-0-42-2/1811/3) was preventing the e2e test with 10 nodes from running successfully 

## Change Summary

See above

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
