### PR TITLE
fix: Allow duplicate `mentionsPositions`

### DIFF
--- a/.changeset/slimy-jobs-do.md
+++ b/.changeset/slimy-jobs-do.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/utils': patch
+---
+
+Allow duplicate mentions positions

--- a/packages/utils/src/validations.test.ts
+++ b/packages/utils/src/validations.test.ts
@@ -189,6 +189,15 @@ describe('validateCastAddBody', () => {
     expect(validations.validateCastAddBody(body)).toEqual(ok(body));
   });
 
+  test('with repeated mentionsPositions', () => {
+    const body = Factories.CastAddBody.build({
+      text: 'Hello ',
+      mentions: [Factories.Fid.build(), Factories.Fid.build()],
+      mentionsPositions: [6, 6],
+    });
+    expect(validations.validateCastAddBody(body)).toEqual(ok(body));
+  });
+
   describe('fails', () => {
     let body: protobufs.CastAddBody;
     let hubErrorMessage: string;
@@ -262,14 +271,6 @@ describe('validateCastAddBody', () => {
         mentionsPositions: [0],
       });
       hubErrorMessage = 'mentions and mentionsPositions must match';
-    });
-
-    test('with repeated mentionsPositions', () => {
-      body = Factories.CastAddBody.build({
-        mentions: [Factories.Fid.build(), Factories.Fid.build()],
-        mentionsPositions: [10, 10],
-      });
-      hubErrorMessage = 'mentionsPositions must be unique';
     });
 
     test('with out of range mentionsPositions', () => {

--- a/packages/utils/src/validations.ts
+++ b/packages/utils/src/validations.ts
@@ -297,9 +297,6 @@ export const validateCastAddBody = (body: protobufs.CastAddBody): HubResult<prot
     if (i > 0) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const prevPosition = body.mentionsPositions[i - 1]!;
-      if (position === prevPosition) {
-        return err(new HubError('bad_request.validation_failure', 'mentionsPositions must be unique'));
-      }
       if (position < prevPosition) {
         return err(
           new HubError('bad_request.validation_failure', 'mentionsPositions must be sorted in ascending order')


### PR DESCRIPTION
## Motivation

It is possible for a cast to have multiple mentions with the same position. Consider the following cast:

    @a@b@c

In this case, we are mentioning the users `a`, `b`, and `c`, without separating their names with any other text. The resulting `mentionsPositions` will be `[0, 0, 0]`, since there is no change in position.

## Change Summary

Relax our validations to allow this case.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
