### PR TITLE
feat: Add admin debug commands

### DIFF
--- a/apps/hubble/src/console/adminCommand.ts
+++ b/apps/hubble/src/console/adminCommand.ts
@@ -1,0 +1,43 @@
+import * as protobufs from '@farcaster/protobufs';
+import { ConsoleCommandInterface } from './console';
+
+export class AdminCommand implements ConsoleCommandInterface {
+  constructor(private readonly adminClient: protobufs.AdminServiceClient) {}
+
+  commandName(): string {
+    return 'admin';
+  }
+  shortHelp(): string {
+    return 'Admin commands';
+  }
+  help(): string {
+    return `
+        Usage: admin.rebuildSyncTrie()
+            Rebuild the sync trie by deleteing the trie and reconstructing it from all the messages in the database.
+            Be careful not to be connected to any other node or syncing while rebuilding the trie.
+        `;
+  }
+  object() {
+    return {
+      rebuildSyncTrie: () => {
+        this.adminClient.rebuildSyncTrie(protobufs.Empty.create(), (err) => {
+          if (err) {
+            return `Error: ${err}`;
+          } else {
+            return '';
+          }
+        });
+      },
+
+      deleteAllMessagesFromDb: () => {
+        this.adminClient.deleteAllMessagesFromDb(protobufs.Empty.create(), (err) => {
+          if (err) {
+            return `Error: ${err}`;
+          } else {
+            return '';
+          }
+        });
+      },
+    };
+  }
+}

--- a/apps/hubble/src/console/console.ts
+++ b/apps/hubble/src/console/console.ts
@@ -1,8 +1,11 @@
+import * as protobufs from '@farcaster/protobufs';
 import { Empty } from '@farcaster/protobufs';
 import { getHubRpcClient } from '@farcaster/utils';
 import path from 'path';
 import * as repl from 'repl';
+import { getAdminSocket } from '~/rpc/server/adminServer';
 import { logger } from '~/utils/logger';
+import { AdminCommand } from './adminCommand';
 import { GenCommand } from './genCommand';
 import { FactoriesCommand, ProtobufCommand } from './protobufCommand';
 import { RpcClientCommand } from './rpcClientCommand';
@@ -38,11 +41,14 @@ export const startConsole = async (addressString: string) => {
   });
 
   const rpcClient = getHubRpcClient(addressString);
+  const adminClient = protobufs.getAdminClient(getAdminSocket());
+
   const commands: ConsoleCommandInterface[] = [
     new RpcClientCommand(rpcClient),
     new ProtobufCommand(),
     new FactoriesCommand(),
     new GenCommand(rpcClient),
+    new AdminCommand(adminClient),
   ];
 
   replServer.defineCommand('help', {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -43,6 +43,7 @@ import {
   p2pMultiAddrStr,
 } from '~/utils/p2p';
 import { PeriodicSyncJobScheduler } from './network/sync/periodicSyncJob';
+import AdminServer from './rpc/server/adminServer';
 import { RootPrefix } from './storage/db/types';
 import {
   UpdateNameRegistryEventExpiryJobQueue,
@@ -130,6 +131,7 @@ export class Hub implements HubInterface {
   private options: HubOptions;
   private gossipNode: GossipNode;
   private rpcServer: Server;
+  private adminServer: AdminServer;
   private contactTimer?: NodeJS.Timer;
   private rocksDB: RocksDB;
   private syncEngine: SyncEngine;
@@ -152,6 +154,7 @@ export class Hub implements HubInterface {
     this.syncEngine = new SyncEngine(this.engine, this.rocksDB);
 
     this.rpcServer = new Server(this, this.engine, this.syncEngine, this.gossipNode);
+    this.adminServer = new AdminServer(this, this.rocksDB, this.engine, this.syncEngine);
 
     // Create the ETH registry provider, which will fetch ETH events and push them into the engine.
     this.ethRegistryProvider = EthEventsProvider.makeWithGoerli(
@@ -234,6 +237,7 @@ export class Hub implements HubInterface {
 
     // Start the RPC server
     await this.rpcServer.start(this.options.rpcPort ? this.options.rpcPort : 0);
+    await this.adminServer.start();
     this.registerEventHandlers();
 
     // Start cron tasks
@@ -275,6 +279,7 @@ export class Hub implements HubInterface {
 
     // First, stop the RPC/Gossip server so we don't get any more messages
     await this.rpcServer.stop();
+    await this.adminServer.stop();
     await this.gossipNode.stop();
 
     // Stop cron tasks

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -97,9 +97,7 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
   public async initialize(rebuildSyncTrie = false) {
     // Check if we need to rebuild sync trie
     if (rebuildSyncTrie) {
-      log.info('Rebuilding sync trie...');
-      await this._trie.rebuild(this.engine);
-      log.info('Rebuilding sync trie complete');
+      await this.rebuildSyncTrie();
     } else {
       // Wait for the Merkle trie to be fully loaded
       await this._trie.initialize();
@@ -107,6 +105,12 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     const rootHash = await this._trie.rootHash();
 
     log.info({ rootHash }, 'Sync engine initialized');
+  }
+
+  public async rebuildSyncTrie() {
+    log.info('Rebuilding sync trie...');
+    await this._trie.rebuild(this.engine);
+    log.info('Rebuilding sync trie complete');
   }
 
   public async stop() {

--- a/apps/hubble/src/rpc/server/adminServer.ts
+++ b/apps/hubble/src/rpc/server/adminServer.ts
@@ -1,0 +1,126 @@
+import * as protobufs from '@farcaster/protobufs';
+import {
+  AdminServiceServer,
+  AdminServiceService,
+  Server as GrpcServer,
+  ServerCredentials,
+  getServer,
+} from '@farcaster/protobufs';
+import { HubAsyncResult, HubError } from '@farcaster/utils';
+import * as net from 'net';
+import { err, ok } from 'neverthrow';
+import { HubInterface } from '~/hubble';
+import SyncEngine from '~/network/sync/syncEngine';
+import RocksDB from '~/storage/db/rocksdb';
+import Engine from '~/storage/engine';
+import { logger } from '~/utils/logger';
+
+const socketPath = '/tmp/hubble.admin.sock';
+export const getAdminSocket = (): string => `unix:${socketPath}`;
+
+const log = logger.child({ module: 'rpc:admin' });
+
+export default class AdminServer {
+  private hub: HubInterface;
+  private db: RocksDB;
+  private engine: Engine;
+  private syncEngine: SyncEngine;
+  private grpcServer: GrpcServer;
+
+  constructor(hub: HubInterface, db: RocksDB, engine: Engine, syncEngine: SyncEngine) {
+    this.hub = hub;
+    this.db = db;
+    this.engine = engine;
+    this.syncEngine = syncEngine;
+
+    this.grpcServer = getServer();
+    this.grpcServer.addService(AdminServiceService, this.getImpl());
+  }
+
+  async start(): HubAsyncResult<undefined> {
+    // Create a unix socket server
+    net.createServer(() => {
+      log.info('Admin server socket connected');
+    });
+
+    return new Promise((resolve) => {
+      this.grpcServer.bindAsync(getAdminSocket(), ServerCredentials.createInsecure(), (e) => {
+        if (e) {
+          log.error(`Failed to bind admin server to socket: ${e}`);
+          resolve(err(new HubError('unavailable.network_failure', `Failed to bind admin server to socket: ${e}`)));
+        } else {
+          this.grpcServer.start();
+          log.info('Starting Admin server');
+          resolve(ok(undefined));
+        }
+      });
+    });
+  }
+
+  async stop(force = false): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (force) {
+        this.grpcServer.forceShutdown();
+        resolve();
+      } else {
+        this.grpcServer.tryShutdown((e) => {
+          if (e) {
+            log.error(`Failed to shutdown admin server: ${e}`);
+            reject(e);
+          } else {
+            resolve();
+          }
+        });
+      }
+    });
+  }
+
+  getImpl = (): AdminServiceServer => {
+    return {
+      rebuildSyncTrie: (call, callback) => {
+        (async () => {
+          await this.syncEngine?.rebuildSyncTrie();
+          callback(null, protobufs.Empty.create());
+        })();
+      },
+
+      deleteAllMessagesFromDb: (call, callback) => {
+        (async () => {
+          log.warn('Deleting all messages from DB');
+
+          let done = false;
+          do {
+            const toDelete: Buffer[] = [];
+            await this.engine?.forEachMessage(async (_message, key) => {
+              toDelete.push(key);
+              if (toDelete.length >= 10_000) {
+                return true;
+              }
+              return false;
+            });
+
+            // If there is nothing remaining to be deleted, we are done
+            if (toDelete.length === 0) {
+              done = true;
+              break;
+            }
+
+            // Delete in batches of 10_000
+            const txn = this.db?.transaction();
+            toDelete.forEach((key) => {
+              txn?.del(key);
+            });
+            await this.db?.commit(txn);
+            log.warn(`Deleted ${toDelete.length} messages from DB`);
+          } while (!done);
+
+          // Rebuild the sync trie after deleting all messages
+          await this.syncEngine?.rebuildSyncTrie();
+
+          log.warn('Finished deleting all messages from DB');
+          callback(null, protobufs.Empty.create());
+        })();
+      },
+    };
+  };
+}

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -120,7 +120,7 @@ class Engine {
   /*                             Sync Methods                                   */
   /* -------------------------------------------------------------------------- */
 
-  async forEachMessage(callback: (message: protobufs.Message) => Promise<void>): Promise<void> {
+  async forEachMessage(callback: (message: protobufs.Message, key: Buffer) => Promise<boolean | void>): Promise<void> {
     const allUserPrefix = Buffer.from([RootPrefix.User]);
 
     for await (const [key, value] of this._db.iteratorByPrefix(allUserPrefix, { keys: true, valueAsBuffer: true })) {
@@ -149,7 +149,10 @@ class Engine {
       )();
 
       if (message.isOk()) {
-        await callback(message.value);
+        const done = await callback(message.value, key);
+        if (done) {
+          break;
+        }
       }
     }
   }

--- a/packages/protobufs/src/generated/rpc.ts
+++ b/packages/protobufs/src/generated/rpc.ts
@@ -2297,6 +2297,68 @@ export const HubServiceClient = makeGenericClientConstructor(HubServiceService, 
   service: typeof HubServiceService;
 };
 
+export type AdminServiceService = typeof AdminServiceService;
+export const AdminServiceService = {
+  rebuildSyncTrie: {
+    path: "/AdminService/RebuildSyncTrie",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: Empty) => Buffer.from(Empty.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => Empty.decode(value),
+    responseSerialize: (value: Empty) => Buffer.from(Empty.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => Empty.decode(value),
+  },
+  deleteAllMessagesFromDb: {
+    path: "/AdminService/DeleteAllMessagesFromDb",
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: (value: Empty) => Buffer.from(Empty.encode(value).finish()),
+    requestDeserialize: (value: Buffer) => Empty.decode(value),
+    responseSerialize: (value: Empty) => Buffer.from(Empty.encode(value).finish()),
+    responseDeserialize: (value: Buffer) => Empty.decode(value),
+  },
+} as const;
+
+export interface AdminServiceServer extends UntypedServiceImplementation {
+  rebuildSyncTrie: handleUnaryCall<Empty, Empty>;
+  deleteAllMessagesFromDb: handleUnaryCall<Empty, Empty>;
+}
+
+export interface AdminServiceClient extends Client {
+  rebuildSyncTrie(request: Empty, callback: (error: ServiceError | null, response: Empty) => void): ClientUnaryCall;
+  rebuildSyncTrie(
+    request: Empty,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: Empty) => void,
+  ): ClientUnaryCall;
+  rebuildSyncTrie(
+    request: Empty,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: Empty) => void,
+  ): ClientUnaryCall;
+  deleteAllMessagesFromDb(
+    request: Empty,
+    callback: (error: ServiceError | null, response: Empty) => void,
+  ): ClientUnaryCall;
+  deleteAllMessagesFromDb(
+    request: Empty,
+    metadata: Metadata,
+    callback: (error: ServiceError | null, response: Empty) => void,
+  ): ClientUnaryCall;
+  deleteAllMessagesFromDb(
+    request: Empty,
+    metadata: Metadata,
+    options: Partial<CallOptions>,
+    callback: (error: ServiceError | null, response: Empty) => void,
+  ): ClientUnaryCall;
+}
+
+export const AdminServiceClient = makeGenericClientConstructor(AdminServiceService, "AdminService") as unknown as {
+  new (address: string, credentials: ChannelCredentials, options?: Partial<ClientOptions>): AdminServiceClient;
+  service: typeof AdminServiceService;
+};
+
 declare var self: any | undefined;
 declare var window: any | undefined;
 declare var global: any | undefined;

--- a/packages/protobufs/src/index.ts
+++ b/packages/protobufs/src/index.ts
@@ -1,5 +1,5 @@
 import * as grpc from '@grpc/grpc-js';
-import { HubServiceClient } from './generated/rpc';
+import { AdminServiceClient, HubServiceClient } from './generated/rpc';
 
 export { Metadata, Server, ServerCredentials, status } from '@grpc/grpc-js';
 export type { CallOptions, Client, ClientReadableStream, ClientUnaryCall, ServiceError } from '@grpc/grpc-js';
@@ -22,4 +22,8 @@ export const getServer = (): grpc.Server => {
 
 export const getClient = (address: string): HubServiceClient => {
   return new HubServiceClient(address, grpc.credentials.createInsecure());
+};
+
+export const getAdminClient = (address: string): AdminServiceClient => {
+  return new AdminServiceClient(address, grpc.credentials.createInsecure());
 };

--- a/packages/protobufs/src/schemas/rpc.proto
+++ b/packages/protobufs/src/schemas/rpc.proto
@@ -164,3 +164,8 @@ service HubService {
   rpc GetSyncMetadataByPrefix(TrieNodePrefix) returns (TrieNodeMetadataResponse);
   rpc GetSyncSnapshotByPrefix(TrieNodePrefix) returns (TrieNodeSnapshotResponse);
 }
+
+service AdminService {
+  rpc RebuildSyncTrie(Empty) returns (Empty);
+  rpc DeleteAllMessagesFromDb(Empty) returns (Empty);
+}


### PR DESCRIPTION
## Motivation

Add a new 'admin' command for `yarn console` that lets you do delete messages and rebuild sync trie. Available only if you run it on the same machine as the server (no remote access)

## Change Summary

- Add Admin service, bind it to unix file system socket
- rebuild command and delete all messages command. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
