### PR TITLE
fix: resolve out of range errors

### DIFF
--- a/apps/hubble/src/network/sync/periodSyncJob.ts
+++ b/apps/hubble/src/network/sync/periodSyncJob.ts
@@ -8,7 +8,7 @@ const log = logger.child({
 
 type SchedulerStatus = 'started' | 'stopped';
 
-const DEFAULT_PERIODIC_JOB_CRON = '* */2 * * * *'; // Every 2 minutes
+const DEFAULT_PERIODIC_JOB_CRON = '*/2 * * * *'; // Every 2 minutes
 
 export class PeriodicSyncJobScheduler {
   private _syncEngine: SyncEngine;

--- a/apps/hubble/src/storage/jobs/revokeSignerJob.ts
+++ b/apps/hubble/src/storage/jobs/revokeSignerJob.ts
@@ -188,7 +188,7 @@ export class RevokeSignerJobQueue {
     }
     for await (const [key, value] of iterator.value) {
       const timestamp = RevokeSignerJobQueue.jobKeyToTimestamp(key as Buffer);
-      const payload = protobufs.RevokeSignerJobPayload.decode(Uint8Array.from(value));
+      const payload = protobufs.RevokeSignerJobPayload.decode(Uint8Array.from(value as Buffer));
       if (timestamp.isOk()) {
         jobs.push([timestamp.value, payload]);
       }

--- a/apps/hubble/src/storage/jobs/updateNameRegistryEventExpiryJob.ts
+++ b/apps/hubble/src/storage/jobs/updateNameRegistryEventExpiryJob.ts
@@ -108,7 +108,7 @@ export class UpdateNameRegistryEventExpiryJobQueue extends TypedEmitter<JobQueue
   }
 
   static jobKeyPrefix(): Buffer {
-    return Buffer.from([RootPrefix.JobRevokeSigner]);
+    return Buffer.from([RootPrefix.JobUpdateNameExpiry]);
   }
 
   static jobKeyToTimestamp(key: Buffer): HubResult<number> {


### PR DESCRIPTION
## Motivation

Recently, we've had a handful of fatal errors show up. After further investigation, these seem to be caused by sloppiness on my part because both RevokeSigner jobs and UpdateNameRegistryEventExpiry jobs were using the same job key prefix. So we'd get out of range errors when a RevokeSigner worker tried to decode what was actually an UpdateNameRegistryEventExpiry payload. 

## Change Summary

* Change UpdateNameRegistryEventExpiry job prefix to unique key

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
