### PR TITLE
Add Sync Engine benchmark script

### DIFF
--- a/apps/hubble/src/network/sync/mock.ts
+++ b/apps/hubble/src/network/sync/mock.ts
@@ -1,0 +1,89 @@
+import { ok } from 'neverthrow';
+
+import * as protobufs from '@farcaster/protobufs';
+import { HubResult } from '@farcaster/utils';
+
+import Engine from '~/storage/engine';
+import { NodeMetadata } from './merkleTrie';
+import SyncEngine from './syncEngine';
+
+export class MockRpcClient {
+  engine: Engine;
+  syncEngine: SyncEngine;
+
+  getSyncMetadataByPrefixCalls: Array<any> = [];
+  getAllSyncIdsByPrefixCalls: Array<any> = [];
+  getAllMessagesBySyncIdsCalls: Array<any> = [];
+  getAllMessagesBySyncIdsReturns = 0;
+
+  constructor(engine: Engine, syncEngine: SyncEngine) {
+    this.engine = engine;
+    this.syncEngine = syncEngine;
+  }
+
+  async getSyncMetadataByPrefix(
+    request: protobufs.TrieNodePrefix
+  ): Promise<HubResult<protobufs.TrieNodeMetadataResponse>> {
+    this.getSyncMetadataByPrefixCalls.push(request);
+    const toTrieNodeMetadataResponse = (metadata?: NodeMetadata): protobufs.TrieNodeMetadataResponse => {
+      const childrenTrie = [];
+
+      if (!metadata) {
+        return protobufs.TrieNodeMetadataResponse.create({});
+      }
+
+      if (metadata.children) {
+        for (const [, child] of metadata.children) {
+          childrenTrie.push(
+            protobufs.TrieNodeMetadataResponse.create({
+              prefix: child.prefix,
+              numMessages: child.numMessages,
+              hash: child.hash,
+              children: [],
+            })
+          );
+        }
+      }
+
+      const metadataResponse = protobufs.TrieNodeMetadataResponse.create({
+        prefix: metadata.prefix,
+        numMessages: metadata.numMessages,
+        hash: metadata.hash,
+        children: childrenTrie,
+      });
+
+      return metadataResponse;
+    };
+
+    const metadata = await this.syncEngine.getTrieNodeMetadata(request.prefix);
+    return ok(toTrieNodeMetadataResponse(metadata));
+  }
+
+  async getAllSyncIdsByPrefix(request: protobufs.TrieNodePrefix): Promise<HubResult<protobufs.SyncIds>> {
+    this.getAllSyncIdsByPrefixCalls.push(request);
+    const syncIds = await this.syncEngine.getAllSyncIdsByPrefix(request.prefix);
+    return ok(
+      protobufs.SyncIds.create({
+        syncIds,
+      })
+    );
+  }
+
+  async getAllMessagesBySyncIds(request: protobufs.SyncIds): Promise<HubResult<protobufs.MessagesResponse>> {
+    this.getAllMessagesBySyncIdsCalls.push(request);
+    const messagesResult = await this.engine.getAllMessagesBySyncIds(request.syncIds);
+    return messagesResult.map((messages) => {
+      this.getAllMessagesBySyncIdsReturns += messages.length;
+      return protobufs.MessagesResponse.create({ messages: messages ?? [] });
+    });
+  }
+
+  stats() {
+    return {
+      getSyncMetadataByPrefixCalls: this.getSyncMetadataByPrefixCalls.length,
+      getAllSyncIdsByPrefixCalls: this.getAllSyncIdsByPrefixCalls.length,
+      getAllMessagesBySyncIdsCalls: this.getAllMessagesBySyncIdsCalls.length,
+      getAllMessagesBySyncIdsReturns: this.getAllMessagesBySyncIdsReturns,
+    };
+  }
+}

--- a/apps/hubble/src/test/bench/helpers.ts
+++ b/apps/hubble/src/test/bench/helpers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable security/detect-object-injection */
 import Chance from 'chance';
 
 import { Message } from '@farcaster/protobufs';
@@ -48,3 +49,9 @@ export const fastSyncId = (fid: number, hash: Uint8Array, timestamp: number, typ
     hash,
   } as Message);
 };
+
+export const sumRecords = (series: Record<string, number>[]): Record<string, number> =>
+  series.reduce((prev, curr) => Object.fromEntries(Object.entries(curr).map(([k, v]) => [k, (prev[k] ?? 0) + v])));
+
+export const avgRecords = (series: Record<string, number>[]): Record<string, number> =>
+  Object.fromEntries(Object.entries(sumRecords(series)).map(([k, v]) => [k, v / series.length]));

--- a/apps/hubble/src/test/bench/index.ts
+++ b/apps/hubble/src/test/bench/index.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 
 import { benchMerkleTrie } from './merkleTrie';
+import { benchSyncEngine } from './syncEngine';
 import { outputWriter, waitForPromise } from './utils';
 
 const app = new Command();
@@ -14,6 +15,8 @@ app
   .requiredOption('-b --benchmark <suite>', 'the benchmarking suite to run')
   .option('-n, --count <count>', 'size of input')
   .option('-c, --cycle <cycles>', 'run at least <cycle> times before taking measurements')
+  .option('-p, --peers-count <peers-count>', 'number of simultaneous peers to run')
+  .option('-d, --drop-rate <drop-rate>', 'drop rate from 0 to 1')
   .option('-o, --output <file>', 'path of the output file (default STDOUT)')
   .option('-s, --write-heap-snapshot', 'write V8 heap snapshot after each cycle', false)
   .showHelpAfterError();
@@ -26,8 +29,10 @@ const writer = outputWriter(opts['output'] ?? process.stdout);
 const args = {
   count: parseInt(opts['count']),
   cycle: parseInt(opts['cycle']),
+  dropRate: parseFloat(opts['dropRate']),
   writer,
   writeHeapSnapshot: opts['writeHeapSnapshot'],
+  peersCount: opts['peersCount'],
 };
 
 let promise;
@@ -35,6 +40,9 @@ let promise;
 switch (opts['benchmark'].toLowerCase()) {
   case 'merkletrie':
     promise = benchMerkleTrie(args);
+    break;
+  case 'syncengine':
+    promise = benchSyncEngine(args);
     break;
   default:
     process.stderr.write('Error: unknown benchmark suite\n');

--- a/apps/hubble/src/test/bench/syncEngine.ts
+++ b/apps/hubble/src/test/bench/syncEngine.ts
@@ -1,0 +1,287 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+/* eslint-disable security/detect-object-injection */
+import { Writable } from 'node:stream';
+
+import Chance from 'chance';
+import { ok } from 'neverthrow';
+
+import * as protobufs from '@farcaster/protobufs';
+import { FARCASTER_EPOCH, HubResult, HubRpcClient } from '@farcaster/utils';
+import { MockRpcClient } from '~/network/sync/mock';
+import SyncEngine from '~/network/sync/syncEngine';
+import { SyncId } from '~/network/sync/syncId';
+import RocksDB from '~/storage/db/rocksdb';
+import Engine from '~/storage/engine';
+import StoreEventHandler from '~/storage/stores/storeEventHandler';
+import { blake3Truncate160, sleepWhile } from '~/utils/crypto';
+import { avgRecords } from './helpers';
+import { yieldToEventLoop } from './utils';
+
+const INITIAL_MESSAGES_COUNT = 10_000;
+const FID_COUNT = 10_000;
+
+const messages: protobufs.Message[] = [];
+const peers: SyncEngine[] = [];
+
+class MockEngine {
+  eventHandler = new StoreEventHandler();
+
+  async mergeMessage(message: protobufs.Message): Promise<HubResult<void>> {
+    this.eventHandler.emit('mergeMessage', message);
+    return ok(undefined);
+  }
+
+  async getAllMessagesBySyncIds(syncIds: Uint8Array[]): Promise<HubResult<protobufs.Message[]>> {
+    return ok(
+      syncIds.map((syncId) => {
+        // The index is embeded in the last 10 bytes of the hash
+        const i = parseInt(
+          Buffer.from(syncId)
+            .subarray(syncId.length - 10)
+            .toString('utf8')
+        );
+        const m = messages[i];
+        if (!m) {
+          throw new Error(`syncid not found`);
+        }
+        return m;
+      })
+    );
+  }
+}
+
+const makeSyncEninge = async (id: number) => {
+  const db = new RocksDB(`engine.syncEngine${id}.benchmark`);
+  await db.open();
+  await db.clear();
+  const syncEngine = new SyncEngine(new MockEngine() as unknown as Engine, db);
+  (syncEngine as any)['_id'] = id;
+  return syncEngine;
+};
+
+const makeMessage = (fid: number, messageId: number, timestamp: number) => {
+  const hash = Buffer.from(blake3Truncate160(Buffer.from(messageId.toString())));
+  hash.fill(' ', 10);
+  hash.write(messageId.toString(), 10);
+  return protobufs.Message.create({
+    data: protobufs.MessageData.create({
+      type: protobufs.MessageType.MESSAGE_TYPE_CAST_ADD,
+      fid,
+      timestamp,
+      network: protobufs.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+      castAddBody: protobufs.CastAddBody.create({
+        text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pharetra dolor leo, vitae tincidunt justo scelerisque vel. Praesent ac leo at nibh rutrum aliquet. Fusce rhoncus ligula a ipsum porta, nec.',
+      }),
+    }),
+    hash,
+  });
+};
+
+const messageGenerator = function* (chance: Chance.Chance): Generator<protobufs.Message> {
+  const fids: number[] = [];
+  for (let i = 1; i <= FID_COUNT; i++) {
+    fids.push(i);
+  }
+  let ts = 1;
+  for (let i = 0; ; i++) {
+    const fid = chance.pickone(fids);
+    const msg = makeMessage(fid, i, ts);
+    ts += chance.integer({ min: 1, max: 600 });
+    yield msg;
+  }
+};
+
+let estimateEntropySkip = INITIAL_MESSAGES_COUNT;
+
+export const estimateEntropy = async () => {
+  let sum = 0;
+  for (let i = estimateEntropySkip; i < messages.length; i++) {
+    let pm = 0;
+    const syncId = new SyncId(messages[i]!);
+    for (let j = 0; j < peers.length; j++) {
+      const exists = await peers[j]?.trie.exists(syncId);
+      if (exists) {
+        pm++;
+      }
+    }
+    pm /= peers.length;
+
+    // Skip unnecessary check in next round
+    if (pm == 1 && i == estimateEntropySkip) {
+      estimateEntropySkip++;
+    }
+
+    if (pm > 0 && pm < 1) {
+      sum += -pm * Math.log2(pm) - (1 - pm) * Math.log2(1 - pm);
+    }
+  }
+  return sum;
+};
+
+/**
+ * SyncEngine simulation. It is a round-based test (not CPU bound). This test aims at measuring the
+ * performance of the sync algorithm.
+ *
+ * Methodology
+ *
+ * 1. Pre-generate 10,000 messages and populate `peersCount` SyncEngine instances.
+ * 2. For each round `1..count`:
+ *     1. Generate `round * cycle` new messages
+ *     2. Add messages to each peers with `dropRate` chance of dropping that message
+ *     3. For each SyncEngine, randomly pick another SyncEngine and perform sync.
+ *     4. Measure number of RPC requests and estimate binary entropy of the network after each
+ *        round.
+ *     5. Repeat each round `cycle` times and output average of measurements.
+ *
+ * The performance of sync is measured by binary entropy in the network. With this measure, lower
+ * entropy values indicate more uniform diffusion of events and therefore better consistency of the
+ * overall network state.
+ *
+ * $H = \sum_{m \subseteq M} - p_mlog_2p_m - (1 - p_m)log_2(1 - p_m)$
+ *
+ * @param args.count Target number of rounds.
+ * @param args.cycle Number of new messages in each round.
+ * @param args.peersCount Number of peers to simulate.
+ * @param args.dropRate Rate of message drop.
+ * @param args.writer Output writer
+ */
+export const benchSyncEngine = async ({
+  count,
+  cycle,
+  peersCount,
+  dropRate,
+  writer,
+}: {
+  count: number;
+  cycle: number;
+  peersCount: number;
+  dropRate: number;
+  writer: Writable;
+}) => {
+  if (isNaN(count) || count < 1) {
+    count = 100;
+  }
+  if (isNaN(cycle) || cycle < 1) {
+    cycle = 1;
+  }
+  if (isNaN(peersCount) || peersCount < 2) {
+    peersCount = 2;
+  }
+  if (isNaN(dropRate) || dropRate < 0 || dropRate > 1) {
+    dropRate = 0.5;
+  }
+
+  // Initialization
+
+  const chance = new Chance(1); // use constant seed for repeatable data
+  const g = messageGenerator(chance);
+
+  for (let i = 0; i < INITIAL_MESSAGES_COUNT; i++) {
+    messages.push(g.next().value);
+  }
+
+  for (let i = 0; i < peersCount; i++) {
+    const syncEngine = await makeSyncEninge(i);
+    await syncEngine.initialize();
+    await Promise.all(messages.map((m) => syncEngine.addMessage(m)));
+
+    peers.push(syncEngine);
+  }
+
+  await yieldToEventLoop();
+
+  // Stub the timestamp
+  global.Date.now = () =>
+    (messages[messages.length - 1]!.data!.timestamp + chance.integer({ min: 1, max: 60 })) * 1000 + FARCASTER_EPOCH;
+
+  writer.write([0, '', '', '', '', '']);
+
+  try {
+    // Rounds
+    const cycleStats = new Array(cycle).fill({});
+    for (let round = 1; round <= count; round++) {
+      process.stderr.write(`Round #${round}\n`);
+      // Deliver `round * cycle` messages
+      const roundSize = round * cycle;
+      for (let c = 0; c < cycle; c++) {
+        let realDelivered = 0;
+        for (let i = 0; i < roundSize; i++) {
+          const msg = g.next().value;
+          messages.push(msg);
+          let delivered = 0;
+          peers.forEach((peer) => {
+            if (chance.bool({ likelihood: (1 - dropRate) * 100 })) {
+              peer.addMessage(msg);
+              delivered++;
+            }
+          });
+          // Deliver to at least one peer
+          if (delivered === 0) {
+            const peer = chance.pickone(peers);
+            peer.addMessage(msg);
+            delivered++;
+          }
+          realDelivered += delivered;
+        }
+        await yieldToEventLoop();
+
+        // Pick a random peer to sync
+        const stats = new Array(peers.length).fill({});
+        for (let i = 0; i < peers.length; i++) {
+          const ourSyncEngine = peers[i]!;
+          let theirSyncEngine;
+          do {
+            theirSyncEngine = chance.pickone(peers);
+          } while (theirSyncEngine === ourSyncEngine);
+
+          const otherSnapshot = (await theirSyncEngine.getSnapshot())._unsafeUnwrap();
+          if ((await ourSyncEngine.shouldSync(otherSnapshot))._unsafeUnwrap()) {
+            const rpcClient = new MockRpcClient((theirSyncEngine as any).engine, theirSyncEngine);
+            await ourSyncEngine.performSync(otherSnapshot, rpcClient as unknown as HubRpcClient);
+
+            const nodeMetadata = await ourSyncEngine.getTrieNodeMetadata(new Uint8Array());
+            stats[i] = {
+              synced: 1,
+              staled: messages.length > nodeMetadata!.numMessages,
+              ...rpcClient.stats(),
+            };
+            await sleepWhile(() => ourSyncEngine.messagesQueuedForSync > 0, 1000);
+          }
+        }
+
+        const entropy = await estimateEntropy();
+        const avg = avgRecords(stats);
+
+        cycleStats[c] = {
+          dropped: (peers.length * roundSize - realDelivered) / peers.length, // Average drop per peer
+          synced: avg['synced'] ?? 0,
+          getSyncMetadataByPrefixCalls: avg['getSyncMetadataByPrefixCalls'] ?? 0,
+          getAllSyncIdsByPrefixCalls: avg['getAllSyncIdsByPrefixCalls'] ?? 0,
+          getAllMessagesBySyncIdsReturns: avg['getAllMessagesBySyncIdsReturns'] ?? 0,
+          entropy,
+        };
+      }
+
+      const avg = avgRecords(cycleStats);
+
+      writer.write([
+        round,
+        avg['dropped'] ?? 0,
+        avg['synced'] ?? 0,
+        avg['getSyncMetadataByPrefixCalls'] ?? 0,
+        avg['getAllSyncIdsByPrefixCalls'] ?? 0,
+        avg['getAllMessagesBySyncIdsReturns'] ?? 0,
+        avg['entropy'],
+      ]);
+
+      await yieldToEventLoop();
+    }
+  } finally {
+    // Clean up RocksDb
+    process.stderr.write('Cleaning up\n');
+    peers.forEach((syncEngine) => {
+      const db = (syncEngine.trie as any)._db;
+      db.destroy();
+    });
+  }
+};


### PR DESCRIPTION
## Motivation

Add Sync Engine benchmark script (#445)

## Change Summary

Add SyncEngine simulation. It is a round-based test (not CPU bound). This test aims at measuring the performance of the sync algorithm. Number of RPC are measured, which can be used to estimate the performance in a network-bounded situation.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)

## Additional Context

### Methodology

1. Pre-generate 10,000 messages and populate `peersCount` SyncEngine instances.
2. For each round `1..count`:
    1. Generate `round * cycle` new messages
    2. Add messages to each peers with `dropRate` chance of dropping that message
    3. For each SyncEngine, randomly pick another SyncEngine and perform sync.
    4. Measure number of RPC requests and estimate binary entropy of the network after each
       round.
    5. Repeat each round `cycle` times and output average of measurements.

The performance of sync is measured by binary entropy in the network. With this measure, lower
entropy values indicate more uniform diffusion of events and therefore better consistency of the
overall network state.

 $H = \sum_{m \subseteq M} - p_mlog_2p_m - (1 - p_m)log_2(1 - p_m)$

### Results

**1% message drop**

<img width="743" alt="image" src="https://user-images.githubusercontent.com/800071/218037922-dd8b0dff-a74d-4543-8d3b-df852df7976d.png">

<img width="743" alt="image" src="https://user-images.githubusercontent.com/800071/218037942-7fc9a42e-e6a9-4940-a42e-4132dbffb7b7.png">


