### PR TITLE
feat: add mentionsPositions to CastAddBody

### DIFF
--- a/.changeset/eight-bats-leave.md
+++ b/.changeset/eight-bats-leave.md
@@ -1,0 +1,6 @@
+---
+'@farcaster/protobufs': patch
+'@farcaster/utils': patch
+---
+
+feat: add mentionsPositions to CastAddBody

--- a/packages/js/src/builders.test.ts
+++ b/packages/js/src/builders.test.ts
@@ -20,6 +20,7 @@ describe('makeCastAddData', () => {
     const body: types.CastAddBody = {
       text: faker.random.alphaNumeric(200),
       mentions: [Factories.Fid.build(), Factories.Fid.build()],
+      mentionsPositions: [10, 20],
       parent: { fid: Factories.Fid.build(), hash: Factories.MessageHashHex.build() },
       embeds: [faker.internet.url()],
     };
@@ -47,6 +48,7 @@ describe('makeCastAdd', () => {
     const body: types.CastAddBody = {
       text: faker.random.alphaNumeric(200),
       mentions: [Factories.Fid.build(), Factories.Fid.build()],
+      mentionsPositions: [10, 20],
       parent: { fid: Factories.Fid.build(), hash: Factories.MessageHashHex.build() },
       embeds: [faker.internet.url()],
     };

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -77,6 +77,7 @@ export type MessageBody =
 export type CastAddBody = {
   embeds?: string[] | undefined;
   mentions?: number[] | undefined;
+  mentionsPositions?: number[] | undefined;
   parent?: CastId | undefined;
   text: string;
 };

--- a/packages/js/src/utils.ts
+++ b/packages/js/src/utils.ts
@@ -218,6 +218,7 @@ export const deserializeCastAddBody = (protobuf: protobufs.CastAddBody): HubResu
     text: protobuf.text,
     embeds: protobuf.embeds,
     mentions: protobuf.mentions,
+    mentionsPositions: protobuf.mentionsPositions,
     parent: parent.value,
   });
 };
@@ -232,6 +233,7 @@ export const serializeCastAddBody = (body: types.CastAddBody): HubResult<protobu
     protobufs.CastAddBody.create({
       embeds: body.embeds ?? [],
       mentions: body.mentions ?? [],
+      mentionsPositions: body.mentionsPositions ?? [],
       parentCastId: parent.value,
       text: body.text,
     })

--- a/packages/protobufs/src/schemas/message.proto
+++ b/packages/protobufs/src/schemas/message.proto
@@ -61,6 +61,7 @@ message CastAddBody {
     CastId parent_cast_id = 3;
   };
   string text = 4;
+  repeated uint32 mentions_positions = 5;
 }
 
 message CastRemoveBody {

--- a/packages/utils/src/factories.ts
+++ b/packages/utils/src/factories.ts
@@ -225,11 +225,13 @@ const MessageDataFactory = Factory.define<protobufs.MessageData>(() => {
 });
 
 const CastAddBodyFactory = Factory.define<protobufs.CastAddBody>(() => {
+  const text = faker.lorem.sentence(12);
   return protobufs.CastAddBody.create({
     embeds: [faker.internet.url(), faker.internet.url()],
     mentions: [FidFactory.build(), FidFactory.build(), FidFactory.build()],
+    mentionsPositions: [0, Math.floor(text.length / 2), text.length], // Hack to avoid duplicates
     parentCastId: CastIdFactory.build(),
-    text: faker.lorem.sentence(4),
+    text,
   });
 });
 

--- a/packages/utils/src/validations.test.ts
+++ b/packages/utils/src/validations.test.ts
@@ -275,6 +275,14 @@ describe('validateCastAddBody', () => {
       body = Factories.CastAddBody.build({ mentions: [Factories.Fid.build()], mentionsPositions: [1.5] });
       hubErrorMessage = 'mentionsPositions must be integers';
     });
+
+    test('with out of order mentionsPositions', () => {
+      body = Factories.CastAddBody.build({
+        mentions: [Factories.Fid.build(), Factories.Fid.build()],
+        mentionsPositions: [2, 1],
+      });
+      hubErrorMessage = 'mentionsPositions must be sorted in ascending order';
+    });
   });
 });
 

--- a/packages/utils/src/validations.test.ts
+++ b/packages/utils/src/validations.test.ts
@@ -32,6 +32,12 @@ describe('validateFid', () => {
       err(new HubError('bad_request.validation_failure', 'fid is missing'))
     );
   });
+
+  test('fails with non-integer number', () => {
+    expect(validations.validateFid(1.5)).toEqual(
+      err(new HubError('bad_request.validation_failure', 'fid must be an integer'))
+    );
+  });
 });
 
 describe('validateFname', () => {
@@ -173,8 +179,8 @@ describe('validateEd25519PublicKey', () => {
 });
 
 describe('validateCastAddBody', () => {
-  test('succeeds', async () => {
-    const body = await Factories.CastAddBody.build();
+  test('succeeds', () => {
+    const body = Factories.CastAddBody.build();
     expect(validations.validateCastAddBody(body)).toEqual(ok(body));
   });
 
@@ -182,52 +188,52 @@ describe('validateCastAddBody', () => {
     let body: protobufs.CastAddBody;
     let hubErrorMessage: string;
 
-    afterEach(async () => {
+    afterEach(() => {
       expect(validations.validateCastAddBody(body)).toEqual(
         err(new HubError('bad_request.validation_failure', hubErrorMessage))
       );
     });
 
-    test('when text is missing', async () => {
-      body = await Factories.CastAddBody.build({ text: '' });
+    test('when text is missing', () => {
+      body = Factories.CastAddBody.build({ text: '' });
       hubErrorMessage = 'text is missing';
     });
 
-    test('when text is longer than 320 characters', async () => {
-      body = await Factories.CastAddBody.build({ text: faker.random.alphaNumeric(321) });
+    test('when text is longer than 320 characters', () => {
+      body = Factories.CastAddBody.build({ text: faker.random.alphaNumeric(321) });
       hubErrorMessage = 'text > 320 chars';
     });
 
-    test('when text is longer than 320 bytes', async () => {
+    test('when text is longer than 320 bytes', () => {
       let text = '';
       for (let i = 0; i < 320; i++) {
         text = text + '🤓';
       }
-      body = await Factories.CastAddBody.build({ text });
+      body = Factories.CastAddBody.build({ text });
       hubErrorMessage = 'text > 320 chars';
     });
 
-    test('with more than 2 embeds', async () => {
-      body = await Factories.CastAddBody.build({
+    test('with more than 2 embeds', () => {
+      body = Factories.CastAddBody.build({
         embeds: [faker.internet.url(), faker.internet.url(), faker.internet.url()],
       });
       hubErrorMessage = 'embeds > 2';
     });
 
-    test('when parent fid is missing', async () => {
-      body = await Factories.CastAddBody.build({
+    test('when parent fid is missing', () => {
+      body = Factories.CastAddBody.build({
         parentCastId: Factories.CastId.build({ fid: undefined }),
       });
       hubErrorMessage = 'fid is missing';
     });
 
-    test('when parent hash is missing', async () => {
-      body = await Factories.CastAddBody.build({ parentCastId: Factories.CastId.build({ hash: undefined }) });
+    test('when parent hash is missing', () => {
+      body = Factories.CastAddBody.build({ parentCastId: Factories.CastId.build({ hash: undefined }) });
       hubErrorMessage = 'hash is missing';
     });
 
-    test('with more than 5 mentions', async () => {
-      body = await Factories.CastAddBody.build({
+    test('with more than 5 mentions', () => {
+      body = Factories.CastAddBody.build({
         mentions: [
           Factories.Fid.build(),
           Factories.Fid.build(),
@@ -238,6 +244,36 @@ describe('validateCastAddBody', () => {
         ],
       });
       hubErrorMessage = 'mentions > 5';
+    });
+
+    test('with more mentions than mentionsPositions', () => {
+      body = Factories.CastAddBody.build({
+        mentions: [Factories.Fid.build(), Factories.Fid.build()],
+        mentionsPositions: [0],
+      });
+      hubErrorMessage = 'mentions and mentionsPositions must match';
+    });
+
+    test('with repeated mentionsPositions', () => {
+      body = Factories.CastAddBody.build({
+        mentions: [Factories.Fid.build(), Factories.Fid.build()],
+        mentionsPositions: [10, 10],
+      });
+      hubErrorMessage = 'mentionsPositions must be unique';
+    });
+
+    test('with out of range mentionsPositions', () => {
+      body = Factories.CastAddBody.build({
+        text: 'a',
+        mentions: [Factories.Fid.build()],
+        mentionsPositions: [2],
+      });
+      hubErrorMessage = 'mentionsPositions must be a position in text';
+    });
+
+    test('with non-integer mentionsPositions', () => {
+      body = Factories.CastAddBody.build({ mentions: [Factories.Fid.build()], mentionsPositions: [1.5] });
+      hubErrorMessage = 'mentionsPositions must be integers';
     });
   });
 });

--- a/packages/utils/src/validations.ts
+++ b/packages/utils/src/validations.ts
@@ -280,10 +280,6 @@ export const validateCastAddBody = (body: protobufs.CastAddBody): HubResult<prot
     return err(new HubError('bad_request.validation_failure', 'mentions and mentionsPositions must match'));
   }
 
-  if (body.mentionsPositions.length > 0 && body.mentionsPositions.length !== new Set(body.mentionsPositions).size) {
-    return err(new HubError('bad_request.validation_failure', 'mentionsPositions must be unique'));
-  }
-
   for (let i = 0; i < body.mentions.length; i++) {
     // eslint-disable-next-line security/detect-object-injection
     const mention = validateFid(body.mentions[i]);
@@ -297,6 +293,18 @@ export const validateCastAddBody = (body: protobufs.CastAddBody): HubResult<prot
     }
     if (position < 0 || position > text.length) {
       return err(new HubError('bad_request.validation_failure', 'mentionsPositions must be a position in text'));
+    }
+    if (i > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const prevPosition = body.mentionsPositions[i - 1]!;
+      if (position === prevPosition) {
+        return err(new HubError('bad_request.validation_failure', 'mentionsPositions must be unique'));
+      }
+      if (position < prevPosition) {
+        return err(
+          new HubError('bad_request.validation_failure', 'mentionsPositions must be sorted in ascending order')
+        );
+      }
     }
   }
 

--- a/packages/utils/src/validations.ts
+++ b/packages/utils/src/validations.ts
@@ -51,6 +51,10 @@ export const validateFid = (fid?: number | null): HubResult<number> => {
     return err(new HubError('bad_request.validation_failure', 'fid must be positive'));
   }
 
+  if (!Number.isInteger(fid)) {
+    return err(new HubError('bad_request.validation_failure', 'fid must be an integer'));
+  }
+
   return ok(fid);
 };
 
@@ -268,9 +272,32 @@ export const validateCastAddBody = (body: protobufs.CastAddBody): HubResult<prot
     return err(new HubError('bad_request.validation_failure', 'embeds > 2'));
   }
 
-  // TODO: validate mentions are actually fids
   if (body.mentions.length > 5) {
     return err(new HubError('bad_request.validation_failure', 'mentions > 5'));
+  }
+
+  if (body.mentions.length !== body.mentionsPositions.length) {
+    return err(new HubError('bad_request.validation_failure', 'mentions and mentionsPositions must match'));
+  }
+
+  if (body.mentionsPositions.length > 0 && body.mentionsPositions.length !== new Set(body.mentionsPositions).size) {
+    return err(new HubError('bad_request.validation_failure', 'mentionsPositions must be unique'));
+  }
+
+  for (let i = 0; i < body.mentions.length; i++) {
+    // eslint-disable-next-line security/detect-object-injection
+    const mention = validateFid(body.mentions[i]);
+    if (mention.isErr()) {
+      return err(mention.error);
+    }
+    // eslint-disable-next-line security/detect-object-injection
+    const position = body.mentionsPositions[i];
+    if (typeof position !== 'number' || !Number.isInteger(position)) {
+      return err(new HubError('bad_request.validation_failure', 'mentionsPositions must be integers'));
+    }
+    if (position < 0 || position > text.length) {
+      return err(new HubError('bad_request.validation_failure', 'mentionsPositions must be a position in text'));
+    }
   }
 
   if (body.parentCastId) {


### PR DESCRIPTION
## Motivation

We can avoid including tokens (like `%0%`) in cast text by storing the positions of mentions in a separate list.

## Change Summary

* Add `mentions_positions` list to CastAddBody schema
* Validate that positions are integers, in-range of text, and the same number as mentions

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [ ] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
