### PR TITLE
feat: Detect unclean shutdown and rebuild trie CLI option

### DIFF
--- a/apps/hubble/.config/hub.config.ts
+++ b/apps/hubble/.config/hub.config.ts
@@ -32,6 +32,8 @@ export const Config = {
   dbName: 'rocks.hub._default',
   /** Clear the RocksDB instance before starting */
   dbReset: false,
+  /** Rebuild the sync trie before starting */
+  rebuildSyncTrie: false,
   /** Farcaster network */
   network: DEFAULT_NETWORK,
 };

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -40,6 +40,7 @@ app
   .option('-r, --rpc-port <port>', 'The tcp port that the rpc server should listen on.  (default: 13112)')
   .option('--db-name <name>', 'The name of the RocksDB instance')
   .option('--db-reset', 'Clears the database before starting')
+  .option('--rebuild-sync-trie', 'Rebuilds the sync trie before starting')
   .option('-i, --id <filepath>', 'Path to the PeerId file')
   .option('-n --network <network>', 'Farcaster network ID', parseNetwork)
   .action(async (cliOptions) => {
@@ -86,6 +87,8 @@ app
       .filter((a) => a.isOk())
       .map((a) => a._unsafeUnwrap());
 
+    const rebuildSyncTrie = cliOptions.rebuildSyncTrie ?? hubConfig.rebuildSyncTrie ?? false;
+
     const options: HubOptions = {
       peerId,
       ipMultiAddr: ipMultiAddrResult.value,
@@ -99,6 +102,7 @@ app
       rpcPort: cliOptions.rpcPort ?? hubConfig.rpcPort,
       rocksDBName: cliOptions.dbName ?? hubConfig.dbName,
       resetDB: cliOptions.dbReset ?? hubConfig.dbReset,
+      rebuildSyncTrie,
     };
 
     const hub = new Hub(options);

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -89,9 +89,16 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     return this._messagesQueuedForSync;
   }
 
-  public async initialize() {
-    // Wait for the Merkle trie to be fully loaded
-    await this._trie.initialize();
+  public async initialize(rebuildSyncTrie = false) {
+    // Check if we need to rebuild sync trie
+    if (rebuildSyncTrie) {
+      log.info('Rebuilding sync trie...');
+      await this._trie.rebuild(this.engine);
+      log.info('Rebuilding sync trie complete');
+    } else {
+      // Wait for the Merkle trie to be fully loaded
+      await this._trie.initialize();
+    }
     const rootHash = await this._trie.rootHash();
 
     this.periodSyncJobScheduler.start();

--- a/apps/hubble/src/network/sync/syncId.ts
+++ b/apps/hubble/src/network/sync/syncId.ts
@@ -1,9 +1,8 @@
 import * as protobufs from '@farcaster/protobufs';
 import { makeMessagePrimaryKey, typeToSetPostfix } from '~/storage/db/message';
-import { FID_BYTES } from '~/storage/db/types';
+import { FID_BYTES, HASH_LENGTH } from '~/storage/db/types';
 
 const TIMESTAMP_LENGTH = 10; // Used to represent a decimal timestamp
-const HASH_LENGTH = 20; // Used to represent a 160-bit BLAKE3 hash
 
 /**
  * SyncIds are used to represent a Farcaster Message in the MerkleTrie and are ordered by timestamp

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -8,6 +8,16 @@ export const TRUE_VALUE = Buffer.from([1]);
 export const FID_BYTES = 4;
 
 /**
+ * The size of the hash
+ */
+export const HASH_LENGTH = 20; // Used to represent a 160-bit BLAKE3 hash
+
+/**
+ * Size of the TS_HASH which is 4 byte timestamp + 20 byte hash
+ */
+export const TSHASH_LENGTH = 4 + HASH_LENGTH;
+
+/**
  * RootPrefix indicates the purpose of the key. It is the 1st byte of every key.
  */
 export enum RootPrefix {
@@ -37,6 +47,8 @@ export enum RootPrefix {
   JobUpdateNameExpiry = 12,
   /* Index name registry events by expiry */
   NameRegistryEventsByExpiry = 13,
+  /* To check if the Hub was cleanly shutdown */
+  HubCleanShutdown = 14,
 }
 
 /**

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -4,7 +4,7 @@ import { err, ok, Result, ResultAsync } from 'neverthrow';
 import { SyncId } from '~/network/sync/syncId';
 import { getManyMessages, typeToSetPostfix } from '~/storage/db/message';
 import RocksDB from '~/storage/db/rocksdb';
-import { FID_BYTES, RootPrefix, UserPostfix } from '~/storage/db/types';
+import { FID_BYTES, RootPrefix, TSHASH_LENGTH, UserPostfix } from '~/storage/db/types';
 import AmpStore from '~/storage/stores/ampStore';
 import CastStore from '~/storage/stores/castStore';
 import ReactionStore from '~/storage/stores/reactionStore';
@@ -124,7 +124,7 @@ class Engine {
     const allUserPrefix = Buffer.from([RootPrefix.User]);
 
     for await (const [key, value] of this._db.iteratorByPrefix(allUserPrefix, { keys: true, valueAsBuffer: true })) {
-      if (key.length < 2 + FID_BYTES) {
+      if (key.length !== 1 + FID_BYTES + 1 + TSHASH_LENGTH) {
         // Not a message key, so we can skip it.
         continue;
       }


### PR DESCRIPTION
## Motivation

Detect unclean shutdown and rebuild Trie if needed

## Change Summary

- `--rebuild-sync-trie` CLI option
- Detect unclean shutdown via new RootPrefix

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
