### PR TITLE
feat: Implement rate limits for gossip/sync

### DIFF
--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -122,7 +122,8 @@ app
     const hub = new Hub(options);
     const startResult = await ResultAsync.fromPromise(hub.start(), (e) => new Error(`Failed to start hub: ${e}`));
     if (startResult.isErr()) {
-      logger.fatal({ error: startResult.error, reason: 'Hub Startup failed' }, 'shutting down hub');
+      logger.fatal(startResult.error);
+      logger.fatal({ reason: 'Hub Startup failed' }, 'shutting down hub');
       try {
         await teardown(hub);
       } finally {

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -24,7 +24,7 @@ import { Multiaddr, multiaddr } from '@multiformats/multiaddr';
 import { isIP } from 'net';
 import { Result, ResultAsync, err, ok } from 'neverthrow';
 import { EthEventsProvider, GoerliEthConstants } from '~/eth/ethEventsProvider';
-import { GossipNode } from '~/network/p2p/gossipNode';
+import { GossipNode, MAX_GOSSIP_MESSAGE_QUEUE_SIZE } from '~/network/p2p/gossipNode';
 import { NETWORK_TOPIC_CONTACT, NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
 import SyncEngine from '~/network/sync/syncEngine';
 import Server from '~/rpc/server';
@@ -329,6 +329,16 @@ export class Hub implements HubInterface {
     if (gossipMessage.message) {
       const message = gossipMessage.message;
 
+      if (this.syncEngine.syncMergeQSize + this.syncEngine.syncTrieQSize > MAX_GOSSIP_MESSAGE_QUEUE_SIZE) {
+        // If there are too many messages in the queue, drop this message. This is a gossip message, so the sync
+        // will eventually re-fetch and merge this message in anyway.
+        log.warn(
+          { syncTrieQ: this.syncEngine.syncTrieQSize, syncMergeQ: this.syncEngine.syncMergeQSize },
+          `Sync queue is full, dropping gossip message`
+        );
+        return err(new HubError('unavailable', 'Sync queue is full'));
+      }
+
       // Get the RPC Client to use to merge this message
       const contactInfo = this.syncEngine.getContactInfoForPeerId(peerId.toString())?.contactInfo;
       if (contactInfo) {
@@ -527,6 +537,11 @@ export class Hub implements HubInterface {
   async submitMessage(message: Message, source?: HubSubmitSource): HubAsyncResult<number> {
     // message is a reserved key in some logging systems, so we use submittedMessage instead
     const logMessage = log.child({ submittedMessage: messageToLog(message), source });
+
+    if (this.syncEngine.syncTrieQSize > MAX_GOSSIP_MESSAGE_QUEUE_SIZE) {
+      log.warn({ syncTrieQSize: this.syncEngine.syncTrieQSize }, 'SubmitMessage rejected: Sync trie queue is full');
+      return err(new HubError('unavailable.storage_failure', 'Sync trie queue is full'));
+    }
 
     const mergeResult = await this.engine.mergeMessage(message);
 

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -24,7 +24,7 @@ import { Multiaddr, multiaddr } from '@multiformats/multiaddr';
 import { isIP } from 'net';
 import { Result, ResultAsync, err, ok } from 'neverthrow';
 import { EthEventsProvider, GoerliEthConstants } from '~/eth/ethEventsProvider';
-import { GossipNode, MAX_GOSSIP_MESSAGE_QUEUE_SIZE } from '~/network/p2p/gossipNode';
+import { GossipNode, MAX_MESSAGE_QUEUE_SIZE } from '~/network/p2p/gossipNode';
 import { NETWORK_TOPIC_CONTACT, NETWORK_TOPIC_PRIMARY } from '~/network/p2p/protocol';
 import SyncEngine from '~/network/sync/syncEngine';
 import Server from '~/rpc/server';
@@ -329,7 +329,7 @@ export class Hub implements HubInterface {
     if (gossipMessage.message) {
       const message = gossipMessage.message;
 
-      if (this.syncEngine.syncMergeQSize + this.syncEngine.syncTrieQSize > MAX_GOSSIP_MESSAGE_QUEUE_SIZE) {
+      if (this.syncEngine.syncMergeQSize + this.syncEngine.syncTrieQSize > MAX_MESSAGE_QUEUE_SIZE) {
         // If there are too many messages in the queue, drop this message. This is a gossip message, so the sync
         // will eventually re-fetch and merge this message in anyway.
         log.warn(
@@ -538,7 +538,7 @@ export class Hub implements HubInterface {
     // message is a reserved key in some logging systems, so we use submittedMessage instead
     const logMessage = log.child({ submittedMessage: messageToLog(message), source });
 
-    if (this.syncEngine.syncTrieQSize > MAX_GOSSIP_MESSAGE_QUEUE_SIZE) {
+    if (this.syncEngine.syncTrieQSize > MAX_MESSAGE_QUEUE_SIZE) {
       log.warn({ syncTrieQSize: this.syncEngine.syncTrieQSize }, 'SubmitMessage rejected: Sync trie queue is full');
       return err(new HubError('unavailable.storage_failure', 'Sync trie queue is full'));
     }

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -17,6 +17,7 @@ import { logger } from '~/utils/logger';
 import { addressInfoFromParts, checkNodeAddrs, ipMultiAddrStrFromAddressInfo } from '~/utils/p2p';
 
 const MultiaddrLocalHost = '/ip4/127.0.0.1';
+export const MAX_GOSSIP_MESSAGE_QUEUE_SIZE = 1000;
 
 const log = logger.child({ component: 'Node' });
 

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -17,7 +17,9 @@ import { logger } from '~/utils/logger';
 import { addressInfoFromParts, checkNodeAddrs, ipMultiAddrStrFromAddressInfo } from '~/utils/p2p';
 
 const MultiaddrLocalHost = '/ip4/127.0.0.1';
-export const MAX_GOSSIP_MESSAGE_QUEUE_SIZE = 1000;
+
+/** The maximum number of pending merge messages before we drop new incoming gossip or sync messages  */
+export const MAX_MESSAGE_QUEUE_SIZE = 1000;
 
 const log = logger.child({ component: 'Node' });
 

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -6,7 +6,7 @@ import RocksDB from '~/storage/db/rocksdb';
 import Engine from '~/storage/engine';
 import { logger } from '~/utils/logger';
 
-const TRIE_UNLOAD_THRESHOLD = 1000;
+const TRIE_UNLOAD_THRESHOLD = 10_000;
 
 /**
  * Represents a node in the trie, and it's immediate children
@@ -89,8 +89,13 @@ class MerkleTrie {
     this._root = new TrieNode();
 
     // Rebuild the trie
+    let count = 0;
     await engine.forEachMessage(async (message) => {
       await this.insert(new SyncId(message));
+      count += 1;
+      if (count % 10_000 === 0) {
+        log.info({ count }, 'Rebuilding Merkle Trie');
+      }
     });
   }
 

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -63,7 +63,7 @@ describe('SyncEngine', () => {
       })
     );
 
-    await sleepWhile(() => syncEngine.messagesQueuedForSync > 0, 1000);
+    await sleepWhile(() => syncEngine.syncTrieQSize > 0, 1000);
     return results;
   };
 
@@ -80,7 +80,7 @@ describe('SyncEngine', () => {
     expect(result.isOk()).toBeTruthy();
 
     // Wait for the trie to be updated
-    await sleepWhile(() => syncEngine.messagesQueuedForSync > 0, 1000);
+    await sleepWhile(() => syncEngine.syncTrieQSize > 0, 1000);
 
     // Two messages (signerAdd + castAdd) was added to the trie
     expect((await syncEngine.trie.items()) - existingItems).toEqual(2);
@@ -96,7 +96,7 @@ describe('SyncEngine', () => {
     expect(result.isErr()).toBeTruthy();
 
     // Wait for the trie to be updated
-    await sleepWhile(() => syncEngine.messagesQueuedForSync > 0, 1000);
+    await sleepWhile(() => syncEngine.syncTrieQSize > 0, 1000);
 
     expect(await syncEngine.trie.items()).toEqual(0);
     expect(await syncEngine.trie.exists(new SyncId(castAdd))).toBeFalsy();
@@ -120,7 +120,7 @@ describe('SyncEngine', () => {
     expect(result.isOk()).toBeTruthy();
 
     // Wait for the trie to be updated
-    await sleepWhile(() => syncEngine.messagesQueuedForSync > 0, 1000);
+    await sleepWhile(() => syncEngine.syncTrieQSize > 0, 1000);
 
     const id = new SyncId(castRemove);
     expect(await syncEngine.trie.exists(id)).toBeTruthy();
@@ -164,7 +164,7 @@ describe('SyncEngine', () => {
     expect(result.isOk()).toBeTruthy();
 
     // Wait for the trie to be updated
-    await sleepWhile(() => syncEngine.messagesQueuedForSync > 0, 1000);
+    await sleepWhile(() => syncEngine.syncTrieQSize > 0, 1000);
     expect(await syncEngine.trie.items()).toEqual(2); // signerAdd + reaction1
 
     // Then merging the second reaction should also succeed and remove reaction1
@@ -172,7 +172,7 @@ describe('SyncEngine', () => {
     expect(result.isOk()).toBeTruthy();
 
     // Wait for the trie to be updated
-    await sleepWhile(() => syncEngine.messagesQueuedForSync > 0, 1000);
+    await sleepWhile(() => syncEngine.syncTrieQSize > 0, 1000);
     expect(await syncEngine.trie.items()).toEqual(2); // signerAdd + reaction2 (reaction1 is removed)
 
     // Create a new engine and sync engine
@@ -187,7 +187,7 @@ describe('SyncEngine', () => {
     expect(result.isOk()).toBeTruthy();
 
     // Wait for the trie to be updated
-    await sleepWhile(() => syncEngine.messagesQueuedForSync > 0, 1000);
+    await sleepWhile(() => syncEngine.syncTrieQSize > 0, 1000);
     expect(await syncEngine2.trie.items()).toEqual(2); // signerAdd + reaction2
 
     // Roothashes must match

--- a/apps/hubble/src/test/bench/syncEngine.ts
+++ b/apps/hubble/src/test/bench/syncEngine.ts
@@ -253,7 +253,7 @@ export const benchSyncEngine = async ({
               staled: messages.length > nodeMetadata!.numMessages,
               ...rpcClient.stats(),
             };
-            await sleepWhile(() => ourSyncEngine.messagesQueuedForSync > 0, 1000);
+            await sleepWhile(() => ourSyncEngine.syncTrieQSize > 0, 1000);
           }
         }
 


### PR DESCRIPTION
## Motivation

If the merge stores are backed up and new messages are about to be timedout, we drop gossiped messages. They will be fetched with the next sync 

## Change Summary

- Drop gossip messages if merge Q is full. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
