### PR TITLE
fix: Allow empty cast text

### DIFF
--- a/.changeset/silly-trees-tickle.md
+++ b/.changeset/silly-trees-tickle.md
@@ -1,0 +1,5 @@
+---
+"@farcaster/utils": patch
+---
+
+Allow empty cast text

--- a/packages/utils/src/validations.test.ts
+++ b/packages/utils/src/validations.test.ts
@@ -184,6 +184,11 @@ describe('validateCastAddBody', () => {
     expect(validations.validateCastAddBody(body)).toEqual(ok(body));
   });
 
+  test('when text is empty', () => {
+    const body = Factories.CastAddBody.build({ text: '', mentions: [], mentionsPositions: [] });
+    expect(validations.validateCastAddBody(body)).toEqual(ok(body));
+  });
+
   describe('fails', () => {
     let body: protobufs.CastAddBody;
     let hubErrorMessage: string;
@@ -194,8 +199,13 @@ describe('validateCastAddBody', () => {
       );
     });
 
-    test('when text is missing', () => {
-      body = Factories.CastAddBody.build({ text: '' });
+    test('when text is undefined', () => {
+      body = Factories.CastAddBody.build({ text: undefined });
+      hubErrorMessage = 'text is missing';
+    });
+
+    test('when text is null', () => {
+      body = Factories.CastAddBody.build({ text: null });
       hubErrorMessage = 'text is missing';
     });
 

--- a/packages/utils/src/validations.ts
+++ b/packages/utils/src/validations.ts
@@ -260,7 +260,7 @@ export const validateVerificationAddEthAddressSignature = (
 
 export const validateCastAddBody = (body: protobufs.CastAddBody): HubResult<protobufs.CastAddBody> => {
   const text = body.text;
-  if (!text) {
+  if (text === undefined || text === null) {
     return err(new HubError('bad_request.validation_failure', 'text is missing'));
   }
 


### PR DESCRIPTION
## Motivation

Since a cast could consist of just a mention, a valid cast can have no actual text (i.e. is the empty string), only a mention.

## Change Summary

Don't fail validation if an empty text string is provided for the cast.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
