### PR TITLE
fix: Occasional crash in UpdateNameRegistryEventExpiryJob

### DIFF
--- a/apps/hubble/src/storage/jobs/updateNameRegistryEventExpiryJob.ts
+++ b/apps/hubble/src/storage/jobs/updateNameRegistryEventExpiryJob.ts
@@ -10,7 +10,7 @@ import {
   validations,
 } from '@farcaster/utils';
 import { blake3 } from '@noble/hashes/blake3';
-import { err, ok, ResultAsync } from 'neverthrow';
+import { err, ok, Result, ResultAsync } from 'neverthrow';
 import AbstractRocksDB from 'rocksdb';
 import { TypedEmitter } from 'tiny-typed-emitter';
 import { EthEventsProvider } from '~/eth/ethEventsProvider';
@@ -213,10 +213,17 @@ export class UpdateNameRegistryEventExpiryJobQueue extends TypedEmitter<JobQueue
         } else if (!key && !value) {
           resolve(err(new HubError('not_found', 'record not found')));
         } else {
-          const payload = protobufs.UpdateNameRegistryEventExpiryJobPayload.decode(Uint8Array.from(value as Buffer));
+          const payload = Result.fromThrowable(
+            () => protobufs.UpdateNameRegistryEventExpiryJobPayload.decode(Uint8Array.from(value as Buffer)),
+            (err) =>
+              new HubError('bad_request.parse_failure', {
+                cause: err as Error,
+                message: `Failed to parse UpdateNameRegistryEventExpiryJobPayload`,
+              })
+          )();
           // Delete job from rocksdb to prevent it from being done multiple times
           await this._db.del(key as Buffer);
-          resolve(ok(payload));
+          resolve(payload);
         }
       });
     });


### PR DESCRIPTION
## Motivation

There's an occasional crash in `UpdateNameRegistryEventExpiryJob`. I'm not 100% sure what's casusing it, but I decided to wrap it in a HubError and log it so we can debug more. 

```
[08:23:56.713] FATAL (5032): index out of range: 4 + 52941 > 26
    err: {
      "type": "RangeError",
      "message": "index out of range: 4 + 52941 > 26",
      "stack":
          RangeError: index out of range: 4 + 52941 > 26
              at indexOutOfRange (file:///home/adityapk/github/farcaster/hub/packages/protobufs/dist/index.mjs:1847:14)
              at Reader.read_bytes [as bytes] (file:///home/adityapk/github/farcaster/hub/packages/protobufs/dist/index.mjs:1984:15)
              at Object.decode (file:///home/adityapk/github/farcaster/hub/packages/protobufs/dist/index.mjs:5686:34)
              at <anonymous> (/home/adityapk/github/farcaster/hub/apps/hubble/src/storage/jobs/updateNameRegistryEventExpiryJob.ts:216:77)
              at <anonymous> (/home/adityapk/github/farcaster/hub/node_modules/abstract-leveldown/abstract-iterator.js:42:5)
              at process.processTicksAndRejections (node:internal/process/task_queues:83:21)
    }
error Command failed with exit code 1.
```

cc: @pfletcherhill 

## Change Summary

- Catch and wrap the error in a `HubError`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
