### PR TITLE
chore: Remove unspecified/unrecognized enum values from generated types

### DIFF
--- a/.changeset/orange-falcons-reply.md
+++ b/.changeset/orange-falcons-reply.md
@@ -1,0 +1,6 @@
+---
+'@farcaster/protobufs': minor
+'@farcaster/js': patch
+---
+
+Remove unspecified/unrecognized enum values from generated types

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -1,32 +1,30 @@
 import * as protobufs from '@farcaster/protobufs';
 
-export {
-  FarcasterNetwork,
-  HashScheme,
-  MessageType,
-  ReactionType,
-  SignatureScheme,
-  UserDataType,
-} from '@farcaster/protobufs';
 export type { VerificationEthAddressClaim } from '@farcaster/utils';
+
+export type HashScheme = Exclude<protobufs.HashScheme, protobufs.HashScheme.HASH_SCHEME_NONE>;
+export type SignatureScheme = Exclude<protobufs.SignatureScheme, protobufs.SignatureScheme.SIGNATURE_SCHEME_NONE>;
 
 export type Message<TData = MessageData> = Readonly<{
   _protobuf: protobufs.Message;
   data: TData;
   hash: string; // Hex string
-  hashScheme: protobufs.HashScheme;
+  hashScheme: HashScheme;
   signature: string; // Hex string
-  signatureScheme: protobufs.SignatureScheme;
+  signatureScheme: SignatureScheme;
   signer: string; // Hex string
 }>;
 
-export type MessageData<TBody = MessageBody, TType = protobufs.MessageType> = {
+export type MessageType = Exclude<protobufs.MessageType, protobufs.MessageType.MESSAGE_TYPE_NONE>;
+export type FarcasterNetwork = Exclude<protobufs.FarcasterNetwork, protobufs.FarcasterNetwork.FARCASTER_NETWORK_NONE>;
+
+export type MessageData<TBody = MessageBody, TType = MessageType> = {
   _protobuf: protobufs.MessageData;
   body: TBody;
   type: TType;
   timestamp: number;
   fid: number;
-  network: protobufs.FarcasterNetwork;
+  network: FarcasterNetwork;
 };
 
 export type CastAddData = MessageData<CastAddBody, protobufs.MessageType.MESSAGE_TYPE_CAST_ADD>;
@@ -81,9 +79,11 @@ export type CastRemoveBody = {
   targetHash: string;
 };
 
+export type ReactionType = Exclude<protobufs.ReactionType, protobufs.ReactionType.REACTION_TYPE_NONE>;
+
 export type ReactionBody = {
   target: CastId;
-  type: protobufs.ReactionType;
+  type: ReactionType;
 };
 
 export type AmpBody = {
@@ -104,8 +104,10 @@ export type SignerBody = {
   signer: string; // Hex string
 };
 
+export type UserDataType = Exclude<protobufs.UserDataType, protobufs.UserDataType.USER_DATA_TYPE_NONE>;
+
 export type UserDataBody = {
-  type: protobufs.UserDataType;
+  type: UserDataType;
   value: string;
 };
 

--- a/packages/protobufs/package.json
+++ b/packages/protobufs/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "clean": "rimraf ./dist",
-    "protoc": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/generated/ --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputServices=grpc-js,useOptionals=none --proto_path=./src/schemas ./src/schemas/*",
+    "protoc": "protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_out=./src/generated/ --ts_proto_opt=esModuleInterop=true,exportCommonSymbols=false,outputServices=grpc-js,useOptionals=none,unrecognizedEnum=false --proto_path=./src/schemas ./src/schemas/*",
     "lint": "eslint  src/ --color --ext .ts",
     "lint:fix": "yarn run lint -- --fix",
     "prepublishOnly": "yarn run build"

--- a/packages/protobufs/src/generated/gossip.ts
+++ b/packages/protobufs/src/generated/gossip.ts
@@ -5,7 +5,6 @@ import { Message } from "./message";
 
 export enum GossipVersion {
   GOSSIP_VERSION_1 = 0,
-  UNRECOGNIZED = -1,
 }
 
 export function gossipVersionFromJSON(object: any): GossipVersion {
@@ -13,10 +12,8 @@ export function gossipVersionFromJSON(object: any): GossipVersion {
     case 0:
     case "GOSSIP_VERSION_1":
       return GossipVersion.GOSSIP_VERSION_1;
-    case -1:
-    case "UNRECOGNIZED":
     default:
-      return GossipVersion.UNRECOGNIZED;
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum GossipVersion");
   }
 }
 
@@ -24,9 +21,8 @@ export function gossipVersionToJSON(object: GossipVersion): string {
   switch (object) {
     case GossipVersion.GOSSIP_VERSION_1:
       return "GOSSIP_VERSION_1";
-    case GossipVersion.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum GossipVersion");
   }
 }
 

--- a/packages/protobufs/src/generated/hub_event.ts
+++ b/packages/protobufs/src/generated/hub_event.ts
@@ -12,7 +12,6 @@ export enum HubEventType {
   HUB_EVENT_TYPE_REVOKE_MESSAGE = 3,
   HUB_EVENT_TYPE_MERGE_ID_REGISTRY_EVENT = 4,
   HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT = 5,
-  UNRECOGNIZED = -1,
 }
 
 export function hubEventTypeFromJSON(object: any): HubEventType {
@@ -35,10 +34,8 @@ export function hubEventTypeFromJSON(object: any): HubEventType {
     case 5:
     case "HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT":
       return HubEventType.HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT;
-    case -1:
-    case "UNRECOGNIZED":
     default:
-      return HubEventType.UNRECOGNIZED;
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum HubEventType");
   }
 }
 
@@ -56,9 +53,8 @@ export function hubEventTypeToJSON(object: HubEventType): string {
       return "HUB_EVENT_TYPE_MERGE_ID_REGISTRY_EVENT";
     case HubEventType.HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT:
       return "HUB_EVENT_TYPE_MERGE_NAME_REGISTRY_EVENT";
-    case HubEventType.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum HubEventType");
   }
 }
 

--- a/packages/protobufs/src/generated/id_registry_event.ts
+++ b/packages/protobufs/src/generated/id_registry_event.ts
@@ -6,7 +6,6 @@ export enum IdRegistryEventType {
   ID_REGISTRY_EVENT_TYPE_NONE = 0,
   ID_REGISTRY_EVENT_TYPE_REGISTER = 1,
   ID_REGISTRY_EVENT_TYPE_TRANSFER = 2,
-  UNRECOGNIZED = -1,
 }
 
 export function idRegistryEventTypeFromJSON(object: any): IdRegistryEventType {
@@ -20,10 +19,8 @@ export function idRegistryEventTypeFromJSON(object: any): IdRegistryEventType {
     case 2:
     case "ID_REGISTRY_EVENT_TYPE_TRANSFER":
       return IdRegistryEventType.ID_REGISTRY_EVENT_TYPE_TRANSFER;
-    case -1:
-    case "UNRECOGNIZED":
     default:
-      return IdRegistryEventType.UNRECOGNIZED;
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum IdRegistryEventType");
   }
 }
 
@@ -35,9 +32,8 @@ export function idRegistryEventTypeToJSON(object: IdRegistryEventType): string {
       return "ID_REGISTRY_EVENT_TYPE_REGISTER";
     case IdRegistryEventType.ID_REGISTRY_EVENT_TYPE_TRANSFER:
       return "ID_REGISTRY_EVENT_TYPE_TRANSFER";
-    case IdRegistryEventType.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum IdRegistryEventType");
   }
 }
 

--- a/packages/protobufs/src/generated/message.ts
+++ b/packages/protobufs/src/generated/message.ts
@@ -7,7 +7,6 @@ export enum HashScheme {
   HASH_SCHEME_NONE = 0,
   /** HASH_SCHEME_BLAKE3 - Default scheme for hashing MessageData */
   HASH_SCHEME_BLAKE3 = 1,
-  UNRECOGNIZED = -1,
 }
 
 export function hashSchemeFromJSON(object: any): HashScheme {
@@ -18,10 +17,8 @@ export function hashSchemeFromJSON(object: any): HashScheme {
     case 1:
     case "HASH_SCHEME_BLAKE3":
       return HashScheme.HASH_SCHEME_BLAKE3;
-    case -1:
-    case "UNRECOGNIZED":
     default:
-      return HashScheme.UNRECOGNIZED;
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum HashScheme");
   }
 }
 
@@ -31,9 +28,8 @@ export function hashSchemeToJSON(object: HashScheme): string {
       return "HASH_SCHEME_NONE";
     case HashScheme.HASH_SCHEME_BLAKE3:
       return "HASH_SCHEME_BLAKE3";
-    case HashScheme.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum HashScheme");
   }
 }
 
@@ -44,7 +40,6 @@ export enum SignatureScheme {
   SIGNATURE_SCHEME_ED25519 = 1,
   /** SIGNATURE_SCHEME_EIP712 - ECDSA signature using EIP-712 scheme */
   SIGNATURE_SCHEME_EIP712 = 2,
-  UNRECOGNIZED = -1,
 }
 
 export function signatureSchemeFromJSON(object: any): SignatureScheme {
@@ -58,10 +53,8 @@ export function signatureSchemeFromJSON(object: any): SignatureScheme {
     case 2:
     case "SIGNATURE_SCHEME_EIP712":
       return SignatureScheme.SIGNATURE_SCHEME_EIP712;
-    case -1:
-    case "UNRECOGNIZED":
     default:
-      return SignatureScheme.UNRECOGNIZED;
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum SignatureScheme");
   }
 }
 
@@ -73,9 +66,8 @@ export function signatureSchemeToJSON(object: SignatureScheme): string {
       return "SIGNATURE_SCHEME_ED25519";
     case SignatureScheme.SIGNATURE_SCHEME_EIP712:
       return "SIGNATURE_SCHEME_EIP712";
-    case SignatureScheme.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum SignatureScheme");
   }
 }
 
@@ -100,7 +92,6 @@ export enum MessageType {
   MESSAGE_TYPE_SIGNER_REMOVE = 10,
   /** MESSAGE_TYPE_USER_DATA_ADD - Add metadata about a user */
   MESSAGE_TYPE_USER_DATA_ADD = 11,
-  UNRECOGNIZED = -1,
 }
 
 export function messageTypeFromJSON(object: any): MessageType {
@@ -135,10 +126,8 @@ export function messageTypeFromJSON(object: any): MessageType {
     case 11:
     case "MESSAGE_TYPE_USER_DATA_ADD":
       return MessageType.MESSAGE_TYPE_USER_DATA_ADD;
-    case -1:
-    case "UNRECOGNIZED":
     default:
-      return MessageType.UNRECOGNIZED;
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
 }
 
@@ -164,9 +153,8 @@ export function messageTypeToJSON(object: MessageType): string {
       return "MESSAGE_TYPE_SIGNER_REMOVE";
     case MessageType.MESSAGE_TYPE_USER_DATA_ADD:
       return "MESSAGE_TYPE_USER_DATA_ADD";
-    case MessageType.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum MessageType");
   }
 }
 
@@ -179,7 +167,6 @@ export enum FarcasterNetwork {
   FARCASTER_NETWORK_TESTNET = 2,
   /** FARCASTER_NETWORK_DEVNET - Private test network */
   FARCASTER_NETWORK_DEVNET = 3,
-  UNRECOGNIZED = -1,
 }
 
 export function farcasterNetworkFromJSON(object: any): FarcasterNetwork {
@@ -196,10 +183,8 @@ export function farcasterNetworkFromJSON(object: any): FarcasterNetwork {
     case 3:
     case "FARCASTER_NETWORK_DEVNET":
       return FarcasterNetwork.FARCASTER_NETWORK_DEVNET;
-    case -1:
-    case "UNRECOGNIZED":
     default:
-      return FarcasterNetwork.UNRECOGNIZED;
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum FarcasterNetwork");
   }
 }
 
@@ -213,9 +198,8 @@ export function farcasterNetworkToJSON(object: FarcasterNetwork): string {
       return "FARCASTER_NETWORK_TESTNET";
     case FarcasterNetwork.FARCASTER_NETWORK_DEVNET:
       return "FARCASTER_NETWORK_DEVNET";
-    case FarcasterNetwork.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum FarcasterNetwork");
   }
 }
 
@@ -232,7 +216,6 @@ export enum UserDataType {
   USER_DATA_TYPE_URL = 5,
   /** USER_DATA_TYPE_FNAME - Preferred Farcaster Name for the user */
   USER_DATA_TYPE_FNAME = 6,
-  UNRECOGNIZED = -1,
 }
 
 export function userDataTypeFromJSON(object: any): UserDataType {
@@ -255,10 +238,8 @@ export function userDataTypeFromJSON(object: any): UserDataType {
     case 6:
     case "USER_DATA_TYPE_FNAME":
       return UserDataType.USER_DATA_TYPE_FNAME;
-    case -1:
-    case "UNRECOGNIZED":
     default:
-      return UserDataType.UNRECOGNIZED;
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
 }
 
@@ -276,9 +257,8 @@ export function userDataTypeToJSON(object: UserDataType): string {
       return "USER_DATA_TYPE_URL";
     case UserDataType.USER_DATA_TYPE_FNAME:
       return "USER_DATA_TYPE_FNAME";
-    case UserDataType.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum UserDataType");
   }
 }
 
@@ -289,7 +269,6 @@ export enum ReactionType {
   REACTION_TYPE_LIKE = 1,
   /** REACTION_TYPE_RECAST - Share target cast to the user's audience */
   REACTION_TYPE_RECAST = 2,
-  UNRECOGNIZED = -1,
 }
 
 export function reactionTypeFromJSON(object: any): ReactionType {
@@ -303,10 +282,8 @@ export function reactionTypeFromJSON(object: any): ReactionType {
     case 2:
     case "REACTION_TYPE_RECAST":
       return ReactionType.REACTION_TYPE_RECAST;
-    case -1:
-    case "UNRECOGNIZED":
     default:
-      return ReactionType.UNRECOGNIZED;
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum ReactionType");
   }
 }
 
@@ -318,9 +295,8 @@ export function reactionTypeToJSON(object: ReactionType): string {
       return "REACTION_TYPE_LIKE";
     case ReactionType.REACTION_TYPE_RECAST:
       return "REACTION_TYPE_RECAST";
-    case ReactionType.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum ReactionType");
   }
 }
 

--- a/packages/protobufs/src/generated/name_registry_event.ts
+++ b/packages/protobufs/src/generated/name_registry_event.ts
@@ -5,7 +5,6 @@ export enum NameRegistryEventType {
   NAME_REGISTRY_EVENT_TYPE_NONE = 0,
   NAME_REGISTRY_EVENT_TYPE_TRANSFER = 1,
   NAME_REGISTRY_EVENT_TYPE_RENEW = 2,
-  UNRECOGNIZED = -1,
 }
 
 export function nameRegistryEventTypeFromJSON(object: any): NameRegistryEventType {
@@ -19,10 +18,8 @@ export function nameRegistryEventTypeFromJSON(object: any): NameRegistryEventTyp
     case 2:
     case "NAME_REGISTRY_EVENT_TYPE_RENEW":
       return NameRegistryEventType.NAME_REGISTRY_EVENT_TYPE_RENEW;
-    case -1:
-    case "UNRECOGNIZED":
     default:
-      return NameRegistryEventType.UNRECOGNIZED;
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum NameRegistryEventType");
   }
 }
 
@@ -34,9 +31,8 @@ export function nameRegistryEventTypeToJSON(object: NameRegistryEventType): stri
       return "NAME_REGISTRY_EVENT_TYPE_TRANSFER";
     case NameRegistryEventType.NAME_REGISTRY_EVENT_TYPE_RENEW:
       return "NAME_REGISTRY_EVENT_TYPE_RENEW";
-    case NameRegistryEventType.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      throw new tsProtoGlobalThis.Error("Unrecognized enum value " + object + " for enum NameRegistryEventType");
   }
 }
 

--- a/packages/utils/src/validations.ts
+++ b/packages/utils/src/validations.ts
@@ -314,6 +314,10 @@ export const validateCastRemoveBody = (body: protobufs.CastRemoveBody): HubResul
 };
 
 export const validateReactionType = (type: number): HubResult<protobufs.ReactionType> => {
+  if (type === 0) {
+    return err(new HubError('bad_request.validation_failure', 'missing reaction type'));
+  }
+
   if (!Object.values(protobufs.ReactionType).includes(type)) {
     return err(new HubError('bad_request.validation_failure', 'invalid reaction type'));
   }
@@ -322,6 +326,10 @@ export const validateReactionType = (type: number): HubResult<protobufs.Reaction
 };
 
 export const validateMessageType = (type: number): HubResult<protobufs.MessageType> => {
+  if (type === 0) {
+    return err(new HubError('bad_request.validation_failure', 'missing message type'));
+  }
+
   if (!Object.values(protobufs.MessageType).includes(type)) {
     return err(new HubError('bad_request.validation_failure', 'invalid message type'));
   }
@@ -330,6 +338,10 @@ export const validateMessageType = (type: number): HubResult<protobufs.MessageTy
 };
 
 export const validateNetwork = (network: number): HubResult<protobufs.FarcasterNetwork> => {
+  if (network === 0) {
+    return err(new HubError('bad_request.validation_failure', 'missing network'));
+  }
+
   if (!Object.values(protobufs.FarcasterNetwork).includes(network)) {
     return err(new HubError('bad_request.validation_failure', 'invalid network'));
   }
@@ -375,6 +387,10 @@ export const validateSignerBody = (body: protobufs.SignerBody): HubResult<protob
 };
 
 export const validateUserDataType = (type: number): HubResult<protobufs.UserDataType> => {
+  if (type === 0) {
+    return err(new HubError('bad_request.validation_failure', 'missing user data type'));
+  }
+
   if (
     !Object.values(protobufs.UserDataType).includes(type) ||
     type === protobufs.UserDataType.USER_DATA_TYPE_NONE ||


### PR DESCRIPTION
# WIP. Looking for feedback on whether we want to continue pursuing

## Motivation

Currently, our various enums are created to look like the following:

    enum MyEnum {
      MY_ENUM_NONE = 0,
      ...
      UNRECOGNIZED = -1,
    }

The `*_NONE` exists because proto3 has a hard requirement on the first value being 0.

The `UNRECOGNIZED` value can be disabled with a flag.

We want to remove these values because it makes it easier for us to perform type narrowing in TypeScript, which makes working with the library more pleasant/convenient since TypeScript's typechecking can do more heavy lifting.

## Change Summary

We disable `UNRECOGNIZED` since it doesn't serve much practical purpose for our uses, and we export a number of types from `@farcaster/js` that explicitly excludes the `*_NONE` value from the various enums we reference.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged
