### PR TITLE
fix: Remove --no-fetch-ip arg

### DIFF
--- a/apps/hubble/.config/hub.config.ts
+++ b/apps/hubble/.config/hub.config.ts
@@ -24,8 +24,6 @@ export const Config = {
   ip: '127.0.0.1',
   /** The IP address that libp2p should announce to peers */
   announceIp: '',
-  /** Fetch the IP address from an external service? */
-  fetchIp: false,
   /** The TCP port libp2p should listen on. */
   gossipPort: DEFAULT_GOSSIP_PORT,
   /** The RPC port to use. */

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -32,8 +32,10 @@ app
   .option('-b, --bootstrap <peer-multiaddrs...>', 'A list of peer multiaddrs to bootstrap libp2p')
   .option('-a, --allowed-peers <peerIds...>', 'An allow-list of peer ids permitted to connect to the hub')
   .option('--ip <ip-address>', 'The IP address libp2p should listen on. (default: "127.0.0.1")')
-  .option('--announce-ip <ip-address>', 'The IP address libp2p should announce to other peers')
-  .option('--no-fetch-ip', 'Do not fetch the IP address from an external service (default: false)')
+  .option(
+    '--announce-ip <ip-address>',
+    'The IP address libp2p should announce to other peers. If not provided, the IP address will be fetched from an external service'
+  )
   .option('-g, --gossip-port <port>', 'The tcp port libp2p should gossip over. (default: 13111)')
   .option('-r, --rpc-port <port>', 'The tcp port that the rpc server should listen on.  (default: 13112)')
   .option('--db-name <name>', 'The name of the RocksDB instance')
@@ -88,7 +90,6 @@ app
       peerId,
       ipMultiAddr: ipMultiAddrResult.value,
       announceIp: cliOptions.announceIp ?? hubConfig.announceIp,
-      fetchIp: cliOptions.fetchIp ?? hubConfig.fetchIp,
       gossipPort: hubAddressInfo.value.port,
       network: cliOptions.network ?? hubConfig.network,
       ethRpcUrl: cliOptions.ethRpcUrl ?? hubConfig.ethRpcUrl,

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -77,11 +77,8 @@ export interface HubOptions {
   /** IP address string in MultiAddr format to bind to */
   ipMultiAddr?: string;
 
-  /** External IP address to announce to peers */
+  /** External IP address to announce to peers. If not provided, it'll fetch the IP from an external service */
   announceIp?: string;
-
-  /** Fetch IP from external service if announceIp is not provided? */
-  fetchIp?: boolean;
 
   /** Port for libp2p to listen for gossip */
   gossipPort?: number;
@@ -202,10 +199,10 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
   /* Start the GossipNode and RPC server  */
   async start() {
     // See if we have to fetch the IP address
-    if (!this.options.announceIp && this.options.fetchIp) {
+    if (!this.options.announceIp || this.options.announceIp.trim().length === 0) {
       const ipResult = await getPublicIp();
       if (ipResult.isErr()) {
-        log.error('failed to fetch public IP address', { error: ipResult.error });
+        log.error(`failed to fetch public IP address, using ${this.options.ipMultiAddr}`, { error: ipResult.error });
       } else {
         this.options.announceIp = ipResult.value;
       }


### PR DESCRIPTION
## Motivation

Remove the `--no-fetch-ip` arg, and infer it if no `--announce-ip` is provided

## Change Summary

- Remove `--no-fetch-ip`, it will be implied based on `--announce-ip`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
