### PR TITLE
fix: 2 bugs that cause sync to run incorrectly

### DIFF
--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -435,9 +435,24 @@ describe('MerkleTrie', () => {
       const trie = await trieWithIds([1665182332, 1665182343]);
 
       const snapshot = await trie.getSnapshot(Buffer.from('1677123'));
-      expect(snapshot.prefix).toEqual(Buffer.from('167'));
-      expect(snapshot.numMessages).toEqual(2);
-      expect(snapshot.excludedHashes.length).toEqual('167'.length);
+      expect(snapshot.prefix).toEqual(Buffer.from('16'));
+      expect(snapshot.numMessages).toEqual(0);
+      expect(snapshot.excludedHashes.length).toEqual('16'.length);
+
+      const snapshot2 = await trie.getSnapshot(Buffer.from('167'));
+      expect(snapshot2.prefix).toEqual(Buffer.from('16'));
+      expect(snapshot2.numMessages).toEqual(0);
+      expect(snapshot2.excludedHashes.length).toEqual('16'.length);
+
+      const snapshot3 = await trie.getSnapshot(Buffer.from('16'));
+      expect(snapshot3.prefix).toEqual(Buffer.from('16'));
+      expect(snapshot3.numMessages).toEqual(0);
+      expect(snapshot3.excludedHashes.length).toEqual('16'.length);
+
+      const snapshot4 = await trie.getSnapshot(Buffer.from('222'));
+      expect(snapshot4.prefix).toEqual(Buffer.from(''));
+      expect(snapshot4.numMessages).toEqual(0);
+      expect(snapshot4.excludedHashes.length).toEqual(''.length);
     });
 
     test('excluded hashes excludes the prefix char at every level', async () => {
@@ -495,6 +510,18 @@ describe('MerkleTrie', () => {
 
   test('getAllValues returns all values for child nodes', async () => {
     const trie = await trieWithIds([1665182332, 1665182343, 1665182345]);
+
+    let values = await trie.getAllValues(Buffer.from('16651823'));
+    expect(values?.length).toEqual(3);
+    values = await trie.getAllValues(Buffer.from('166518233'));
+    expect(values?.length).toEqual(1);
+  });
+
+  test('getAllValues returns all values for child nodes after unloadChildren', async () => {
+    const trie = await trieWithIds([1665182332, 1665182343, 1665182345]);
+
+    // Unload all the children of the first node
+    (await trie.getNode(new Uint8Array()))?.unloadChildren();
 
     let values = await trie.getAllValues(Buffer.from('16651823'));
     expect(values?.length).toEqual(3);

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -267,13 +267,13 @@ describe('SyncEngine', () => {
     await engine.mergeIdRegistryEvent(custodyEvent);
     await engine.mergeMessage(signerAdd);
 
-    await addMessagesWithTimestamps([30662167, 30662169, 30662172]);
+    await addMessagesWithTimestamps([30662160, 30662169, 30662172]);
     const nowOrig = Date.now;
     Date.now = () => 16409952e5 + 30662167 * 1000;
     try {
       const result = await syncEngine.getSnapshot();
       const snapshot = result._unsafeUnwrap();
-      expect(snapshot.prefix).toEqual(Buffer.from('0030662160'));
+      expect((snapshot.prefix as Buffer).toString('utf8')).toEqual('0030662160');
     } finally {
       Date.now = nowOrig;
     }

--- a/apps/hubble/src/network/sync/syncEnginePerf.test.ts
+++ b/apps/hubble/src/network/sync/syncEnginePerf.test.ts
@@ -83,7 +83,9 @@ describe('SyncEngine', () => {
       Date.now = () => 1640995200000 + 30662200 * 1000;
 
       const snapshot2 = (await syncEngine2.getSnapshot())._unsafeUnwrap();
-      expect((snapshot2.prefix as Buffer).toString('utf8')).toEqual('00306622');
+      expect((snapshot2.prefix as Buffer).toString('utf8')).toEqual('0030662');
+      // Force a non-existent prefix (the original bug #536 is fixed)
+      snapshot2.prefix = Buffer.from('00306622', 'hex');
 
       let rpcClient = new MockRpcClient(engine2, syncEngine2);
       await syncEngine1.performSync(snapshot2, rpcClient as unknown as HubRpcClient);

--- a/apps/hubble/src/network/sync/trieNode.ts
+++ b/apps/hubble/src/network/sync/trieNode.ts
@@ -239,37 +239,33 @@ class TrieNode {
     return exists;
   }
 
-  // Generates a snapshot for the current node and below until the prefix. current_index is the index of the prefix the method
+  // Generates a snapshot for the current node and below until the prefix. currentIndex is the index of the prefix the method
   // is operating on
-  public async getSnapshot(prefix: Uint8Array, db: RocksDB, current_index = 0): Promise<TrieSnapshot> {
-    const char = prefix.at(current_index) as number;
-    if (current_index === prefix.length - 1) {
-      const excludedHash = await this._excludedHash(prefix, char, db);
-      return {
-        prefix: prefix,
-        excludedHashes: [excludedHash.hash],
-        numMessages: excludedHash.items,
-      };
+  public async getSnapshot(prefix: Uint8Array, db: RocksDB, currentIndex = 0): Promise<TrieSnapshot> {
+    const excludedHashes: string[] = [];
+    let numMessages = 0;
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let currentNode: TrieNode = this; // traverse from current node
+    for (let i = currentIndex; i < prefix.length; i++) {
+      const currentPrefix = prefix.subarray(0, i);
+      const char = prefix.at(i) as number;
+      if (!currentNode._children.has(char)) {
+        return {
+          prefix: currentPrefix,
+          excludedHashes,
+          numMessages,
+        };
+      }
+      const excludedHash = await currentNode._excludedHash(currentPrefix, char, db);
+      excludedHashes.push(excludedHash.hash);
+      numMessages += excludedHash.items;
+      currentNode = await currentNode._getOrLoadChild(currentPrefix, char, db);
     }
-
-    // Check if child is present
-    let innerSnapshot: TrieSnapshot | undefined = undefined;
-    if (this._children.has(char)) {
-      innerSnapshot = await (
-        await this._getOrLoadChild(prefix.slice(0, current_index), char, db)
-      ).getSnapshot(prefix, db, current_index + 1);
-    }
-
-    const excludedHash = await this._excludedHash(prefix, char, db);
-
-    // if (current_index === TIMESTAMP_LENGTH) {
-    //   this.unloadChildren();
-    // }
-
     return {
-      prefix: innerSnapshot?.prefix || prefix.subarray(0, current_index + 1),
-      excludedHashes: [excludedHash.hash, ...(innerSnapshot?.excludedHashes || [])],
-      numMessages: excludedHash.items + (innerSnapshot?.numMessages || 0),
+      prefix,
+      excludedHashes,
+      numMessages,
     };
   }
 
@@ -335,15 +331,15 @@ class TrieNode {
     return this._children.entries();
   }
 
-  public async getAllValues(key: Uint8Array, db: RocksDB, current_index = 0): Promise<Uint8Array[]> {
+  public async getAllValues(prefix: Uint8Array, db: RocksDB): Promise<Uint8Array[]> {
     // TODO: Get this straight from the DB with an iterator
     if (this.isLeaf) {
       return this._key ? [this._key] : [];
     }
     const values: Uint8Array[] = [];
     for (const [char] of this._children) {
-      const child = await this._getOrLoadChild(key.slice(0, current_index), char, db);
-      values.push(...(await child.getAllValues(key, db, current_index + 1)));
+      const child = await this._getOrLoadChild(prefix, char, db);
+      values.push(...(await child.getAllValues(Buffer.concat([prefix, Buffer.from([char])]), db)));
 
       // if (current_index >= TIMESTAMP_LENGTH) {
       //   this.unloadChildren();


### PR DESCRIPTION
## Motivation

Fix 2 additional bugs discovered during SyncEngine benchmarking and discussed in #536

## Change Summary

  * Fix `getSnapshot` returning non-existent prefix in some cases (#536)
  * Refactor `getSnapshot` to make it more readable
  * Fix `getAllValues` not working if child nodes are not loaded
  * Add test cases for `getAllValues` case

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

