### PR TITLE
feat: support Renew events from the name registry contract

### DIFF
--- a/apps/hubble/src/eth/ethEventsProvider.test.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.test.ts
@@ -5,12 +5,12 @@ import { Factories, hexStringToBytes } from '@farcaster/utils';
 import { BigNumber, Contract, utils } from 'ethers';
 import { IdRegistry, NameRegistry } from '~/eth/abis';
 import { EthEventsProvider } from '~/eth/ethEventsProvider';
+import { bytesToBytes32 } from '~/eth/utils';
 import { getIdRegistryEvent } from '~/storage/db/idRegistryEvent';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import { getNameRegistryEvent } from '~/storage/db/nameRegistryEvent';
 import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
-import { bytesToBytes32 } from './utils';
 
 const db = jestRocksDB('flatbuffers.ethEventsProvider.test');
 const engine = new Engine(db, protobufs.FarcasterNetwork.FARCASTER_NETWORK_TESTNET);

--- a/apps/hubble/src/eth/ethEventsProvider.test.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.test.ts
@@ -1,7 +1,7 @@
 import { Event } from '@ethersproject/contracts';
 import { BaseProvider, Block, TransactionReceipt, TransactionResponse } from '@ethersproject/providers';
 import * as protobufs from '@farcaster/protobufs';
-import { Factories, bytesToHexString, hexStringToBytes } from '@farcaster/utils';
+import { Factories, hexStringToBytes } from '@farcaster/utils';
 import { BigNumber, Contract, utils } from 'ethers';
 import { IdRegistry, NameRegistry } from '~/eth/abis';
 import { EthEventsProvider } from '~/eth/ethEventsProvider';
@@ -10,6 +10,7 @@ import { jestRocksDB } from '~/storage/db/jestUtils';
 import { getNameRegistryEvent } from '~/storage/db/nameRegistryEvent';
 import Engine from '~/storage/engine';
 import { MockHub } from '~/test/mocks';
+import { bytesToBytes32 } from './utils';
 
 const db = jestRocksDB('flatbuffers.ethEventsProvider.test');
 const engine = new Engine(db, protobufs.FarcasterNetwork.FARCASTER_NETWORK_TESTNET);
@@ -163,7 +164,7 @@ describe('process events', () => {
       'Transfer',
       '0x000001',
       '0x000002',
-      BigNumber.from(bytesToHexString(fname)._unsafeUnwrap()),
+      bytesToBytes32(fname)._unsafeUnwrap(),
       new MockEvent(blockNumber++, '0xb00001', '0x400001', 0)
     );
     expect(rTransfer).toBeTruthy();
@@ -177,25 +178,25 @@ describe('process events', () => {
     // The event is now available
     expect((await getNameRegistryEvent(db, fname)).fname).toEqual(fname);
 
-    // // Renew the fname
-    // mockNameRegistry.emit(
-    //   'Renew',
-    //   BigNumber.from(bytesToHexString(fname)._unsafeUnwrap()),
-    //   BigNumber.from(1000),
-    //   new MockEvent(blockNumber++, '0xb00002', '0x400002', 0)
-    // );
-    // // The event is not immediately available, since it has to wait for confirmations. We should still get the Transfer event
-    // expect((await getNameRegistryEvent(db, fname)).type).toEqual(
-    //   protobufs.NameRegistryEventType.NAME_REGISTRY_EVENT_TYPE_TRANSFER
-    // );
+    // Renew the fname
+    mockNameRegistry.emit(
+      'Renew',
+      bytesToBytes32(fname)._unsafeUnwrap(),
+      BigNumber.from(Date.now() + 1000),
+      new MockEvent(blockNumber++, '0xb00002', '0x400002', 0)
+    );
+    // The event is not immediately available, since it has to wait for confirmations. We should still get the Transfer event
+    expect(await getNameRegistryEvent(db, fname)).toMatchObject({
+      type: protobufs.NameRegistryEventType.NAME_REGISTRY_EVENT_TYPE_TRANSFER,
+    });
 
-    // // Add 6 confirmations
-    // blockNumber = await addBlocks(blockNumber, 6);
+    // Add 6 confirmations
+    blockNumber = await addBlocks(blockNumber, 6);
 
-    // // The renew event is now available
-    // expect((await getNameRegistryEvent(db, fname)).fname).toEqual(fname);
-    // expect((await getNameRegistryEvent(db, fname)).type).toEqual(
-    //   protobufs.NameRegistryEventType.NAME_REGISTRY_EVENT_TYPE_RENEW
-    // );
+    // The renew event is now available
+    expect(await getNameRegistryEvent(db, fname)).toMatchObject({
+      fname,
+      type: protobufs.NameRegistryEventType.NAME_REGISTRY_EVENT_TYPE_RENEW,
+    });
   });
 });

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -53,6 +53,7 @@ export const APP_VERSION = process.env['npm_package_version'] ?? '1.0.0';
 export const APP_NICKNAME = 'Farcaster Hub';
 
 export interface HubInterface {
+  engine: Engine;
   submitMessage(message: protobufs.Message, source?: HubSubmitSource): HubAsyncResult<void>;
   submitIdRegistryEvent(event: protobufs.IdRegistryEvent, source?: HubSubmitSource): HubAsyncResult<void>;
   submitNameRegistryEvent(event: protobufs.NameRegistryEvent, source?: HubSubmitSource): HubAsyncResult<void>;

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -117,7 +117,7 @@ class UserDataStore {
 
     // When there is a NameRegistryEvent, we need to check if we need to revoke UserDataAdd messages from the
     // previous owner of the name.
-    if (event.from) {
+    if (event.type === protobufs.NameRegistryEventType.NAME_REGISTRY_EVENT_TYPE_TRANSFER && event.from) {
       // Check to see if the from address has an fid
       const idRegistryEvent = await ResultAsync.fromPromise(
         getIdRegistryEventByCustodyAddress(this._db, event.from),


### PR DESCRIPTION
## Motivation

We should ingest Renew events coming from the NameRegistry contract as well as Transfer events.

## Change Summary

* Cache renew events from the contract
* When a new renew event is ready to merge, update the relevant NameRegistryEvent with the new expiry and block info

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
