### PR TITLE
chore: bump changeset versions

### DIFF
--- a/.changeset/great-eagles-explain.md
+++ b/.changeset/great-eagles-explain.md
@@ -1,7 +1,0 @@
----
-'@farcaster/protobufs': patch
-'@farcaster/utils': patch
-'@farcaster/js': patch
----
-
-add fromId to SubscribeRequest protobuf and subscribe gRPC method

--- a/.changeset/hot-pigs-wave.md
+++ b/.changeset/hot-pigs-wave.md
@@ -1,7 +1,0 @@
----
-'@farcaster/protobufs': patch
-'@farcaster/utils': patch
-'@farcaster/js': patch
----
-
-add HubEvent protobuf and types

--- a/.changeset/poor-bears-thank.md
+++ b/.changeset/poor-bears-thank.md
@@ -1,6 +1,0 @@
----
-'@farcaster/protobufs': patch
-'@farcaster/utils': patch
----
-
-remove UserData location type

--- a/apps/hubble/CHANGELOG.md
+++ b/apps/hubble/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @farcaster/hubble
 
+## 1.0.10
+
+### Patch Changes
+
+- Updated dependencies [d04d5d4a]
+- Updated dependencies [4056b5d4]
+- Updated dependencies [22a9d460]
+  - @farcaster/protobufs@0.1.6
+  - @farcaster/utils@0.2.7
+
 ## 1.0.9
 
 ### Patch Changes

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/hubble",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Farcaster Hub",
   "author": "",
   "license": "",
@@ -46,8 +46,8 @@
   "dependencies": {
     "@chainsafe/libp2p-gossipsub": "6.1.0",
     "@chainsafe/libp2p-noise": "^11.0.0 ",
-    "@farcaster/protobufs": "0.1.5",
-    "@farcaster/utils": "0.2.6",
+    "@farcaster/protobufs": "0.1.6",
+    "@farcaster/utils": "0.2.7",
     "@grpc/grpc-js": "~1.8.7",
     "@libp2p/interface-connection": "^3.0.2",
     "@libp2p/interface-peer-id": "^2.0.0",

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @farcaster/js
 
+## 0.2.7
+
+### Patch Changes
+
+- d04d5d4a: add fromId to SubscribeRequest protobuf and subscribe gRPC method
+- 4056b5d4: add HubEvent protobuf and types
+- Updated dependencies [d04d5d4a]
+- Updated dependencies [4056b5d4]
+- Updated dependencies [22a9d460]
+  - @farcaster/protobufs@0.1.6
+  - @farcaster/utils@0.2.7
+
 ## 0.2.6
 
 ### Patch Changes

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/js",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -16,8 +16,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@farcaster/protobufs": "0.1.5",
-    "@farcaster/utils": "0.2.6",
+    "@farcaster/protobufs": "0.1.6",
+    "@farcaster/utils": "0.2.7",
     "@noble/hashes": "^1.2.0",
     "ethers": "^5.7.2",
     "neverthrow": "^6.0.0"

--- a/packages/protobufs/CHANGELOG.md
+++ b/packages/protobufs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @farcaster/protobufs
 
+## 0.1.6
+
+### Patch Changes
+
+- d04d5d4a: add fromId to SubscribeRequest protobuf and subscribe gRPC method
+- 4056b5d4: add HubEvent protobuf and types
+- 22a9d460: remove UserData location type
+
 ## 0.1.5
 
 ### Patch Changes

--- a/packages/protobufs/package.json
+++ b/packages/protobufs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/protobufs",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @farcaster/utils
 
+## 0.2.7
+
+### Patch Changes
+
+- d04d5d4a: add fromId to SubscribeRequest protobuf and subscribe gRPC method
+- 4056b5d4: add HubEvent protobuf and types
+- 22a9d460: remove UserData location type
+- Updated dependencies [d04d5d4a]
+- Updated dependencies [4056b5d4]
+- Updated dependencies [22a9d460]
+  - @farcaster/protobufs@0.1.6
+
 ## 0.2.6
 
 ### Patch Changes

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@farcaster/utils",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@faker-js/faker": "^7.6.0",
-    "@farcaster/protobufs": "0.1.5",
+    "@farcaster/protobufs": "0.1.6",
     "@noble/ed25519": "^1.7.1",
     "@noble/hashes": "^1.2.0",
     "ethers": "^5.7.2",


### PR DESCRIPTION
## Motivation

Since we have removed amps and location for UserData, we want to ensure our types on the backend are up to date.

## Change Summary

Ran `yarn changeset version`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
