### PR TITLE
fix: Store peer contacts instead of RPC proxy objects

### DIFF
--- a/apps/hubble/src/network/sync/periodicSyncJob.ts
+++ b/apps/hubble/src/network/sync/periodicSyncJob.ts
@@ -1,9 +1,10 @@
 import cron from 'node-cron';
+import { Hub } from '~/hubble';
 import { logger } from '~/utils/logger';
 import SyncEngine from './syncEngine';
 
 const log = logger.child({
-  component: 'PeriodSyncJob',
+  component: 'PeriodicSyncJob',
 });
 
 type SchedulerStatus = 'started' | 'stopped';
@@ -11,10 +12,12 @@ type SchedulerStatus = 'started' | 'stopped';
 const DEFAULT_PERIODIC_JOB_CRON = '*/2 * * * *'; // Every 2 minutes
 
 export class PeriodicSyncJobScheduler {
+  private _hub: Hub;
   private _syncEngine: SyncEngine;
   private _cronTask?: cron.ScheduledTask;
 
-  constructor(_syncEngine: SyncEngine) {
+  constructor(_hub: Hub, _syncEngine: SyncEngine) {
+    this._hub = _hub;
     this._syncEngine = _syncEngine;
   }
 
@@ -38,6 +41,6 @@ export class PeriodicSyncJobScheduler {
     log.info('starting doJobs');
 
     // Do a diff sync
-    await this._syncEngine.diffSyncIfRequired();
+    await this._syncEngine.diffSyncIfRequired(this._hub);
   }
 }


### PR DESCRIPTION
## Motivation

Store peer contact info and get RPC clients on demand instead of storing the RPC clients themselves, since the RPC proxy client keeps an open connection and can timeout. 

## Change Summary

- Store peer contacts instead of stateful RPC clients
- Create RPC clients on demand

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
