### PR TITLE
feat: Use cron jobs to schedule peer syncs

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -24,7 +24,6 @@ import { publicAddressesFirst } from '@libp2p/utils/address-sort';
 import { Multiaddr, multiaddr } from '@multiformats/multiaddr';
 import { isIP } from 'net';
 import { Result, ResultAsync, err, ok } from 'neverthrow';
-import { TypedEmitter } from 'tiny-typed-emitter';
 import { EthEventsProvider, GoerliEthConstants } from '~/eth/ethEventsProvider';
 import { GossipNode } from '~/network/p2p/gossipNode';
 import { NETWORK_TOPIC_CONTACT, NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
@@ -117,19 +116,11 @@ const randomDbName = () => {
   return `rocksdb.tmp.${(new Date().getUTCDate() * Math.random()).toString(36).substring(2)}`;
 };
 
-interface HubEvents {
-  /** Emit an event when diff starts */
-  syncStart: () => void;
-
-  /** Emit an event when diff sync completes */
-  syncComplete: (success: boolean) => void;
-}
-
 const log = logger.child({
   component: 'Hub',
 });
 
-export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
+export class Hub implements HubInterface {
   private options: HubOptions;
   private gossipNode: GossipNode;
   private rpcServer: Server;
@@ -146,10 +137,7 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
   engine: Engine;
   ethRegistryProvider: EthEventsProvider;
 
-  private currentHubRpcClients: Map<string, HubRpcClient> = new Map();
-
   constructor(options: HubOptions) {
-    super();
     this.options = options;
     this.rocksDB = new RocksDB(options.rocksDBName ? options.rocksDBName : randomDbName());
     this.gossipNode = new GossipNode();
@@ -264,6 +252,7 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
     this.revokeSignerJobScheduler.stop();
     this.pruneMessagesJobScheduler.stop();
 
+    await this.syncEngine.stop();
     await this.ethRegistryProvider.stop();
     await this.rpcServer.stop();
     await this.gossipNode.stop();
@@ -300,7 +289,7 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
       const message = gossipMessage.message;
 
       // Get the RPC Client to use to merge this message
-      const rpcClient = this.currentHubRpcClients.get(peerId.toString());
+      const rpcClient = this.syncEngine.getRpcClientForPeerId(peerId.toString());
       if (rpcClient) {
         return this.syncEngine.mergeMessages([message], rpcClient).then((result) => result[0] as HubResult<void>);
       } else {
@@ -354,53 +343,14 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
 
     // Check if we already have this client
     if (rpcClient) {
-      if (this.currentHubRpcClients.has(peerId.toString())) {
+      if (this.syncEngine.getRpcClientForPeerId(peerId.toString())) {
         log.info('Already have this client, skipping sync');
         return;
       } else {
-        this.currentHubRpcClients.set(peerId.toString(), rpcClient);
-        await this.diffSyncIfRequired(message, rpcClient);
+        this.syncEngine.addRpcClientForPeerId(peerId.toString(), rpcClient);
+        await this.syncEngine.diffSyncIfRequired(peerId.toString());
       }
     }
-  }
-
-  private async diffSyncIfRequired(message: ContactInfoContent, rpcClient: HubRpcClient) {
-    this.emit('syncStart');
-    if (!rpcClient) {
-      log.warn(`No RPC client for peer, skipping sync`);
-      this.emit('syncComplete', false);
-      return;
-    }
-
-    // First, get the latest state from the peer
-    const peerStateResult = await rpcClient.getSyncSnapshotByPrefix(
-      protobufs.TrieNodePrefix.create({ prefix: new Uint8Array() })
-    );
-    if (peerStateResult.isErr()) {
-      log.warn(`Failed to get peer state, skipping sync`);
-      this.emit('syncComplete', false);
-      return;
-    }
-
-    const peerState = peerStateResult.value;
-    const shouldSync = await this.syncEngine.shouldSync(peerState);
-    if (shouldSync.isErr()) {
-      log.warn(`Failed to get shouldSync`);
-      this.emit('syncComplete', false);
-      return;
-    }
-
-    if (shouldSync.value === true) {
-      log.info(`Syncing with peer`);
-      await this.syncEngine.performSync(peerState, rpcClient);
-    } else {
-      log.info(`No need to sync`);
-      this.emit('syncComplete', false);
-      return;
-    }
-
-    this.emit('syncComplete', false);
-    return;
   }
 
   private async getRPCClientForPeer(peerId: PeerId, peer: ContactInfoContent): Promise<HubRpcClient | undefined> {
@@ -517,7 +467,7 @@ export class Hub extends TypedEmitter<HubEvents> implements HubInterface {
 
     this.gossipNode.on('peerDisconnect', async (connection) => {
       // Remove this peer's connection
-      this.currentHubRpcClients.delete(connection.remotePeer.toString());
+      this.syncEngine.removeRpcClientForPeerId(connection.remotePeer.toString());
     });
   }
 

--- a/apps/hubble/src/network/p2p/gossipNode.test.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.test.ts
@@ -11,14 +11,6 @@ import SyncEngine from '../sync/syncEngine';
 const TEST_TIMEOUT_SHORT = 10 * 1000;
 
 describe('GossipNode', () => {
-  test('start fails with invalid bootstrap addresses', async () => {
-    const node = new GossipNode();
-    const error = (await node.start([multiaddr()]))._unsafeUnwrapErr();
-    expect(error.errCode).toEqual('unavailable');
-    expect(error.message).toContain('could not connect to any bootstrap nodes');
-    await node.stop();
-  });
-
   test('start fails if IpMultiAddr has port or transport addrs', async () => {
     const node = new GossipNode();
     const options = { ipMultiAddr: '/ip4/127.0.0.1/tcp/8080' };
@@ -129,7 +121,8 @@ describe('GossipNode', () => {
         },
       } as unknown as GossipNode;
 
-      server = new Server(hub, engine, new SyncEngine(engine, db), mockGossipNode);
+      const syncEngine = new SyncEngine(engine, db);
+      server = new Server(hub, engine, syncEngine, mockGossipNode);
       const port = await server.start();
       client = getHubRpcClient(`127.0.0.1:${port}`);
 
@@ -149,6 +142,7 @@ describe('GossipNode', () => {
 
       client.$.close();
       await server.stop();
+      await syncEngine.stop();
     });
   });
 });

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -428,7 +428,7 @@ describe('MerkleTrie', () => {
       const snapshot = await trie.getSnapshot(Buffer.from('1665182343'));
       expect(snapshot.prefix).toEqual(Buffer.from('1665182343'));
       expect(snapshot.numMessages).toEqual(1);
-      expect(snapshot.excludedHashes.length).toEqual('1665182343'.length);
+      expect(snapshot.excludedHashes.length).toEqual('1665182343'.length + 1);
     });
 
     test('returns early when prefix is only partially present', async () => {
@@ -436,23 +436,23 @@ describe('MerkleTrie', () => {
 
       const snapshot = await trie.getSnapshot(Buffer.from('1677123'));
       expect(snapshot.prefix).toEqual(Buffer.from('16'));
-      expect(snapshot.numMessages).toEqual(0);
-      expect(snapshot.excludedHashes.length).toEqual('16'.length);
+      expect(snapshot.numMessages).toEqual(2);
+      expect(snapshot.excludedHashes.length).toEqual('16'.length + 1);
 
       const snapshot2 = await trie.getSnapshot(Buffer.from('167'));
       expect(snapshot2.prefix).toEqual(Buffer.from('16'));
-      expect(snapshot2.numMessages).toEqual(0);
-      expect(snapshot2.excludedHashes.length).toEqual('16'.length);
+      expect(snapshot2.numMessages).toEqual(2);
+      expect(snapshot2.excludedHashes.length).toEqual('16'.length + 1);
 
       const snapshot3 = await trie.getSnapshot(Buffer.from('16'));
       expect(snapshot3.prefix).toEqual(Buffer.from('16'));
       expect(snapshot3.numMessages).toEqual(0);
-      expect(snapshot3.excludedHashes.length).toEqual('16'.length);
+      expect(snapshot3.excludedHashes.length).toEqual('16'.length + 1);
 
       const snapshot4 = await trie.getSnapshot(Buffer.from('222'));
       expect(snapshot4.prefix).toEqual(Buffer.from(''));
-      expect(snapshot4.numMessages).toEqual(0);
-      expect(snapshot4.excludedHashes.length).toEqual(''.length);
+      expect(snapshot4.numMessages).toEqual(2);
+      expect(snapshot4.excludedHashes.length).toEqual(''.length + 1);
     });
 
     test('excluded hashes excludes the prefix char at every level', async () => {
@@ -467,6 +467,7 @@ describe('MerkleTrie', () => {
           .update(Buffer.from(node?.children?.get(Buffer.from('4')[0] as number)?.hash || '', 'hex'))
           .digest()
       ).toString('hex');
+      let leafHash = (await trie.getTrieNodeMetadata(Buffer.from('1665182351')))?.hash;
       expect(snapshot.excludedHashes).toEqual([
         EMPTY_HASH, // 1, these are empty because there are no other children at this level
         EMPTY_HASH, // 6
@@ -478,6 +479,7 @@ describe('MerkleTrie', () => {
         EMPTY_HASH, // 3
         expectedHash, // 5 (hash of the 3 and 4 child node hashes)
         EMPTY_HASH, // 1
+        leafHash,
       ]);
 
       snapshot = await trie.getSnapshot(Buffer.from('1665182343'));
@@ -493,6 +495,7 @@ describe('MerkleTrie', () => {
           .update(Buffer.from(node?.children?.get(Buffer.from('5')[0] as number)?.hash || '', 'hex'))
           .digest()
       ).toString('hex');
+      leafHash = (await trie.getTrieNodeMetadata(Buffer.from('1665182343')))?.hash;
       expect(snapshot.excludedHashes).toEqual([
         EMPTY_HASH, // 1
         EMPTY_HASH, // 6
@@ -504,6 +507,7 @@ describe('MerkleTrie', () => {
         EMPTY_HASH, // 3
         expectedPenultimateHash, // 4 (hash of the 3 and 5 child node hashes)
         expectedLastHash, // 3 (hash of the 5 child node hash)
+        leafHash,
       ]);
     });
   });

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -95,6 +95,7 @@ describe('Multi peer sync engine', () => {
     // Cleanup
     clientForServer1.$.close();
     await server1.stop();
+    await syncEngine1.stop();
   });
 
   test('toBytes test', async () => {
@@ -124,6 +125,8 @@ describe('Multi peer sync engine', () => {
     await reinitSyncEngine.initialize();
 
     expect(await reinitSyncEngine.trie.rootHash()).toEqual(await syncEngine1.trie.rootHash());
+
+    await reinitSyncEngine.stop();
   });
 
   test(
@@ -179,6 +182,8 @@ describe('Multi peer sync engine', () => {
 
       // Make sure root hash matches
       expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
+
+      await syncEngine2.stop();
     },
     TEST_TIMEOUT_LONG
   );

--- a/apps/hubble/src/network/sync/periodSyncJob.ts
+++ b/apps/hubble/src/network/sync/periodSyncJob.ts
@@ -1,0 +1,43 @@
+import cron from 'node-cron';
+import { logger } from '~/utils/logger';
+import SyncEngine from './syncEngine';
+
+const log = logger.child({
+  component: 'PeriodSyncJob',
+});
+
+type SchedulerStatus = 'started' | 'stopped';
+
+const DEFAULT_PERIODIC_JOB_CRON = '* */2 * * * *'; // Every 2 minutes
+
+export class PeriodicSyncJobScheduler {
+  private _syncEngine: SyncEngine;
+  private _cronTask?: cron.ScheduledTask;
+
+  constructor(_syncEngine: SyncEngine) {
+    this._syncEngine = _syncEngine;
+  }
+
+  start(cronSchedule?: string) {
+    this._cronTask = cron.schedule(cronSchedule ?? DEFAULT_PERIODIC_JOB_CRON, () => {
+      return this.doJobs();
+    });
+  }
+
+  stop() {
+    if (this._cronTask) {
+      return this._cronTask.stop();
+    }
+  }
+
+  status(): SchedulerStatus {
+    return this._cronTask ? 'started' : 'stopped';
+  }
+
+  async doJobs() {
+    log.info('starting doJobs');
+
+    // Do a diff sync
+    await this._syncEngine.diffSyncIfRequired();
+  }
+}

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -45,6 +45,10 @@ describe('SyncEngine', () => {
     syncEngine = new SyncEngine(engine, testDb);
   });
 
+  afterEach(async () => {
+    await syncEngine.stop();
+  });
+
   const addMessagesWithTimestamps = async (timestamps: number[]) => {
     const results = await Promise.all(
       timestamps.map(async (t) => {
@@ -188,6 +192,8 @@ describe('SyncEngine', () => {
 
     // Roothashes must match
     expect(await syncEngine2.trie.rootHash()).toEqual(await syncEngine.trie.rootHash());
+
+    await syncEngine2.stop();
   });
 
   test('snapshotTimestampPrefix trims the seconds', async () => {
@@ -267,6 +273,8 @@ describe('SyncEngine', () => {
     expect(await syncEngine2.trie.exists(new SyncId(messages[0] as protobufs.Message))).toBeTruthy();
     expect(await syncEngine2.trie.exists(new SyncId(messages[1] as protobufs.Message))).toBeTruthy();
     expect(await syncEngine2.trie.exists(new SyncId(messages[2] as protobufs.Message))).toBeTruthy();
+
+    await syncEngine2.stop();
   });
 
   test('getSnapshot should use a prefix of 10-seconds resolution timestamp', async () => {

--- a/apps/hubble/src/network/sync/syncEnginePerf.test.ts
+++ b/apps/hubble/src/network/sync/syncEnginePerf.test.ts
@@ -55,14 +55,17 @@ describe('SyncEngine', () => {
 
   test('should not fetch all messages when snapshot contains non-existent prefix', async () => {
     const nowOrig = Date.now;
+    let syncEngine1;
+    let syncEngine2;
+
     try {
       testDb.clear();
       testDb2.clear();
 
       const engine1 = new Engine(testDb, FarcasterNetwork.FARCASTER_NETWORK_TESTNET);
-      const syncEngine1 = new SyncEngine(engine1, testDb);
+      syncEngine1 = new SyncEngine(engine1, testDb);
       const engine2 = new Engine(testDb2, FarcasterNetwork.FARCASTER_NETWORK_TESTNET);
-      const syncEngine2 = new SyncEngine(engine2, testDb2);
+      syncEngine2 = new SyncEngine(engine2, testDb2);
 
       await engine1.mergeIdRegistryEvent(custodyEvent);
       await engine1.mergeMessage(signerAdd);
@@ -108,6 +111,8 @@ describe('SyncEngine', () => {
       expect(rpcClient.getAllMessagesBySyncIdsCalls.length).toEqual(0);
     } finally {
       Date.now = nowOrig;
+      await syncEngine1?.stop();
+      await syncEngine2?.stop();
     }
   });
 });

--- a/apps/hubble/src/network/sync/trieNode.ts
+++ b/apps/hubble/src/network/sync/trieNode.ts
@@ -239,6 +239,11 @@ class TrieNode {
     for (let i = currentIndex; i < prefix.length; i++) {
       const currentPrefix = prefix.subarray(0, i);
       const char = prefix.at(i) as number;
+
+      const excludedHash = await currentNode._excludedHash(currentPrefix, char, db);
+      excludedHashes.push(excludedHash.hash);
+      numMessages += excludedHash.items;
+
       if (!currentNode._children.has(char)) {
         return {
           prefix: currentPrefix,
@@ -246,11 +251,11 @@ class TrieNode {
           numMessages,
         };
       }
-      const excludedHash = await currentNode._excludedHash(currentPrefix, char, db);
-      excludedHashes.push(excludedHash.hash);
-      numMessages += excludedHash.items;
       currentNode = await currentNode._getOrLoadChild(currentPrefix, char, db);
     }
+
+    excludedHashes.push(Buffer.from(currentNode.hash).toString('hex'));
+
     return {
       prefix,
       excludedHashes,


### PR DESCRIPTION
## Motivation

Use a node-cron job to schedule periodic syncs with peers

## Change Summary

- Use node-cron to schedule jobs for sync
- Make sure to use the leaf node's excludedHash as well
- Minor test fixes

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
