### PR TITLE
docs: add JS docs to message builders

### DIFF
--- a/packages/js/docs/modules.md
+++ b/packages/js/docs/modules.md
@@ -97,27 +97,43 @@ await client.submitMessage(cast._unsafeUnwrap());
 
 `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`CastAddBody`](modules/types.md#castaddbody), [`MESSAGE_TYPE_CAST_ADD`](enums/protobufs.MessageType.md#message_type_cast_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
 
-...
-
 ___
 
 ### makeCastRemove
 
 ▸ **makeCastRemove**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`CastRemoveBody`](modules/types.md#castremovebody), [`MESSAGE_TYPE_CAST_REMOVE`](enums/protobufs.MessageType.md#message_type_cast_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
 
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
+Make a message to remove a cast
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
+import {
+  Client,
+  Ed25519Signer,
+  makeCastAdd,
+  makeCastRemove,
+  types,
+} from '@farcaster/js';
+import * as ed from '@noble/ed25519';
 
-const client = new Client(...)
+const rpcUrl = '<rpc-url>';
+const client = new Client(rpcUrl);
 
-const message = makeCastAdd(...)
-await client.submitMessage(message)
+const privateKeyHex = '86be7f6f8dcf18...'; // EdDSA hex private key
+const privateKey = ed.utils.hexToBytes(privateKeyHex);
+
+// _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+
+const dataOptions = {
+  fid: -9999, // must be changed to fid of the custody address, or else it will fail
+  network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+};
+
+const removeBody = { targetHash: '0xf88d738eb7145f4cea40fbe8f3bdf...' };
+const castRemove = await makeCastRemove(removeBody, dataOptions, ed25519Signer);
+await client.submitMessage(castRemove._unsafeUnwrap());
 ```
 
 #### Parameters
@@ -131,8 +147,6 @@ await client.submitMessage(message)
 #### Returns
 
 `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`CastRemoveBody`](modules/types.md#castremovebody), [`MESSAGE_TYPE_CAST_REMOVE`](enums/protobufs.MessageType.md#message_type_cast_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
 
 ___
 
@@ -208,19 +222,42 @@ ___
 
 ▸ **makeReactionAdd**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_ADD`](enums/protobufs.MessageType.md#message_type_reaction_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
 
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
+Make a message to react a cast (like or recast)
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
+import {
+  Client,
+  Ed25519Signer,
+  makeCastAdd,
+  makeCastRemove,
+  types,
+} from '@farcaster/js';
+import * as ed from '@noble/ed25519';
 
-const client = new Client(...)
+const rpcUrl = '<rpc-url>';
+const client = new Client(rpcUrl);
 
-const message = makeCastAdd(...)
-await client.submitMessage(message)
+const privateKeyHex = '86be7f6f8dcf18...'; // EdDSA hex private key
+const privateKey = ed.utils.hexToBytes(privateKeyHex);
+
+// _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+
+const dataOptions = {
+  fid: -9999, // must be changed to fid of the custody address, or else it will fail
+  network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+};
+
+// fid here is the fid of the author of the cast
+const reactionLikeBody = {
+  type: types.ReactionType.REACTION_TYPE_LIKE,
+  target: { fid: -9998, tsHash: '0x455a6caad5dfd4d...' },
+};
+
+const like = await makeReactionAdd(reactionLikeBody, dataOptions, ed25519Signer);
+await client.submitMessage(like._unsafeUnwrap());
 ```
 
 #### Parameters
@@ -235,27 +272,48 @@ await client.submitMessage(message)
 
 `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_ADD`](enums/protobufs.MessageType.md#message_type_reaction_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
 
-...
-
 ___
 
 ### makeReactionRemove
 
 ▸ **makeReactionRemove**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_REMOVE`](enums/protobufs.MessageType.md#message_type_reaction_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
 
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
+Make a message to undo a reaction to a cast (unlike or undo recast)
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
+import {
+  Client,
+  Ed25519Signer,
+  makeCastAdd,
+  makeCastRemove,
+  types,
+} from '@farcaster/js';
+import * as ed from '@noble/ed25519';
 
-const client = new Client(...)
+const rpcUrl = '<rpc-url>';
+const client = new Client(rpcUrl);
 
-const message = makeCastAdd(...)
-await client.submitMessage(message)
+const privateKeyHex = '86be7f6f8dcf18...'; // EdDSA hex private key
+const privateKey = ed.utils.hexToBytes(privateKeyHex);
+
+// _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+
+const dataOptions = {
+  fid: -9999, // must be changed to fid of the custody address, or else it will fail
+  network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+};
+
+// fid here is the fid of the author of the cast
+const reactionLikeBody = {
+  type: types.ReactionType.REACTION_TYPE_LIKE,
+  target: { fid: -9998, tsHash: '0x455a6caad5dfd4d...' },
+};
+
+const unlike = await makeReactionRemove(reactionLikeBody, dataOptions, ed25519Signer);
+await client.submitMessage(unlike._unsafeUnwrap());
 ```
 
 #### Parameters
@@ -270,27 +328,45 @@ await client.submitMessage(message)
 
 `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_REMOVE`](enums/protobufs.MessageType.md#message_type_reaction_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
 
-...
-
 ___
 
 ### makeSignerAdd
 
 ▸ **makeSignerAdd**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`SignerBody`](modules/types.md#signerbody), [`MESSAGE_TYPE_SIGNER_ADD`](enums/protobufs.MessageType.md#message_type_signer_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
 
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
+Make a message to add an EdDSA signer
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
+import { Client, Ed25519Signer, Eip712Signer, makeSignerAdd, types } from '@farcaster/js';
+import { ethers } from 'ethers';
+import * as ed from '@noble/ed25519';
 
-const client = new Client(...)
+const rpcUrl = '<rpc-url>';
+const client = new Client(rpcUrl);
 
-const message = makeCastAdd(...)
-await client.submitMessage(message)
+const privateKey = ed.utils.randomPrivateKey();
+const privateKeyHex = ed.utils.bytesToHex(privateKey);
+console.log(privateKeyHex); // 86be7f6f8dcf18...
+// developers should safely store this EdDSA private key on behalf of users
+
+// _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+
+const mnemonic = 'your mnemonic apple orange banana ...';
+const wallet = ethers.Wallet.fromMnemonic(mnemonic);
+
+// _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+const eip712Signer = Eip712Signer.fromSigner(wallet, wallet.address)._unsafeUnwrap();
+
+const dataOptions = {
+  fid: -9999, // must be changed to fid of the custody address, or else it will fail
+  network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+};
+
+const signerAdd = await makeSignerAdd({ signer: ed25519Signer.signerKeyHex }, dataOptions, eip712Signer);
+await client.submitMessage(signerAdd._unsafeUnwrap());
 ```
 
 #### Parameters
@@ -304,8 +380,6 @@ await client.submitMessage(message)
 #### Returns
 
 `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`SignerBody`](modules/types.md#signerbody), [`MESSAGE_TYPE_SIGNER_ADD`](enums/protobufs.MessageType.md#message_type_signer_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
 
 ___
 
@@ -348,19 +422,40 @@ ___
 
 ▸ **makeUserDataAdd**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`UserDataBody`](modules/types.md#userdatabody), [`MESSAGE_TYPE_USER_DATA_ADD`](enums/protobufs.MessageType.md#message_type_user_data_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
 
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
+Make a message to set user data (pfp, bio, display name, etc)
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
+import {
+  Client,
+  Ed25519Signer,
+  makeCastAdd,
+  makeCastRemove,
+  types,
+} from '@farcaster/js';
+import * as ed from '@noble/ed25519';
 
-const client = new Client(...)
+const rpcUrl = '<rpc-url>';
+const client = new Client(rpcUrl);
 
-const message = makeCastAdd(...)
-await client.submitMessage(message)
+const privateKeyHex = '86be7f6f8dcf18...'; // EdDSA hex private key
+const privateKey = ed.utils.hexToBytes(privateKeyHex);
+
+// _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+
+const dataOptions = {
+  fid: -9999, // must be changed to fid of the custody address, or else it will fail
+  network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+};
+
+const userDataPfpBody = {
+  type: types.UserDataType.USER_DATA_TYPE_PFP,
+  value: 'https://i.imgur.com/yed5Zfk.gif',
+};
+const userDataPfpAdd = await makeUserDataAdd(userDataPfpBody, dataOptions, ed25519Signer);
+await client.submitMessage(userDataPfpAdd._unsafeUnwrap());
 ```
 
 #### Parameters
@@ -374,8 +469,6 @@ await client.submitMessage(message)
 #### Returns
 
 `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`UserDataBody`](modules/types.md#userdatabody), [`MESSAGE_TYPE_USER_DATA_ADD`](enums/protobufs.MessageType.md#message_type_user_data_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
 
 ___
 

--- a/packages/js/docs/modules.md
+++ b/packages/js/docs/modules.md
@@ -23,25 +23,16 @@
 ### Functions
 
 - [makeCastAdd](modules.md#makecastadd)
-- [makeCastAddData](modules.md#makecastadddata)
 - [makeCastRemove](modules.md#makecastremove)
-- [makeCastRemoveData](modules.md#makecastremovedata)
 - [makeMessageHash](modules.md#makemessagehash)
 - [makeMessageWithSignature](modules.md#makemessagewithsignature)
 - [makeReactionAdd](modules.md#makereactionadd)
-- [makeReactionAddData](modules.md#makereactionadddata)
 - [makeReactionRemove](modules.md#makereactionremove)
-- [makeReactionRemoveData](modules.md#makereactionremovedata)
 - [makeSignerAdd](modules.md#makesigneradd)
-- [makeSignerAddData](modules.md#makesigneradddata)
 - [makeSignerRemove](modules.md#makesignerremove)
-- [makeSignerRemoveData](modules.md#makesignerremovedata)
 - [makeUserDataAdd](modules.md#makeuserdataadd)
-- [makeUserDataAddData](modules.md#makeuserdataadddata)
 - [makeVerificationAddEthAddress](modules.md#makeverificationaddethaddress)
-- [makeVerificationAddEthAddressData](modules.md#makeverificationaddethaddressdata)
 - [makeVerificationRemove](modules.md#makeverificationremove)
-- [makeVerificationRemoveData](modules.md#makeverificationremovedata)
 
 ## Type Aliases
 
@@ -110,40 +101,6 @@ await client.submitMessage(cast._unsafeUnwrap());
 
 ___
 
-### makeCastAddData
-
-▸ **makeCastAddData**(`bodyJson`, `dataOptions`): `HubResult`<[`MessageData`](modules/types.md#messagedata)<[`CastAddBody`](modules/types.md#castaddbody), [`MESSAGE_TYPE_CAST_ADD`](enums/protobufs.MessageType.md#message_type_cast_add)\>\>
-
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
-
-**`Example`**
-
-```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-
-const message = makeCastAdd(...)
-await client.submitMessage(message)
-```
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`CastAddBody`](modules/types.md#castaddbody) |
-| `dataOptions` | `MessageDataOptions` |
-
-#### Returns
-
-`HubResult`<[`MessageData`](modules/types.md#messagedata)<[`CastAddBody`](modules/types.md#castaddbody), [`MESSAGE_TYPE_CAST_ADD`](enums/protobufs.MessageType.md#message_type_cast_add)\>\>
-
-...
-
-___
-
 ### makeCastRemove
 
 ▸ **makeCastRemove**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`CastRemoveBody`](modules/types.md#castremovebody), [`MESSAGE_TYPE_CAST_REMOVE`](enums/protobufs.MessageType.md#message_type_cast_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
@@ -174,40 +131,6 @@ await client.submitMessage(message)
 #### Returns
 
 `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`CastRemoveBody`](modules/types.md#castremovebody), [`MESSAGE_TYPE_CAST_REMOVE`](enums/protobufs.MessageType.md#message_type_cast_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
-
-___
-
-### makeCastRemoveData
-
-▸ **makeCastRemoveData**(`bodyJson`, `dataOptions`): `HubResult`<[`MessageData`](modules/types.md#messagedata)<[`CastRemoveBody`](modules/types.md#castremovebody), [`MESSAGE_TYPE_CAST_REMOVE`](enums/protobufs.MessageType.md#message_type_cast_remove)\>\>
-
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
-
-**`Example`**
-
-```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-
-const message = makeCastAdd(...)
-await client.submitMessage(message)
-```
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`CastRemoveBody`](modules/types.md#castremovebody) |
-| `dataOptions` | `MessageDataOptions` |
-
-#### Returns
-
-`HubResult`<[`MessageData`](modules/types.md#messagedata)<[`CastRemoveBody`](modules/types.md#castremovebody), [`MESSAGE_TYPE_CAST_REMOVE`](enums/protobufs.MessageType.md#message_type_cast_remove)\>\>
 
 ...
 
@@ -316,40 +239,6 @@ await client.submitMessage(message)
 
 ___
 
-### makeReactionAddData
-
-▸ **makeReactionAddData**(`bodyJson`, `dataOptions`): `HubResult`<[`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_ADD`](enums/protobufs.MessageType.md#message_type_reaction_add)\>\>
-
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
-
-**`Example`**
-
-```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-
-const message = makeCastAdd(...)
-await client.submitMessage(message)
-```
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`ReactionBody`](modules/types.md#reactionbody) |
-| `dataOptions` | `MessageDataOptions` |
-
-#### Returns
-
-`HubResult`<[`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_ADD`](enums/protobufs.MessageType.md#message_type_reaction_add)\>\>
-
-...
-
-___
-
 ### makeReactionRemove
 
 ▸ **makeReactionRemove**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_REMOVE`](enums/protobufs.MessageType.md#message_type_reaction_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
@@ -380,40 +269,6 @@ await client.submitMessage(message)
 #### Returns
 
 `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_REMOVE`](enums/protobufs.MessageType.md#message_type_reaction_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
-
-___
-
-### makeReactionRemoveData
-
-▸ **makeReactionRemoveData**(`bodyJson`, `dataOptions`): `HubResult`<[`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_REMOVE`](enums/protobufs.MessageType.md#message_type_reaction_remove)\>\>
-
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
-
-**`Example`**
-
-```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-
-const message = makeCastAdd(...)
-await client.submitMessage(message)
-```
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`ReactionBody`](modules/types.md#reactionbody) |
-| `dataOptions` | `MessageDataOptions` |
-
-#### Returns
-
-`HubResult`<[`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_REMOVE`](enums/protobufs.MessageType.md#message_type_reaction_remove)\>\>
 
 ...
 
@@ -454,40 +309,6 @@ await client.submitMessage(message)
 
 ___
 
-### makeSignerAddData
-
-▸ **makeSignerAddData**(`bodyJson`, `dataOptions`): `HubResult`<[`MessageData`](modules/types.md#messagedata)<[`SignerBody`](modules/types.md#signerbody), [`MESSAGE_TYPE_SIGNER_ADD`](enums/protobufs.MessageType.md#message_type_signer_add)\>\>
-
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
-
-**`Example`**
-
-```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-
-const message = makeCastAdd(...)
-await client.submitMessage(message)
-```
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`SignerBody`](modules/types.md#signerbody) |
-| `dataOptions` | `MessageDataOptions` |
-
-#### Returns
-
-`HubResult`<[`MessageData`](modules/types.md#messagedata)<[`SignerBody`](modules/types.md#signerbody), [`MESSAGE_TYPE_SIGNER_ADD`](enums/protobufs.MessageType.md#message_type_signer_add)\>\>
-
-...
-
-___
-
 ### makeSignerRemove
 
 ▸ **makeSignerRemove**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`SignerBody`](modules/types.md#signerbody), [`MESSAGE_TYPE_SIGNER_REMOVE`](enums/protobufs.MessageType.md#message_type_signer_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
@@ -518,40 +339,6 @@ await client.submitMessage(message)
 #### Returns
 
 `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`SignerBody`](modules/types.md#signerbody), [`MESSAGE_TYPE_SIGNER_REMOVE`](enums/protobufs.MessageType.md#message_type_signer_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
-
-___
-
-### makeSignerRemoveData
-
-▸ **makeSignerRemoveData**(`bodyJson`, `dataOptions`): `HubResult`<[`MessageData`](modules/types.md#messagedata)<[`SignerBody`](modules/types.md#signerbody), [`MESSAGE_TYPE_SIGNER_REMOVE`](enums/protobufs.MessageType.md#message_type_signer_remove)\>\>
-
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
-
-**`Example`**
-
-```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-
-const message = makeCastAdd(...)
-await client.submitMessage(message)
-```
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`SignerBody`](modules/types.md#signerbody) |
-| `dataOptions` | `MessageDataOptions` |
-
-#### Returns
-
-`HubResult`<[`MessageData`](modules/types.md#messagedata)<[`SignerBody`](modules/types.md#signerbody), [`MESSAGE_TYPE_SIGNER_REMOVE`](enums/protobufs.MessageType.md#message_type_signer_remove)\>\>
 
 ...
 
@@ -592,40 +379,6 @@ await client.submitMessage(message)
 
 ___
 
-### makeUserDataAddData
-
-▸ **makeUserDataAddData**(`bodyJson`, `dataOptions`): `HubResult`<[`MessageData`](modules/types.md#messagedata)<[`UserDataBody`](modules/types.md#userdatabody), [`MESSAGE_TYPE_USER_DATA_ADD`](enums/protobufs.MessageType.md#message_type_user_data_add)\>\>
-
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
-
-**`Example`**
-
-```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-
-const message = makeCastAdd(...)
-await client.submitMessage(message)
-```
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`UserDataBody`](modules/types.md#userdatabody) |
-| `dataOptions` | `MessageDataOptions` |
-
-#### Returns
-
-`HubResult`<[`MessageData`](modules/types.md#messagedata)<[`UserDataBody`](modules/types.md#userdatabody), [`MESSAGE_TYPE_USER_DATA_ADD`](enums/protobufs.MessageType.md#message_type_user_data_add)\>\>
-
-...
-
-___
-
 ### makeVerificationAddEthAddress
 
 ▸ **makeVerificationAddEthAddress**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`VerificationAddEthAddressBody`](modules/types.md#verificationaddethaddressbody), [`MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS`](enums/protobufs.MessageType.md#message_type_verification_add_eth_address)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
@@ -661,40 +414,6 @@ await client.submitMessage(message)
 
 ___
 
-### makeVerificationAddEthAddressData
-
-▸ **makeVerificationAddEthAddressData**(`bodyJson`, `dataOptions`): `HubResult`<[`MessageData`](modules/types.md#messagedata)<[`VerificationAddEthAddressBody`](modules/types.md#verificationaddethaddressbody), [`MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS`](enums/protobufs.MessageType.md#message_type_verification_add_eth_address)\>\>
-
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
-
-**`Example`**
-
-```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-
-const message = makeCastAdd(...)
-await client.submitMessage(message)
-```
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`VerificationAddEthAddressBody`](modules/types.md#verificationaddethaddressbody) |
-| `dataOptions` | `MessageDataOptions` |
-
-#### Returns
-
-`HubResult`<[`MessageData`](modules/types.md#messagedata)<[`VerificationAddEthAddressBody`](modules/types.md#verificationaddethaddressbody), [`MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS`](enums/protobufs.MessageType.md#message_type_verification_add_eth_address)\>\>
-
-...
-
-___
-
 ### makeVerificationRemove
 
 ▸ **makeVerificationRemove**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`VerificationRemoveBody`](modules/types.md#verificationremovebody), [`MESSAGE_TYPE_VERIFICATION_REMOVE`](enums/protobufs.MessageType.md#message_type_verification_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
@@ -725,39 +444,5 @@ await client.submitMessage(message)
 #### Returns
 
 `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`VerificationRemoveBody`](modules/types.md#verificationremovebody), [`MESSAGE_TYPE_VERIFICATION_REMOVE`](enums/protobufs.MessageType.md#message_type_verification_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
-
-___
-
-### makeVerificationRemoveData
-
-▸ **makeVerificationRemoveData**(`bodyJson`, `dataOptions`): `HubResult`<[`MessageData`](modules/types.md#messagedata)<[`VerificationRemoveBody`](modules/types.md#verificationremovebody), [`MESSAGE_TYPE_VERIFICATION_REMOVE`](enums/protobufs.MessageType.md#message_type_verification_remove)\>\>
-
-TODO DOCS: description
-
-TODO DOCS: usage example, here's the structure:
-
-**`Example`**
-
-```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-
-const message = makeCastAdd(...)
-await client.submitMessage(message)
-```
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`VerificationRemoveBody`](modules/types.md#verificationremovebody) |
-| `dataOptions` | `MessageDataOptions` |
-
-#### Returns
-
-`HubResult`<[`MessageData`](modules/types.md#messagedata)<[`VerificationRemoveBody`](modules/types.md#verificationremovebody), [`MESSAGE_TYPE_VERIFICATION_REMOVE`](enums/protobufs.MessageType.md#message_type_verification_remove)\>\>
 
 ...

--- a/packages/js/src/builders.ts
+++ b/packages/js/src/builders.ts
@@ -426,20 +426,64 @@ export const makeReactionRemoveData = buildMakeMessageDataMethod(
 /**
  * TODO DOCS: description
  *
- * TODO DOCS: usage example, here's the structure:
  * @example
  * ```typescript
- * import { ... } from '@farcaster/js';
+ *  import {
+ *   Client,
+ *   Ed25519Signer,
+ *   Eip712Signer,
+ *   makeVerificationAddEthAddress,
+ *   types,
+ * } from "@farcaster/js";
+ * import { ethers } from "ethers";
+ * import * as ed from "@noble/ed25519";
  *
- * const client = new Client(...)
+ * const rpcUrl = "<rpc-url>";
+ * const client = new Client(rpcUrl);
  *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
+ * const privateKey = ed.utils.randomPrivateKey();
+ * const privateKeyHex = ed.utils.bytesToHex(privateKey);
+ * console.log(privateKeyHex); // 86be7f6f8dcf18...
+ * // developers should safely store this EdDSA private key on behalf of users
+ *
+ * // _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+ * const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+ *
+ * const mnemonic = "your mnemonic apple orange banana ...";
+ * const wallet = ethers.Wallet.fromMnemonic(mnemonic);
+ *
+ * // _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+ * const eip712Signer = Eip712Signer.fromSigner(
+ *   wallet,
+ *   wallet.address
+ * )._unsafeUnwrap();
+ *
+ * const dataOptions = {
+ *   fid: -9999, // must be changed to fid of the custody address, or else it will fail
+ *   network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+ * };
+ *
+ * const claimBody = {
+ *   fid: -1,
+ *   address: eip712Signer.signerKeyHex,
+ *   network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+ *   blockHash: "2c87468704d6b0f4c46f480dc54251de...",
+ * };
+ * const ethSig = await eip712Signer.signVerificationEthAddressClaimHex(claimBody);
+ *
+ * const verificationBody = {
+ *   address: eip712Signer.signerKeyHex,
+ *   signature: ethSig._unsafeUnwrap(),
+ *   blockHash: "2c87468704d6b0f4c46f480dc54251de...",
+ * };
+ *
+ * const verificationMessage = await makeVerificationAddEthAddress(
+ *   verificationBody,
+ *   dataOptions,
+ *   ed25519Signer
+ * );
+ * await client.submitMessage(verificationMessage._unsafeUnwrap());
  * ```
- *
- * @param ...
- *
- * @returns ...
  */
 export const makeVerificationAddEthAddress = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS,
@@ -450,20 +494,55 @@ export const makeVerificationAddEthAddress = buildMakeMessageMethod(
 /**
  * TODO DOCS: description
  *
- * TODO DOCS: usage example, here's the structure:
  * @example
  * ```typescript
- * import { ... } from '@farcaster/js';
+ * import {
+ *   Client,
+ *   Ed25519Signer,
+ *   Eip712Signer,
+ *   makeVerificationRemove,
+ *   types,
+ * } from "@farcaster/js";
+ * import { ethers } from "ethers";
+ * import * as ed from "@noble/ed25519";
  *
- * const client = new Client(...)
+ * const rpcUrl = "<rpc-url>";
+ * const client = new Client(rpcUrl);
  *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
+ * const privateKey = ed.utils.randomPrivateKey();
+ * const privateKeyHex = ed.utils.bytesToHex(privateKey);
+ * console.log(privateKeyHex); // 86be7f6f8dcf18...
+ * // developers should safely store this EdDSA private key on behalf of users
+ *
+ * // _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+ * const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+ *
+ * const mnemonic = "your mnemonic apple orange banana ...";
+ * const wallet = ethers.Wallet.fromMnemonic(mnemonic);
+ *
+ * // _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+ * const eip712Signer = Eip712Signer.fromSigner(
+ *   wallet,
+ *   wallet.address
+ * )._unsafeUnwrap();
+ *
+ * const dataOptions = {
+ *   fid: -9999, // must be changed to fid of the custody address, or else it will fail
+ *   network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+ * };
+ *
+ * const verificationRemoveBody = {
+ *   address: eip712Signer.signerKeyHex,
+ * };
+ *
+ * const verificationRemoveMessage = await makeVerificationRemove(
+ *   verificationRemoveBody,
+ *   dataOptions,
+ *   ed25519Signer
+ * );
+ *
+ * await client.submitMessage(verificationRemoveMessage._unsafeUnwrap());
  * ```
- *
- * @param ...
- *
- * @returns ...
  */
 export const makeVerificationRemove = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_VERIFICATION_REMOVE,
@@ -529,22 +608,39 @@ export const makeSignerAdd = buildMakeMessageMethod(
 );
 
 /**
- * TODO DOCS: description
+ * Make a message to remove an EdDSA signer
  *
- * TODO DOCS: usage example, here's the structure:
  * @example
  * ```typescript
- * import { ... } from '@farcaster/js';
+ * import { Client, Ed25519Signer, Eip712Signer, makeSignerAdd, types } from '@farcaster/js';
+ * import { ethers } from 'ethers';
+ * import * as ed from '@noble/ed25519';
  *
- * const client = new Client(...)
+ * const rpcUrl = '<rpc-url>';
+ * const client = new Client(rpcUrl);
  *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
+ * const privateKey = ed.utils.randomPrivateKey();
+ * const privateKeyHex = ed.utils.bytesToHex(privateKey);
+ * console.log(privateKeyHex); // 86be7f6f8dcf18...
+ * // developers should safely store this EdDSA private key on behalf of users
+ *
+ * // _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+ * const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+ *
+ * const mnemonic = 'your mnemonic apple orange banana ...';
+ * const wallet = ethers.Wallet.fromMnemonic(mnemonic);
+ *
+ * // _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+ * const eip712Signer = Eip712Signer.fromSigner(wallet, wallet.address)._unsafeUnwrap();
+ *
+ * const dataOptions = {
+ *   fid: -9999, // must be changed to fid of the custody address, or else it will fail
+ *   network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+ * };
+ *
+ * const signerRemove = await makeSignerRemove({ signer: ed25519Signer.signerKeyHex }, dataOptions, eip712Signer);
+ * await client.submitMessage(signerRemove._unsafeUnwrap());
  * ```
- *
- * @param ...
- *
- * @returns ...
  */
 export const makeSignerRemove = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_SIGNER_REMOVE,

--- a/packages/js/src/builders.ts
+++ b/packages/js/src/builders.ts
@@ -292,48 +292,14 @@ export const makeCastRemove = buildMakeMessageMethod(
   utils.serializeCastRemoveBody
 );
 
-/**
- * TODO DOCS: description
- *
- * TODO DOCS: usage example, here's the structure:
- * @example
- * ```typescript
- * import { ... } from '@farcaster/js';
- *
- * const client = new Client(...)
- *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
- * ```
- *
- * @param ...
- *
- * @returns ...
- */
+/** @ignore */
 export const makeCastAddData = buildMakeMessageDataMethod(
   protobufs.MessageType.MESSAGE_TYPE_CAST_ADD,
   'castAddBody',
   utils.serializeCastAddBody
 );
 
-/**
- * TODO DOCS: description
- *
- * TODO DOCS: usage example, here's the structure:
- * @example
- * ```typescript
- * import { ... } from '@farcaster/js';
- *
- * const client = new Client(...)
- *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
- * ```
- *
- * @param ...
- *
- * @returns ...
- */
+/** @ignore */
 export const makeCastRemoveData = buildMakeMessageDataMethod(
   protobufs.MessageType.MESSAGE_TYPE_CAST_REMOVE,
   'castRemoveBody',
@@ -390,48 +356,14 @@ export const makeReactionRemove = buildMakeMessageMethod(
   utils.serializeReactionBody
 );
 
-/**
- * TODO DOCS: description
- *
- * TODO DOCS: usage example, here's the structure:
- * @example
- * ```typescript
- * import { ... } from '@farcaster/js';
- *
- * const client = new Client(...)
- *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
- * ```
- *
- * @param ...
- *
- * @returns ...
- */
+/** @ignore */
 export const makeReactionAddData = buildMakeMessageDataMethod(
   protobufs.MessageType.MESSAGE_TYPE_REACTION_ADD,
   'reactionBody',
   utils.serializeReactionBody
 );
 
-/**
- * TODO DOCS: description
- *
- * TODO DOCS: usage example, here's the structure:
- * @example
- * ```typescript
- * import { ... } from '@farcaster/js';
- *
- * const client = new Client(...)
- *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
- * ```
- *
- * @param ...
- *
- * @returns ...
- */
+/** @ignore */
 export const makeReactionRemoveData = buildMakeMessageDataMethod(
   protobufs.MessageType.MESSAGE_TYPE_REACTION_REMOVE,
   'reactionBody',
@@ -488,48 +420,14 @@ export const makeVerificationRemove = buildMakeMessageMethod(
   utils.serializeVerificationRemoveBody
 );
 
-/**
- * TODO DOCS: description
- *
- * TODO DOCS: usage example, here's the structure:
- * @example
- * ```typescript
- * import { ... } from '@farcaster/js';
- *
- * const client = new Client(...)
- *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
- * ```
- *
- * @param ...
- *
- * @returns ...
- */
+/** @ignore */
 export const makeVerificationAddEthAddressData = buildMakeMessageDataMethod(
   protobufs.MessageType.MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS,
   'verificationAddEthAddressBody',
   utils.serializeVerificationAddEthAddressBody
 );
 
-/**
- * TODO DOCS: description
- *
- * TODO DOCS: usage example, here's the structure:
- * @example
- * ```typescript
- * import { ... } from '@farcaster/js';
- *
- * const client = new Client(...)
- *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
- * ```
- *
- * @param ...
- *
- * @returns ...
- */
+/** @ignore */
 export const makeVerificationRemoveData = buildMakeMessageDataMethod(
   protobufs.MessageType.MESSAGE_TYPE_VERIFICATION_REMOVE,
   'verificationRemoveBody',
@@ -586,48 +484,14 @@ export const makeSignerRemove = buildMakeMessageMethod(
   utils.serializeSignerBody
 );
 
-/**
- * TODO DOCS: description
- *
- * TODO DOCS: usage example, here's the structure:
- * @example
- * ```typescript
- * import { ... } from '@farcaster/js';
- *
- * const client = new Client(...)
- *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
- * ```
- *
- * @param ...
- *
- * @returns ...
- */
+/** @ignore */
 export const makeSignerAddData = buildMakeMessageDataMethod(
   protobufs.MessageType.MESSAGE_TYPE_SIGNER_ADD,
   'signerBody',
   utils.serializeSignerBody
 );
 
-/**
- * TODO DOCS: description
- *
- * TODO DOCS: usage example, here's the structure:
- * @example
- * ```typescript
- * import { ... } from '@farcaster/js';
- *
- * const client = new Client(...)
- *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
- * ```
- *
- * @param ...
- *
- * @returns ...
- */
+/** @ignore */
 export const makeSignerRemoveData = buildMakeMessageDataMethod(
   protobufs.MessageType.MESSAGE_TYPE_SIGNER_REMOVE,
   'signerBody',
@@ -660,24 +524,7 @@ export const makeUserDataAdd = buildMakeMessageMethod(
   utils.serializeUserDataBody
 );
 
-/**
- * TODO DOCS: description
- *
- * TODO DOCS: usage example, here's the structure:
- * @example
- * ```typescript
- * import { ... } from '@farcaster/js';
- *
- * const client = new Client(...)
- *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
- * ```
- *
- * @param ...
- *
- * @returns ...
- */
+/** @ignore */
 export const makeUserDataAddData = buildMakeMessageDataMethod(
   protobufs.MessageType.MESSAGE_TYPE_USER_DATA_ADD,
   'userDataBody',

--- a/packages/js/src/builders.ts
+++ b/packages/js/src/builders.ts
@@ -257,10 +257,6 @@ export const makeMessageWithSignature = async (
  * const cast = await makeCastAdd({ text: 'hello world' }, dataOptions, ed25519Signer);
  * await client.submitMessage(cast._unsafeUnwrap());
  * ```
- *
- * @param ...
- *
- * @returns ...
  */
 export const makeCastAdd = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_CAST_ADD,
@@ -269,22 +265,37 @@ export const makeCastAdd = buildMakeMessageMethod(
 );
 
 /**
- * TODO DOCS: description
+ * Make a message to remove a cast
  *
- * TODO DOCS: usage example, here's the structure:
  * @example
  * ```typescript
- * import { ... } from '@farcaster/js';
+ * import {
+ *   Client,
+ *   Ed25519Signer,
+ *   makeCastAdd,
+ *   makeCastRemove,
+ *   types,
+ * } from '@farcaster/js';
+ * import * as ed from '@noble/ed25519';
  *
- * const client = new Client(...)
+ * const rpcUrl = '<rpc-url>';
+ * const client = new Client(rpcUrl);
  *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
+ * const privateKeyHex = '86be7f6f8dcf18...'; // EdDSA hex private key
+ * const privateKey = ed.utils.hexToBytes(privateKeyHex);
+ *
+ * // _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+ * const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+ *
+ * const dataOptions = {
+ *   fid: -9999, // must be changed to fid of the custody address, or else it will fail
+ *   network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+ * };
+ *
+ * const removeBody = { targetHash: '0xf88d738eb7145f4cea40fbe8f3bdf...' };
+ * const castRemove = await makeCastRemove(removeBody, dataOptions, ed25519Signer);
+ * await client.submitMessage(castRemove._unsafeUnwrap());
  * ```
- *
- * @param ...
- *
- * @returns ...
  */
 export const makeCastRemove = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_CAST_REMOVE,
@@ -309,22 +320,42 @@ export const makeCastRemoveData = buildMakeMessageDataMethod(
 /** Amp Methods */
 
 /**
- * TODO DOCS: description
+ * Make a message to react a cast (like or recast)
  *
- * TODO DOCS: usage example, here's the structure:
  * @example
  * ```typescript
- * import { ... } from '@farcaster/js';
+ * import {
+ *   Client,
+ *   Ed25519Signer,
+ *   makeCastAdd,
+ *   makeCastRemove,
+ *   types,
+ * } from '@farcaster/js';
+ * import * as ed from '@noble/ed25519';
  *
- * const client = new Client(...)
+ * const rpcUrl = '<rpc-url>';
+ * const client = new Client(rpcUrl);
  *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
+ * const privateKeyHex = '86be7f6f8dcf18...'; // EdDSA hex private key
+ * const privateKey = ed.utils.hexToBytes(privateKeyHex);
+ *
+ * // _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+ * const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+ *
+ * const dataOptions = {
+ *   fid: -9999, // must be changed to fid of the custody address, or else it will fail
+ *   network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+ * };
+ *
+ * // fid here is the fid of the author of the cast
+ * const reactionLikeBody = {
+ *   type: types.ReactionType.REACTION_TYPE_LIKE,
+ *   target: { fid: -9998, tsHash: '0x455a6caad5dfd4d...' },
+ * };
+ *
+ * const like = await makeReactionAdd(reactionLikeBody, dataOptions, ed25519Signer);
+ * await client.submitMessage(like._unsafeUnwrap());
  * ```
- *
- * @param ...
- *
- * @returns ...
  */
 export const makeReactionAdd = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_REACTION_ADD,
@@ -333,22 +364,42 @@ export const makeReactionAdd = buildMakeMessageMethod(
 );
 
 /**
- * TODO DOCS: description
+ * Make a message to undo a reaction to a cast (unlike or undo recast)
  *
- * TODO DOCS: usage example, here's the structure:
  * @example
  * ```typescript
- * import { ... } from '@farcaster/js';
+ * import {
+ *   Client,
+ *   Ed25519Signer,
+ *   makeCastAdd,
+ *   makeCastRemove,
+ *   types,
+ * } from '@farcaster/js';
+ * import * as ed from '@noble/ed25519';
  *
- * const client = new Client(...)
+ * const rpcUrl = '<rpc-url>';
+ * const client = new Client(rpcUrl);
  *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
+ * const privateKeyHex = '86be7f6f8dcf18...'; // EdDSA hex private key
+ * const privateKey = ed.utils.hexToBytes(privateKeyHex);
+ *
+ * // _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+ * const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+ *
+ * const dataOptions = {
+ *   fid: -9999, // must be changed to fid of the custody address, or else it will fail
+ *   network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+ * };
+ *
+ * // fid here is the fid of the author of the cast
+ * const reactionLikeBody = {
+ *   type: types.ReactionType.REACTION_TYPE_LIKE,
+ *   target: { fid: -9998, tsHash: '0x455a6caad5dfd4d...' },
+ * };
+ *
+ * const unlike = await makeReactionRemove(reactionLikeBody, dataOptions, ed25519Signer);
+ * await client.submitMessage(unlike._unsafeUnwrap());
  * ```
- *
- * @param ...
- *
- * @returns ...
  */
 export const makeReactionRemove = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_REACTION_REMOVE,
@@ -437,22 +488,39 @@ export const makeVerificationRemoveData = buildMakeMessageDataMethod(
 /** Signer Methods */
 
 /**
- * TODO DOCS: description
+ * Make a message to add an EdDSA signer
  *
- * TODO DOCS: usage example, here's the structure:
  * @example
  * ```typescript
- * import { ... } from '@farcaster/js';
+ * import { Client, Ed25519Signer, Eip712Signer, makeSignerAdd, types } from '@farcaster/js';
+ * import { ethers } from 'ethers';
+ * import * as ed from '@noble/ed25519';
  *
- * const client = new Client(...)
+ * const rpcUrl = '<rpc-url>';
+ * const client = new Client(rpcUrl);
  *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
+ * const privateKey = ed.utils.randomPrivateKey();
+ * const privateKeyHex = ed.utils.bytesToHex(privateKey);
+ * console.log(privateKeyHex); // 86be7f6f8dcf18...
+ * // developers should safely store this EdDSA private key on behalf of users
+ *
+ * // _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+ * const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+ *
+ * const mnemonic = 'your mnemonic apple orange banana ...';
+ * const wallet = ethers.Wallet.fromMnemonic(mnemonic);
+ *
+ * // _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+ * const eip712Signer = Eip712Signer.fromSigner(wallet, wallet.address)._unsafeUnwrap();
+ *
+ * const dataOptions = {
+ *   fid: -9999, // must be changed to fid of the custody address, or else it will fail
+ *   network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+ * };
+ *
+ * const signerAdd = await makeSignerAdd({ signer: ed25519Signer.signerKeyHex }, dataOptions, eip712Signer);
+ * await client.submitMessage(signerAdd._unsafeUnwrap());
  * ```
- *
- * @param ...
- *
- * @returns ...
  */
 export const makeSignerAdd = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_SIGNER_ADD,
@@ -501,22 +569,40 @@ export const makeSignerRemoveData = buildMakeMessageDataMethod(
 /** User Data Methods */
 
 /**
- * TODO DOCS: description
+ * Make a message to set user data (pfp, bio, display name, etc)
  *
- * TODO DOCS: usage example, here's the structure:
  * @example
  * ```typescript
- * import { ... } from '@farcaster/js';
+ * import {
+ *   Client,
+ *   Ed25519Signer,
+ *   makeCastAdd,
+ *   makeCastRemove,
+ *   types,
+ * } from '@farcaster/js';
+ * import * as ed from '@noble/ed25519';
  *
- * const client = new Client(...)
+ * const rpcUrl = '<rpc-url>';
+ * const client = new Client(rpcUrl);
  *
- * const message = makeCastAdd(...)
- * await client.submitMessage(message)
+ * const privateKeyHex = '86be7f6f8dcf18...'; // EdDSA hex private key
+ * const privateKey = ed.utils.hexToBytes(privateKeyHex);
+ *
+ * // _unsafeUnwrap() is used here for simplicity, but should be avoided in production
+ * const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+ *
+ * const dataOptions = {
+ *   fid: -9999, // must be changed to fid of the custody address, or else it will fail
+ *   network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
+ * };
+ *
+ * const userDataPfpBody = {
+ *   type: types.UserDataType.USER_DATA_TYPE_PFP,
+ *   value: 'https://i.imgur.com/yed5Zfk.gif',
+ * };
+ * const userDataPfpAdd = await makeUserDataAdd(userDataPfpBody, dataOptions, ed25519Signer);
+ * await client.submitMessage(userDataPfpAdd._unsafeUnwrap());
  * ```
- *
- * @param ...
- *
- * @returns ...
  */
 export const makeUserDataAdd = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_USER_DATA_ADD,


### PR DESCRIPTION
## Motivation

Continue documenting the JS package. See: https://github.com/vinliao/hubble/blob/md-docs-2/packages/js/docs/modules.md#functions

## Change Summary

Added a bunch of TSDoc comments on `builders.ts` and generated docs with `yarn docs`. Removed all "Data" functions (stuffs that end with "data").

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

Wondering if `makeMessageHash` and `makeMessageHashWithSignature` should be ignored in the docs because it seems to be a low-level utility function that JS devs won't touch.
