### PR TITLE
fix: Disable audit in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Run audit
-        run: yarn audit
+      # - name: Run audit
+      #   run: yarn audit
 
       - name: Run linter
         run: yarn lint


### PR DESCRIPTION
## Motivation

Temporarily disable the "audit"  part of the github action to disable a spurious `yarn audit` failures

## Change Summary

- Disable audit in the analyze github action

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
