### PR TITLE
fix: Log failed sync message that didn't merge

### DIFF
--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -289,9 +289,21 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     }
 
     log.info(
-      { messages: mergeResults.length, success: mergeResults.filter((r) => r.isOk()).length },
+      {
+        total: mergeResults.length,
+        success: mergeResults.filter((r) => r.isOk()).length,
+      },
       'Merged messages'
     );
+
+    // If there was a failed merge, log the error and move on. We'll only log one error, since they're likely all the same.
+    const failedMerge = mergeResults.find((r) => r.isErr());
+    if (failedMerge) {
+      log.warn(
+        { error: failedMerge._unsafeUnwrapErr(), errorMessage: failedMerge._unsafeUnwrapErr().message },
+        'Failed to merge message'
+      );
+    }
 
     return mergeResults;
   }


### PR DESCRIPTION
## Motivation

Write a log warn message if a sync'd message fails to merge. 

## Change Summary

- `log.warn` if a sync message fails to merge

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
