### PR TITLE
docs: remove verbose types

### DIFF
--- a/hideSig.js
+++ b/hideSig.js
@@ -1,0 +1,12 @@
+/**
+ * TypeDoc plugin to hide the return type of a function signature
+ */
+const { Converter, ReflectionKind, UnknownType } = require('typedoc');
+
+exports.load = function (app) {
+  app.converter.on(Converter.EVENT_CREATE_SIGNATURE, (ctx, sig) => {
+    if (sig.kind === ReflectionKind.CallSignature) {
+      sig.type = undefined;
+    }
+  });
+};

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -19,7 +19,7 @@ yarn add @farcaster/js
 pnpm install @farcaster/js
 ```
 
-Read the [documentation](./docs/) or get started with an simple example below.
+Read the [documentation](./docs/modules.md) or get started with an simple example below.
 
 ## Quickstart
 

--- a/packages/js/docs/README.md
+++ b/packages/js/docs/README.md
@@ -21,7 +21,7 @@ yarn add @farcaster/js
 pnpm install @farcaster/js
 ```
 
-Read the [documentation](./docs/) or get started with an simple example below.
+Read the [documentation](./modules.md) or get started with an simple example below.
 
 ## Quickstart
 

--- a/packages/js/docs/README.md
+++ b/packages/js/docs/README.md
@@ -21,7 +21,7 @@ yarn add @farcaster/js
 pnpm install @farcaster/js
 ```
 
-Read the [documentation](./modules.md) or get started with an simple example below.
+Read the [documentation](./docs/modules.md) or get started with an simple example below.
 
 ## Quickstart
 

--- a/packages/js/docs/README.md
+++ b/packages/js/docs/README.md
@@ -2,199 +2,136 @@
 
 # @farcaster/js
 
-A collection of Typescript classes and methods for easily creating Farcaster messages and interacting with Farcaster hubs over gRPC.
+A simple library for Farcaster that makes it easy to create new messages and interact with hubs. Designed to work with [Hubble](https://github.com/farcasterxyz/hubble/) and any other Hub that implements the [Farcaster protocol](https://github.com/farcasterxyz/protocol).
 
-TODO DOCS: explain what protobufs are, and what this package does under the hood
+**Features**
+
+- Create and sign Farcaster messages using simple methods.
+- Use all Hub endpoints natively in Javascript, including subscriptions.
+- Converts protobufs to and from native Javascript types automatically.
+- Written entirely in TypeScript, with strict types for safety.
+
+## Installation
+
+Install @farcaster/js with the package manager of your choice
+
+```bash
+npm install @farcaster/js
+yarn add @farcaster/js
+pnpm install @farcaster/js
+```
+
+Read the [documentation](./docs/) or get started with an simple example below.
 
 ## Quickstart
 
+### Fetching Data from Hubs
+
+```typescript
+import { Client } from '@farcaster/js';
+
+(async () => {
+  // Connect to a known hub using its address of the form <ip_address>:<rpc_port>
+  const client = new Client('127.0.0.1:8080');
+
+  // Set the user whose casts we will be fetching
+  const fid = 2;
+
+  const castsResult = await client.getCastsByFid(fid);
+
+  if (castsResult.isErr()) {
+    console.log('Failed: ', castsResult.error);
+  }
+
+  castsResult.map((casts) => casts.map((c) => console.log(`${c.data.body.text}\n`)));
+})();
+```
+
+Note that functions do not throw exceptions and instead return a Result. Each Result contains a success or error value which should be handled with conditional logic. Read the [neverthrow](https://github.com/supermacro/neverthrow/blob/master/README.md) documentation to learn more about Result types.
+
+### Writing Data to Hubs
+
+If you own a Farcaster account you can also write messages and submit them to a Hubb. You'll need the mnemonic of the custody address that owns the account on the Ethereum blockchain to get started.
+
 ```bash
-npm install @farcaster/js ethers@5.7.2 @noble/ed25519
+npm install noble ethers
+yarn add noble ethers
+pnpm install noble ethers
 ```
 
-```typescript
-/* -------------------------------------------------------------------------- */
-/*                          Signer key registration                           */
-/* -------------------------------------------------------------------------- */
-
-/**
- * this package uses `neverthrow` to handle errors, that's why
- * there are things like isOk() and _unsafeUnwrap() in the code
- *
- * read more: https://github.com/supermacro/neverthrow
- */
-
-import { Client, Ed25519Signer, Eip712Signer, makeSignerAdd, types } from '@farcaster/js';
-import { ethers } from 'ethers';
-import * as ed from '@noble/ed25519';
-
-const rpcUrl = '<rpc-url>';
-const client = new Client(rpcUrl);
-
-const privateKey = ed.utils.randomPrivateKey();
-const privateKeyHex = ed.utils.bytesToHex(privateKey);
-console.log(privateKeyHex); // 86be7f6f8dcf18...
-// developers should safely store this EdDSA private key on behalf of users
-
-// _unsafeUnwrap() is used here for simplicity, but should be avoided in production
-const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
-
-const mnemonic = 'your mnemonic apple orange banana ...';
-const wallet = ethers.Wallet.fromMnemonic(mnemonic);
-
-// _unsafeUnwrap() is used here for simplicity, but should be avoided in production
-const eip712Signer = Eip712Signer.fromSigner(wallet, wallet.address)._unsafeUnwrap();
-
-// todo: could the fid value be fetched from smart contract?
-const dataOptions = {
-  fid: -9999, // must be changed to fid of the custody address, or else it will fail
-  network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
-};
-
-const signerAdd = await makeSignerAdd({ signer: ed25519Signer.signerKeyHex }, dataOptions, eip712Signer);
-
-if (signerAdd.isErr()) {
-  // handle error
-}
-
-const result = await client.submitMessage(signerAdd.value);
-
-console.log(result);
-
-/**
- * if everything goes well, it should return something like this:
- *
- *  {
- *  _protobuf: { // raw bytes },
- *  data: {
- *    _protobuf: { // raw bytes },
- *     body: {
- *    signer: '0xa1ae695cc61bedcf4787ddfe1de63640f3e3ccd2e2734f80ceb4dee27baa8aaa'
- *    },
- *    type: 9,
- *    timestamp: 1676960015000,
- *    fid: 4640,
- *    network: 3
- *  },
- *  hash: '0x7ff7a6c7a3bc86a1b03b535cefaa7c855c917f8a',
- *  hashScheme: 1,
- *  signature: '0xd5e186bee6b560af60bcb9...',
- *  signatureScheme: 2,
- *  signer: '0x86dd7e4af49829b895d24ea2ab581c7c32e87332'
- *  }
- *
- *
- * this means is the signer key was successfully added to the hub
- * and the hub will now accept messages signed by ed25519Signer above
- *
- * to read more about the signer key:
- * https://github.com/farcasterxyz/protocol#92-signers
- */
-```
+Create a new [Signer](https://github.com/farcasterxyz/protocol#92-signers) key pair and authorize it by signing it with the custody address.
 
 ```typescript
-/* -------------------------------------------------------------- */
-/*                       Interacting with hub                     */
-/* -------------------------------------------------------------- */
-
-/**
- * let us suppose we are in a brand-new file, here's how we can make
- * an ed25519Signer from a previously registered signer key
- */
-
 import {
   Client,
   Ed25519Signer,
   Eip712Signer,
+  makeCastAdd,
   makeCastRemove,
   makeReactionAdd,
   makeReactionRemove,
   makeSignerAdd,
-  makeSignerRemove,
   makeUserDataAdd,
   types,
 } from '@farcaster/js';
-
 import * as ed from '@noble/ed25519';
+import { ethers } from 'ethers';
+import * as ed from '@noble/ed25519';
+import { ethers } from 'ethers';
 
-const rpcUrl = '<rpc-url>';
-const client = new Client(rpcUrl);
+// Safety: we use unsafeUnwrap() and crash on failure in a few places, since it can't be handled
+//  any other way
 
-const privateKeyHex = '86be7f6f8dcf18...'; // EdDSA hex private key
-const privateKey = ed.utils.hexToBytes(privateKeyHex);
+// Create an EIP712 Signer with the wallet that holds the custody address of the user
+const mnemonic = 'your mnemonic apple orange banana ...'; // mnemonic for the custody address' wallet
+const wallet = ethers.Wallet.fromMnemonic(mnemonic);
+const eip712Signer = Eip712Signer.fromSigner(wallet, wallet.address)._unsafeUnwrap();
 
-// _unsafeUnwrap() is used here for simplicity, but should be avoided in production
-const ed25519Signer = Ed25519Signer.fromPrivateKey(privateKey)._unsafeUnwrap();
+// Generate a new Ed25519 key pair which will become the Signer and store the private key securely
+const signerPrivateKey = ed.utils.randomPrivateKey();
+const signerPrivateKeyHex = ed.utils.bytesToHex(signerPrivateKey);
 
-const checkSigner = await client.getSigner(-9999, ed25519Signer.signerKeyHex);
-console.log(checkSigner);
-
-/**
- * valid signer key would return an object like makeSignerAdd() above
- *
- * now that we have a valid signer key object, we can use it to interact with hubs
- *
- * the flow of interacting with hub:
- * 1. create a message with signer key (cast message, reactions message, verification message, etc)
- * 2. submit the message to the hub
- * 3. to see all the available function, see the "Functions" part below
- */
-
+// Create a SignerAdd message that contains the public key of the signer
 const dataOptions = {
-  fid: -9999, // must be changed to fid of the custody address, or else it will fail
+  fid: -9999, // Set to the fid of the user
   network: types.FarcasterNetwork.FARCASTER_NETWORK_DEVNET,
 };
+const signerAddResult = await makeSignerAdd({ signer: signerPrivateKeyHex }, dataOptions, eip712Signer);
+const signerAdd = signerAddResult._unsafeUnwrap();
 
-/* ============= make a cast ============== */
+// Submit the SignerAdd message to the Hub
+const client = new Client('127 .0.0.1:8080');
+const result = await client.submitMessage(signerAdd);
+result.isOk() ? console.log('SignerAdd was published successfully!') : console.log(result.error);
+```
+
+Once a SignerAdd is accepted the Signer can be used publish other types of Farcaster messages to a Hub, as shown below.
+
+```typescript
+const ed25519Signer = Ed25519Signer.fromPrivateKey(signerPrivateKey)._unsafeUnwrap();
+
+// Make a new cast
 const cast = await makeCastAdd({ text: 'hello world' }, dataOptions, ed25519Signer);
 await client.submitMessage(cast._unsafeUnwrap());
 
-/* ============= like a cast ============== */
+// Like an existing cast
 const reactionLikeBody = {
   type: types.ReactionType.REACTION_TYPE_LIKE,
-  target: { fid: -9998, tsHash: '0x455a6caad5dfd4d...' },
+  target: { fid: -9998, hash: '0x455a6caad5dfd4d...' },
 };
 const like = await makeReactionAdd(reactionLikeBody, dataOptions, ed25519Signer);
 await client.submitMessage(like._unsafeUnwrap());
 
-/* ============= undo a like ============== */
+// Undo the previous like
 const unlike = await makeReactionRemove(reactionLikeBody, dataOptions, ed25519Signer);
 await client.submitMessage(unlike._unsafeUnwrap());
 
-/* ============= recast a cast ============== */
-const reactionRecastBody = {
-  type: types.ReactionType.REACTION_TYPE_RECAST,
-  target: { fid: -9998, tsHash: '0x455a6caad5dfd4d...' },
-};
-const recast = await makeReactionAdd(reactionRecastBody, dataOptions, ed25519Signer);
-client.submitMessage(recast._unsafeUnwrap());
-
-/* ============= undo a recast ============== */
-const unrecast = await makeReactionRemove(reactionRecastBody, dataOptions, ed25519Signer);
-client.submit(unrecast._unsafeUnwrap());
-
-/* ============= delete a cast ============== */
+// Delete a cast
 const removeBody = { targetHash: '0xf88d738eb7145f4cea40fbe8f3bdf...' };
 const castRemove = await makeCastRemove(removeBody, dataOptions, ed25519Signer);
 await client.submitMessage(castRemove._unsafeUnwrap());
 
-/* ============= make a signer key ============== */
-const mnemonic = 'your mnemonic here apple orange banana';
-const wallet = ethers.Wallet.fromMnemonic(mnemonic);
-const eip712Signer = Eip712Signer.fromSigner(wallet, wallet.address)._unsafeUnwrap();
-
-const newPrivateKey = ed.utils.randomPrivateKey();
-const newEd25519Signer = Ed25519Signer.fromPrivateKey(newPrivateKey)._unsafeUnwrap();
-
-const signerBody = { signer: newEd25519Signer.signerKeyHex };
-const signerAdd = await makeSignerAdd(signerBody, dataOptions, eip712Signer);
-await client.submitMessage(signerAdd._unsafeUnwrap());
-
-/* ============= remove a signer key ============== */
-const signerRemove = makeSignerRemove(signerBody, dataOptions, eip712Signer);
-await client.submitMessage(signerRemove._unsafeUnwrap());
-
-/* ============= set user pfp ============== */
+// Set a profile picture
 const userDataPfpBody = {
   type: types.UserDataType.USER_DATA_TYPE_PFP,
   value: 'https://i.imgur.com/yed5Zfk.gif',
@@ -202,6 +139,8 @@ const userDataPfpBody = {
 const userDataPfpAdd = await makeUserDataAdd(userDataPfpBody, dataOptions, ed25519Signer);
 await client.submitMessage(userDataPfpAdd._unsafeUnwrap());
 ```
+
+If you want to write messages on behalf of another user, you will not have access to their custody address. In such cases, generate a signer and share the public key with the user who can use their wallet to create the SignerAdd and submit it to the Hub. Once that completes, you can use the Signer to write messages on behalf of the user.
 
 ## `Client`
 
@@ -220,17 +159,17 @@ Class to interact with hubble. See the [docs](./docs/classes/Client.md) for more
 | `getCastsByFid()`                   | Gets all casts by a given fid                                     |
 | `getCastsByMention()`               | Gets all casts by a given mention                                 |
 | `getCastsByParent()`                | Gets all casts with a given parent cast hash                      |
-| `getIdRegistryEvent()`              | TODO DOCS                                                              |
-| `getNameRegistryEvent()`            | TODO DOCS                                                              |
-| `getReaction()`                     | TODO DOCS                                                              |
+| `getIdRegistryEvent()`              | TODO DOCS                                                         |
+| `getNameRegistryEvent()`            | TODO DOCS                                                         |
+| `getReaction()`                     | TODO DOCS                                                         |
 | `getReactionsByCast()`              | Gets all reactions for a given cast hash                          |
 | `getReactionsByFid()`               | Gets all reactions by a given fid                                 |
-| `getSigner()`                       | TODO DOCS                                                              |
+| `getSigner()`                       | TODO DOCS                                                         |
 | `getSignersByFid()`                 | Gets all signers by a given fid                                   |
 | `getUserData()`                     | Gets user data (pfp, display name, bio, etc)                      |
 | `getUserDataByFid()`                | Gets all user data by a given fid                                 |
-| `getVerification()`                 | TODO DOCS                                                              |
-| `getVerificationsByFid()`           | TODO DOCS                                                              |
+| `getVerification()`                 | TODO DOCS                                                         |
+| `getVerificationsByFid()`           | TODO DOCS                                                         |
 | `submitMessage()`                   | Submits a message to hubble                                       |
 | `subscribe()`                       | Subscribes to updates from hubble                                 |
 
@@ -260,8 +199,8 @@ Class to sign messages in the EIP712 format. See the [docs](./docs/classes/Eip71
 | `signerKeyHex`                         | Property: signer's ECDSA public key in hex.                                            |
 | `signMessageHash()`                    | Signs a message hash with the signer's Ethereum address.                               |
 | `signMessageHashHex()`                 | Signs a message hash with the signer's Ethereum address, returns result in hex format. |
-| `signVerificationEthAddressClaim()`    | TODO DOCS                                                                                   |
-| `signVerificationEthAddressClaimHex()` | TODO DOCS                                                                                   |
+| `signVerificationEthAddressClaim()`    | TODO DOCS                                                                              |
+| `signVerificationEthAddressClaimHex()` | TODO DOCS                                                                              |
 | `fromSigner()`                         | Instantiate a new EIP712Signer from an ECDSA private key (Ethereum).                   |
 
 ## `Functions`
@@ -272,11 +211,11 @@ Functions to make messages. See the [docs](./docs/modules.md#functions) for more
 | --------------------------------- | ------------------------------------------------------------------- |
 | `makeCastAdd()`                   | Creates a message to add cast                                       |
 | `makeCastRemove()`                | Creates a message to delete cast                                    |
-| `makeMessageHash()`               | TODO DOCS                                                                |
+| `makeMessageHash()`               | TODO DOCS                                                           |
 | `makeReactionAdd()`               | Creates a message to react to cast (like or recast)                 |
 | `makeReactionRemove()`            | Creates a message to remove reaction from cast (unlike or unrecast) |
 | `makeSignerAdd()`                 | Creates a message to add a ed25519 signer key                       |
 | `makeSignerRemove()`              | Creates a message to remove a ed25519 signer key                    |
 | `makeUserDataAdd()`               | Creates a message to set user data (pfp, link, display name, etc)   |
-| `makeVerificationAddEthAddress()` | TODO DOCS                                                                |
-| `makeVerificationRemove()`        | TODO DOCS                                                                |
+| `makeVerificationAddEthAddress()` | TODO DOCS                                                           |
+| `makeVerificationRemove()`        | TODO DOCS                                                           |

--- a/packages/js/docs/classes/Client.md
+++ b/packages/js/docs/classes/Client.md
@@ -75,7 +75,7 @@ const client = new Client(...)
 
 ### getAllCastMessagesByFid
 
-▸ **getAllCastMessagesByFid**(`fid`): `HubAsyncResult`<(`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`CastAddData`](../modules/types.md#castadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\> \| `Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`CastRemoveData`](../modules/types.md#castremovedata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>)[]\>
+▸ **getAllCastMessagesByFid**(`fid`)
 
 TODO DOCS: description
 
@@ -98,18 +98,12 @@ console.log(result)
 | Name | Type |
 | :------ | :------ |
 | `fid` | `number` |
-
-#### Returns
-
-`HubAsyncResult`<(`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`CastAddData`](../modules/types.md#castadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\> \| `Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`CastRemoveData`](../modules/types.md#castremovedata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>)[]\>
-
-...
 
 ___
 
 ### getAllReactionMessagesByFid
 
-▸ **getAllReactionMessagesByFid**(`fid`): `HubAsyncResult`<(`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`ReactionAddData`](../modules/types.md#reactionadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\> \| `Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`ReactionRemoveData`](../modules/types.md#reactionremovedata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>)[]\>
+▸ **getAllReactionMessagesByFid**(`fid`)
 
 TODO DOCS: description
 
@@ -132,18 +126,12 @@ console.log(result)
 | Name | Type |
 | :------ | :------ |
 | `fid` | `number` |
-
-#### Returns
-
-`HubAsyncResult`<(`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`ReactionAddData`](../modules/types.md#reactionadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\> \| `Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`ReactionRemoveData`](../modules/types.md#reactionremovedata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>)[]\>
-
-...
 
 ___
 
 ### getAllSignerMessagesByFid
 
-▸ **getAllSignerMessagesByFid**(`fid`): `HubAsyncResult`<(`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`SignerAddData`](../modules/types.md#signeradddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\> \| `Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`SignerRemoveData`](../modules/types.md#signerremovedata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>)[]\>
+▸ **getAllSignerMessagesByFid**(`fid`)
 
 TODO DOCS: description
 
@@ -166,18 +154,12 @@ console.log(result)
 | Name | Type |
 | :------ | :------ |
 | `fid` | `number` |
-
-#### Returns
-
-`HubAsyncResult`<(`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`SignerAddData`](../modules/types.md#signeradddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\> \| `Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`SignerRemoveData`](../modules/types.md#signerremovedata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>)[]\>
-
-...
 
 ___
 
 ### getAllUserDataMessagesByFid
 
-▸ **getAllUserDataMessagesByFid**(`fid`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`UserDataAddData`](../modules/types.md#userdataadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
+▸ **getAllUserDataMessagesByFid**(`fid`)
 
 TODO DOCS: description
 
@@ -200,18 +182,12 @@ console.log(result)
 | Name | Type |
 | :------ | :------ |
 | `fid` | `number` |
-
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`UserDataAddData`](../modules/types.md#userdataadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
-
-...
 
 ___
 
 ### getAllVerificationMessagesByFid
 
-▸ **getAllVerificationMessagesByFid**(`fid`): `HubAsyncResult`<(`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`VerificationAddEthAddressData`](../modules/types.md#verificationaddethaddressdata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\> \| `Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`VerificationRemoveData`](../modules/types.md#verificationremovedata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>)[]\>
+▸ **getAllVerificationMessagesByFid**(`fid`)
 
 TODO DOCS: description
 
@@ -235,17 +211,11 @@ console.log(result)
 | :------ | :------ |
 | `fid` | `number` |
 
-#### Returns
-
-`HubAsyncResult`<(`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`VerificationAddEthAddressData`](../modules/types.md#verificationaddethaddressdata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\> \| `Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`VerificationRemoveData`](../modules/types.md#verificationremovedata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>)[]\>
-
-...
-
 ___
 
 ### getCast
 
-▸ **getCast**(`fid`, `hash`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`CastAddData`](../modules/types.md#castadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **getCast**(`fid`, `hash`)
 
 TODO DOCS: description
 
@@ -270,17 +240,11 @@ console.log(result)
 | `fid` | `number` |
 | `hash` | `string` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`CastAddData`](../modules/types.md#castadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
-
 ___
 
 ### getCastsByFid
 
-▸ **getCastsByFid**(`fid`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`CastAddData`](../modules/types.md#castadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
+▸ **getCastsByFid**(`fid`)
 
 TODO DOCS: description
 
@@ -304,17 +268,11 @@ console.log(result)
 | :------ | :------ |
 | `fid` | `number` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`CastAddData`](../modules/types.md#castadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
-
-...
-
 ___
 
 ### getCastsByMention
 
-▸ **getCastsByMention**(`mentionFid`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`CastAddData`](../modules/types.md#castadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
+▸ **getCastsByMention**(`mentionFid`)
 
 TODO DOCS: description
 
@@ -338,17 +296,11 @@ console.log(result)
 | :------ | :------ |
 | `mentionFid` | `number` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`CastAddData`](../modules/types.md#castadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
-
-...
-
 ___
 
 ### getCastsByParent
 
-▸ **getCastsByParent**(`parent`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`CastAddData`](../modules/types.md#castadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
+▸ **getCastsByParent**(`parent`)
 
 TODO DOCS: description
 
@@ -372,17 +324,11 @@ console.log(result)
 | :------ | :------ |
 | `parent` | [`CastId`](../modules/types.md#castid) |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`CastAddData`](../modules/types.md#castadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
-
-...
-
 ___
 
 ### getIdRegistryEvent
 
-▸ **getIdRegistryEvent**(`fid`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent) ; `blockHash`: `string` ; `blockNumber`: `number` ; `fid`: `number` ; `from`: `undefined` \| `string` ; `logIndex`: `number` ; `to`: `string` ; `transactionHash`: `string` ; `type`: [`IdRegistryEventType`](../enums/protobufs.IdRegistryEventType.md)  }\>\>
+▸ **getIdRegistryEvent**(`fid`)
 
 TODO DOCS: description
 
@@ -406,17 +352,11 @@ console.log(result)
 | :------ | :------ |
 | `fid` | `number` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent) ; `blockHash`: `string` ; `blockNumber`: `number` ; `fid`: `number` ; `from`: `undefined` \| `string` ; `logIndex`: `number` ; `to`: `string` ; `transactionHash`: `string` ; `type`: [`IdRegistryEventType`](../enums/protobufs.IdRegistryEventType.md)  }\>\>
-
-...
-
 ___
 
 ### getNameRegistryEvent
 
-▸ **getNameRegistryEvent**(`fname`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent) ; `blockHash`: `string` ; `blockNumber`: `number` ; `expiry`: `undefined` \| `number` ; `fname`: `string` ; `from`: `string` ; `logIndex`: `number` ; `to`: `string` ; `transactionHash`: `string` ; `type`: [`NameRegistryEventType`](../enums/protobufs.NameRegistryEventType.md)  }\>\>
+▸ **getNameRegistryEvent**(`fname`)
 
 TODO DOCS: description
 
@@ -440,17 +380,11 @@ console.log(result)
 | :------ | :------ |
 | `fname` | `string` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent) ; `blockHash`: `string` ; `blockNumber`: `number` ; `expiry`: `undefined` \| `number` ; `fname`: `string` ; `from`: `string` ; `logIndex`: `number` ; `to`: `string` ; `transactionHash`: `string` ; `type`: [`NameRegistryEventType`](../enums/protobufs.NameRegistryEventType.md)  }\>\>
-
-...
-
 ___
 
 ### getReaction
 
-▸ **getReaction**(`fid`, `type`, `cast`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`ReactionAddData`](../modules/types.md#reactionadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **getReaction**(`fid`, `type`, `cast`)
 
 TODO DOCS: description
 
@@ -476,17 +410,11 @@ console.log(result)
 | `type` | [`ReactionType`](../enums/protobufs.ReactionType.md) |
 | `cast` | [`CastId`](../modules/types.md#castid) |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`ReactionAddData`](../modules/types.md#reactionadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
-
 ___
 
 ### getReactionsByCast
 
-▸ **getReactionsByCast**(`cast`, `type?`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`ReactionAddData`](../modules/types.md#reactionadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
+▸ **getReactionsByCast**(`cast`, `type?`)
 
 TODO DOCS: description
 
@@ -511,17 +439,11 @@ console.log(result)
 | `cast` | [`CastId`](../modules/types.md#castid) |
 | `type?` | [`ReactionType`](../enums/protobufs.ReactionType.md) |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`ReactionAddData`](../modules/types.md#reactionadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
-
-...
-
 ___
 
 ### getReactionsByFid
 
-▸ **getReactionsByFid**(`fid`, `type?`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`ReactionAddData`](../modules/types.md#reactionadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
+▸ **getReactionsByFid**(`fid`, `type?`)
 
 TODO DOCS: description
 
@@ -546,17 +468,11 @@ console.log(result)
 | `fid` | `number` |
 | `type?` | [`ReactionType`](../enums/protobufs.ReactionType.md) |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`ReactionAddData`](../modules/types.md#reactionadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
-
-...
-
 ___
 
 ### getSigner
 
-▸ **getSigner**(`fid`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`SignerAddData`](../modules/types.md#signeradddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **getSigner**(`fid`, `signer`)
 
 TODO DOCS: description
 
@@ -581,17 +497,11 @@ console.log(result)
 | `fid` | `number` |
 | `signer` | `string` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`SignerAddData`](../modules/types.md#signeradddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
-
 ___
 
 ### getSignersByFid
 
-▸ **getSignersByFid**(`fid`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`SignerAddData`](../modules/types.md#signeradddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
+▸ **getSignersByFid**(`fid`)
 
 TODO DOCS: description
 
@@ -615,17 +525,11 @@ console.log(result)
 | :------ | :------ |
 | `fid` | `number` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`SignerAddData`](../modules/types.md#signeradddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
-
-...
-
 ___
 
 ### getUserData
 
-▸ **getUserData**(`fid`, `type`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`UserDataAddData`](../modules/types.md#userdataadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **getUserData**(`fid`, `type`)
 
 TODO DOCS: description
 
@@ -650,17 +554,11 @@ console.log(result)
 | `fid` | `number` |
 | `type` | [`UserDataType`](../enums/protobufs.UserDataType.md) |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`UserDataAddData`](../modules/types.md#userdataadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
-
 ___
 
 ### getUserDataByFid
 
-▸ **getUserDataByFid**(`fid`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`UserDataAddData`](../modules/types.md#userdataadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
+▸ **getUserDataByFid**(`fid`)
 
 TODO DOCS: description
 
@@ -684,17 +582,11 @@ console.log(result)
 | :------ | :------ |
 | `fid` | `number` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`UserDataAddData`](../modules/types.md#userdataadddata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
-
-...
-
 ___
 
 ### getVerification
 
-▸ **getVerification**(`fid`, `address`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`VerificationAddEthAddressData`](../modules/types.md#verificationaddethaddressdata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **getVerification**(`fid`, `address`)
 
 TODO DOCS: description
 
@@ -719,17 +611,11 @@ console.log(result)
 | `fid` | `number` |
 | `address` | `string` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`VerificationAddEthAddressData`](../modules/types.md#verificationaddethaddressdata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
-
 ___
 
 ### getVerificationsByFid
 
-▸ **getVerificationsByFid**(`fid`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`VerificationAddEthAddressData`](../modules/types.md#verificationaddethaddressdata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
+▸ **getVerificationsByFid**(`fid`)
 
 TODO DOCS: description
 
@@ -753,17 +639,11 @@ console.log(result)
 | :------ | :------ |
 | `fid` | `number` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`VerificationAddEthAddressData`](../modules/types.md#verificationaddethaddressdata) ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>[]\>
-
-...
-
 ___
 
 ### submitMessage
 
-▸ **submitMessage**(`message`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`MessageData`](../modules/types.md#messagedata)<[`MessageBody`](../modules/types.md#messagebody), [`MessageType`](../enums/protobufs.MessageType.md)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **submitMessage**(`message`)
 
 TODO DOCS: description
 
@@ -787,17 +667,11 @@ console.log(result)
 | :------ | :------ |
 | `message` | `Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`MessageData`](../modules/types.md#messagedata)<[`MessageBody`](../modules/types.md#messagebody), [`MessageType`](../enums/protobufs.MessageType.md)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\> |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](../modules/protobufs.md#message) ; `data`: [`MessageData`](../modules/types.md#messagedata)<[`MessageBody`](../modules/types.md#messagebody), [`MessageType`](../enums/protobufs.MessageType.md)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
-
 ___
 
 ### subscribe
 
-▸ **subscribe**(`filters?`): `Promise`<`HubResult`<`ClientReadableStream`<[`HubEvent`](../modules/protobufs.md#hubevent)\>\>\>
+▸ **subscribe**(`filters?`)
 
 TODO DOCS: description
 
@@ -822,9 +696,3 @@ console.log(result)
 | Name | Type |
 | :------ | :------ |
 | `filters` | [`EventFilters`](../modules.md#eventfilters) |
-
-#### Returns
-
-`Promise`<`HubResult`<`ClientReadableStream`<[`HubEvent`](../modules/protobufs.md#hubevent)\>\>\>
-
-...

--- a/packages/js/docs/classes/Client.md
+++ b/packages/js/docs/classes/Client.md
@@ -79,25 +79,23 @@ const client = new Client(...)
 
 TODO DOCS: description
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid from which the cast originates from. |
 
 ___
 
@@ -107,25 +105,23 @@ ___
 
 TODO DOCS: description
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid from which the cast originates from. |
 
 ___
 
@@ -135,25 +131,23 @@ ___
 
 TODO DOCS: description
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<(SignerAddMessage | SignerRemoveMessage)[]>` | [`SignerAddMessage`](modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid to get all signers for. |
 
 ___
 
@@ -163,25 +157,23 @@ ___
 
 TODO DOCS: description
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<(UserDataAddMessage | UserDataRemoveMessage)[]>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid to get all user data for. |
 
 ___
 
@@ -189,27 +181,25 @@ ___
 
 ▸ **getAllVerificationMessagesByFid**(`fid`)
 
-TODO DOCS: description
+Get all verifications for a specific address.
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<(VerificationAddEthAddressMessage | VerificationRemoveMessage)[]>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid to get all verifications for. |
 
 ___
 
@@ -217,28 +207,26 @@ ___
 
 ▸ **getCast**(`fid`, `hash`)
 
-TODO DOCS: description
+Get a cast.
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<CastAddMessage>` | [`CastAddMessage`](modules/types.md#castaddmessage) | A `HubAsyncResult` that contains the valid `CastAddMessage`. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
-| `hash` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid from which the cast originates from. |
+| `hash` | `string` | The hash of the cast. |
 
 ___
 
@@ -246,27 +234,25 @@ ___
 
 ▸ **getCastsByFid**(`fid`)
 
-TODO DOCS: description
+Get casts by fid.
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid from which the cast originates from. |
 
 ___
 
@@ -276,25 +262,23 @@ ___
 
 TODO DOCS: description
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `mentionFid` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `mentionFid` | `number` | The fid from which the cast originates from. |
 
 ___
 
@@ -302,27 +286,25 @@ ___
 
 ▸ **getCastsByParent**(`parent`)
 
-TODO DOCS: description
+Get direct children of a cast.
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `parent` | [`CastId`](../modules/types.md#castid) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `parent` | [`CastId`](../modules/types.md#castid) | The parent cast id. |
 
 ___
 
@@ -330,27 +312,25 @@ ___
 
 ▸ **getIdRegistryEvent**(`fid`)
 
-TODO DOCS: description
+Get fid registry event for a specific fid.
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<IdRegistryEvent>` | [`IdRegistryEvent`](modules/types.md#idregistryevent) | A `HubAsyncResult` that contains the valid `IdRegistryEvent`. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid to get registry event for. |
 
 ___
 
@@ -358,27 +338,25 @@ ___
 
 ▸ **getNameRegistryEvent**(`fname`)
 
-TODO DOCS: description
+Get fname registry event for a specific fname.
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<NameRegistryEvent>` | [`NameRegistryEvent`](modules/types.md#nameregistryevent) | A `HubAsyncResult` that contains the valid `NameRegistryEvent`. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fname` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fname` | `string` | The fname to get registry event for. |
 
 ___
 
@@ -386,29 +364,27 @@ ___
 
 ▸ **getReaction**(`fid`, `type`, `cast`)
 
-TODO DOCS: description
+Get reaction for a specific cast.
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<ReactionAddMessage>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage) | A `HubAsyncResult` that contains the valid `ReactionAddMessage`. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
-| `type` | [`ReactionType`](../enums/protobufs.ReactionType.md) |
-| `cast` | [`CastId`](../modules/types.md#castid) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid from which the cast originates from. |
+| `type` | [`ReactionType`](../enums/protobufs.ReactionType.md) | The type of the reaction (like or recast). |
+| `cast` | [`CastId`](../modules/types.md#castid) | The cast id. |
 
 ___
 
@@ -418,26 +394,24 @@ ___
 
 TODO DOCS: description
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `cast` | [`CastId`](../modules/types.md#castid) |
-| `type?` | [`ReactionType`](../enums/protobufs.ReactionType.md) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `cast` | [`CastId`](../modules/types.md#castid) | The cast id. |
+| `type?` | [`ReactionType`](../enums/protobufs.ReactionType.md) | The type of the reaction (like or recast). |
 
 ___
 
@@ -445,28 +419,26 @@ ___
 
 ▸ **getReactionsByFid**(`fid`, `type?`)
 
-TODO DOCS: description
+Get reactions from a specific fid.
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
-| `type?` | [`ReactionType`](../enums/protobufs.ReactionType.md) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid from which the cast originates from. |
+| `type?` | [`ReactionType`](../enums/protobufs.ReactionType.md) | The type of the reaction (like or recast). |
 
 ___
 
@@ -476,18 +448,16 @@ ___
 
 TODO DOCS: description
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<SignerAddMessage>` | [`SignerAddMessage`](modules/types.md#signeraddmessage) | A `HubAsyncResult` that contains the valid `SignerAddMessage`. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
@@ -503,27 +473,25 @@ ___
 
 ▸ **getSignersByFid**(`fid`)
 
-TODO DOCS: description
+Get signers of a fid.
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<SignerAddMessage[]>` | [`SignerAddMessage`](modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid to get signers for. |
 
 ___
 
@@ -531,28 +499,26 @@ ___
 
 ▸ **getUserData**(`fid`, `type`)
 
-TODO DOCS: description
+Get user data (pfp, username, fname, etc).
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<UserDataAddMessage>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage) | A `HubAsyncResult` that contains the valid `UserDataAddMessage`. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
-| `type` | [`UserDataType`](../enums/protobufs.UserDataType.md) |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid to get user data for. |
+| `type` | [`UserDataType`](../enums/protobufs.UserDataType.md) | The type of user data to get. |
 
 ___
 
@@ -560,27 +526,25 @@ ___
 
 ▸ **getUserDataByFid**(`fid`)
 
-TODO DOCS: description
+Get user data (pfp, username, fname, etc) by fid.
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<UserDataAddMessage[]>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid to get user data for. |
 
 ___
 
@@ -588,28 +552,26 @@ ___
 
 ▸ **getVerification**(`fid`, `address`)
 
-TODO DOCS: description
+Get verification for a specific address and fid.
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<VerificationAddEthAddressMessage>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage) | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage`. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
-| `address` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid to verify. |
+| `address` | `string` | The custody address to verify. |
 
 ___
 
@@ -617,27 +579,25 @@ ___
 
 ▸ **getVerificationsByFid**(`fid`)
 
-TODO DOCS: description
+Get verifications for a specific fid.
 
-TODO DOCS: usage example, here's the structure:
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<VerificationAddEthAddressMessage[]>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
 
 **`Example`**
 
 ```typescript
-import { ... } from '@farcaster/js';
-
-const client = new Client(...)
-const result = await client.get...
-console.log(result)
-
-// Output: ...
+// TODO DOCS: usage example
 ```
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `fid` | `number` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `fid` | `number` | The fid to verify. |
 
 ___
 

--- a/packages/js/docs/classes/Client.md
+++ b/packages/js/docs/classes/Client.md
@@ -133,9 +133,11 @@ TODO DOCS: description
 
 #### Returns
 
-| Value | Type | Description |
-| :---- | :--- | :---------- |
-| `HubAsyncResult<(SignerAddMessage | SignerRemoveMessage)[]>` | [`SignerAddMessage`](../modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
+| Value                                          | Type                                     | Description                                                               |
+| :--------------------------------------------- | :--------------------------------------- | :------------------------------------------------------------------------ |
+| `HubAsyncResult<(SignerAddMessage)>` | [`SignerAddMessage`](../modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` or `SignerRemoveMessage` array. |
+| OR                                           |                                         |                                                                          |
+| `HubAsyncResult<(SignerRemoveMessage)>` | [`SignerRemoveMessage`](../modules/types.md#signerremovemessage)[] | - |
 
 **`Example`**
 
@@ -161,7 +163,9 @@ TODO DOCS: description
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<(UserDataAddMessage | UserDataRemoveMessage)[]>` | [`UserDataAddMessage`](../modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
+| `HubAsyncResult<(UserDataAddMessage>` | [`UserDataAddMessage`](../modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` or `UserDataRemoveMessage` array. |
+| OR    |                                         |                                                                          |
+| `HubAsyncResult<(UserDataRemoveMessage>` | [`UserDataRemoveMessage`](../modules/types.md#userdataremovemessage)[] | - |
 
 **`Example`**
 
@@ -187,7 +191,9 @@ Get all verifications for a specific address.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<(VerificationAddEthAddressMessage | VerificationRemoveMessage)[]>` | [`VerificationAddEthAddressMessage`](../modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
+| `HubAsyncResult<(VerificationAddEthAddressMessage)[]>` | [`VerificationAddEthAddressMessage`](../modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` or `VerificationRemoveMessageMessage` array. |
+| OR | | |
+| `HubAsyncResult<(VerificationRemoveMessage)[]>` | [`VerificationRemoveMessage`](../modules/types.md#verificationremovemessage)[] | - |
 
 **`Example`**
 

--- a/packages/js/docs/classes/Client.md
+++ b/packages/js/docs/classes/Client.md
@@ -83,7 +83,7 @@ TODO DOCS: description
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
+| `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](../modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
 
 **`Example`**
 
@@ -109,7 +109,7 @@ TODO DOCS: description
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
+| `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](../modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
 
 **`Example`**
 
@@ -135,7 +135,7 @@ TODO DOCS: description
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<(SignerAddMessage | SignerRemoveMessage)[]>` | [`SignerAddMessage`](modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
+| `HubAsyncResult<(SignerAddMessage | SignerRemoveMessage)[]>` | [`SignerAddMessage`](../modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
 
 **`Example`**
 
@@ -161,7 +161,7 @@ TODO DOCS: description
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<(UserDataAddMessage | UserDataRemoveMessage)[]>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
+| `HubAsyncResult<(UserDataAddMessage | UserDataRemoveMessage)[]>` | [`UserDataAddMessage`](../modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
 
 **`Example`**
 
@@ -187,7 +187,7 @@ Get all verifications for a specific address.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<(VerificationAddEthAddressMessage | VerificationRemoveMessage)[]>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
+| `HubAsyncResult<(VerificationAddEthAddressMessage | VerificationRemoveMessage)[]>` | [`VerificationAddEthAddressMessage`](../modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
 
 **`Example`**
 
@@ -213,7 +213,7 @@ Get a cast.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<CastAddMessage>` | [`CastAddMessage`](modules/types.md#castaddmessage) | A `HubAsyncResult` that contains the valid `CastAddMessage`. |
+| `HubAsyncResult<CastAddMessage>` | [`CastAddMessage`](../modules/types.md#castaddmessage) | A `HubAsyncResult` that contains the valid `CastAddMessage`. |
 
 **`Example`**
 
@@ -240,7 +240,7 @@ Get casts by fid.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
+| `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](../modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
 
 **`Example`**
 
@@ -266,7 +266,7 @@ TODO DOCS: description
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
+| `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](../modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
 
 **`Example`**
 
@@ -292,7 +292,7 @@ Get direct children of a cast.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
+| `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](../modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
 
 **`Example`**
 
@@ -318,7 +318,7 @@ Get fid registry event for a specific fid.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<IdRegistryEvent>` | [`IdRegistryEvent`](modules/types.md#idregistryevent) | A `HubAsyncResult` that contains the valid `IdRegistryEvent`. |
+| `HubAsyncResult<IdRegistryEvent>` | [`IdRegistryEvent`](../modules/types.md#idregistryevent) | A `HubAsyncResult` that contains the valid `IdRegistryEvent`. |
 
 **`Example`**
 
@@ -344,7 +344,7 @@ Get fname registry event for a specific fname.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<NameRegistryEvent>` | [`NameRegistryEvent`](modules/types.md#nameregistryevent) | A `HubAsyncResult` that contains the valid `NameRegistryEvent`. |
+| `HubAsyncResult<NameRegistryEvent>` | [`NameRegistryEvent`](../modules/types.md#nameregistryevent) | A `HubAsyncResult` that contains the valid `NameRegistryEvent`. |
 
 **`Example`**
 
@@ -370,7 +370,7 @@ Get reaction for a specific cast.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<ReactionAddMessage>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage) | A `HubAsyncResult` that contains the valid `ReactionAddMessage`. |
+| `HubAsyncResult<ReactionAddMessage>` | [`ReactionAddMessage`](../modules/types.md#reactionaddmessage) | A `HubAsyncResult` that contains the valid `ReactionAddMessage`. |
 
 **`Example`**
 
@@ -398,7 +398,7 @@ TODO DOCS: description
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
+| `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](../modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
 
 **`Example`**
 
@@ -425,7 +425,7 @@ Get reactions from a specific fid.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
+| `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](../modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
 
 **`Example`**
 
@@ -452,7 +452,7 @@ TODO DOCS: description
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<SignerAddMessage>` | [`SignerAddMessage`](modules/types.md#signeraddmessage) | A `HubAsyncResult` that contains the valid `SignerAddMessage`. |
+| `HubAsyncResult<SignerAddMessage>` | [`SignerAddMessage`](../modules/types.md#signeraddmessage) | A `HubAsyncResult` that contains the valid `SignerAddMessage`. |
 
 **`Example`**
 
@@ -479,7 +479,7 @@ Get signers of a fid.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<SignerAddMessage[]>` | [`SignerAddMessage`](modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
+| `HubAsyncResult<SignerAddMessage[]>` | [`SignerAddMessage`](../modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
 
 **`Example`**
 
@@ -505,7 +505,7 @@ Get user data (pfp, username, fname, etc).
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<UserDataAddMessage>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage) | A `HubAsyncResult` that contains the valid `UserDataAddMessage`. |
+| `HubAsyncResult<UserDataAddMessage>` | [`UserDataAddMessage`](../modules/types.md#userdataaddmessage) | A `HubAsyncResult` that contains the valid `UserDataAddMessage`. |
 
 **`Example`**
 
@@ -532,7 +532,7 @@ Get user data (pfp, username, fname, etc) by fid.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<UserDataAddMessage[]>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
+| `HubAsyncResult<UserDataAddMessage[]>` | [`UserDataAddMessage`](../modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
 
 **`Example`**
 
@@ -558,7 +558,7 @@ Get verification for a specific address and fid.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<VerificationAddEthAddressMessage>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage) | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage`. |
+| `HubAsyncResult<VerificationAddEthAddressMessage>` | [`VerificationAddEthAddressMessage`](../modules/types.md#verificationaddethaddressmessage) | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage`. |
 
 **`Example`**
 
@@ -585,7 +585,7 @@ Get verifications for a specific fid.
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<VerificationAddEthAddressMessage[]>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
+| `HubAsyncResult<VerificationAddEthAddressMessage[]>` | [`VerificationAddEthAddressMessage`](../modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
 
 **`Example`**
 

--- a/packages/js/docs/classes/Ed25519Signer.md
+++ b/packages/js/docs/classes/Ed25519Signer.md
@@ -84,7 +84,7 @@ BaseEd25519Signer.signerKeyHex
 
 ### signMessageHash
 
-▸ **signMessageHash**(`hash`): `HubAsyncResult`<`Uint8Array`\>
+▸ **signMessageHash**(`hash`)
 
 Generates a 256-bit signature using from EdDSA key pair.
 
@@ -112,12 +112,6 @@ console.log(signature._unsafeUnwrap());
 | :------ | :------ | :------ |
 | `hash` | `Uint8Array` | The 256-bit hash of the message to be signed. |
 
-#### Returns
-
-`HubAsyncResult`<`Uint8Array`\>
-
-A HubAsyncResult containing the signature as a Uint8Array.
-
 #### Inherited from
 
 BaseEd25519Signer.signMessageHash
@@ -126,7 +120,7 @@ ___
 
 ### signMessageHashHex
 
-▸ **signMessageHashHex**(`hash`): `HubAsyncResult`<`string`\>
+▸ **signMessageHashHex**(`hash`)
 
 Generates a 256-bit hex signature from an EdDSA key pair for a given message hash in hex format.
 
@@ -154,17 +148,11 @@ console.log(signature._unsafeUnwrap()); // 0x9f1c7e13b9d0b8...
 | :------ | :------ | :------ |
 | `hash` | `string` | The hash of the message to be signed in hex format. |
 
-#### Returns
-
-`HubAsyncResult`<`string`\>
-
-A HubAsyncResult containing the signature in hex format.
-
 ___
 
 ### fromPrivateKey
 
-▸ `Static` **fromPrivateKey**(`privateKey`): `HubResult`<[`Ed25519Signer`](Ed25519Signer.md)\>
+▸ `Static` **fromPrivateKey**(`privateKey`)
 
 Creates an Ed25519 signer from a private key.
 
@@ -183,12 +171,6 @@ const signer = Ed25519Signer.fromPrivateKey(privateKeyBytes)._unsafeUnwrap();
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `privateKey` | `Uint8Array` | The 32-byte private key to use for signing. |
-
-#### Returns
-
-`HubResult`<[`Ed25519Signer`](Ed25519Signer.md)\>
-
-A HubResult containing an Ed25519Signer instance on success, or an error message on failure.
 
 #### Overrides
 

--- a/packages/js/docs/classes/Ed25519Signer.md
+++ b/packages/js/docs/classes/Ed25519Signer.md
@@ -88,6 +88,12 @@ BaseEd25519Signer.signerKeyHex
 
 Generates a 256-bit signature using from EdDSA key pair.
 
+#### Returns
+
+| Value | Description |
+| :---- | :---------- |
+| `HubAsyncResult<Uint8Array>` | A HubAsyncResult containing the 256-bit signature as a Uint8Array. |
+
 **`Example`**
 
 ```typescript
@@ -124,6 +130,12 @@ ___
 
 Generates a 256-bit hex signature from an EdDSA key pair for a given message hash in hex format.
 
+#### Returns
+
+| Value | Description |
+| :---- | :---------- |
+| `HubAsyncResult<string>` | A HubAsyncResult containing the 256-bit signature as a hex string. |
+
 **`Example`**
 
 ```typescript
@@ -155,6 +167,12 @@ ___
 ▸ `Static` **fromPrivateKey**(`privateKey`)
 
 Creates an Ed25519 signer from a private key.
+
+#### Returns
+
+| Value | Description |
+| :---- | :---------- |
+| `HubResult<Ed25519Signer>` | A HubResult containing an Ed25519Signer instance |
 
 **`Example`**
 

--- a/packages/js/docs/classes/Eip712Signer.md
+++ b/packages/js/docs/classes/Eip712Signer.md
@@ -86,7 +86,7 @@ BaseEip712Signer.signerKeyHex
 
 ### signMessageHash
 
-▸ **signMessageHash**(`hash`): `HubAsyncResult`<`Uint8Array`\>
+▸ **signMessageHash**(`hash`)
 
 Generates a 256-bit signature from an Ethereum address.
 
@@ -116,12 +116,6 @@ console.log(signature._unsafeUnwrap());
 | :------ | :------ | :------ |
 | `hash` | `Uint8Array` | The 256-bit hash of the message to be signed. |
 
-#### Returns
-
-`HubAsyncResult`<`Uint8Array`\>
-
-A HubAsyncResult containing the 256-bit signature as a Uint8Array.
-
 #### Inherited from
 
 BaseEip712Signer.signMessageHash
@@ -130,7 +124,7 @@ ___
 
 ### signMessageHashHex
 
-▸ **signMessageHashHex**(`hash`): `HubAsyncResult`<`string`\>
+▸ **signMessageHashHex**(`hash`)
 
 Generates a 256-bit hex signature from an Ethereum address.
 
@@ -158,17 +152,11 @@ console.log(messageHashResultHex._unsafeUnwrap());
 | :------ | :------ | :------ |
 | `hash` | `string` | The 256-bit hash of the message to be signed. |
 
-#### Returns
-
-`HubAsyncResult`<`string`\>
-
-A HubAsyncResult containing the 256-bit signature as a hex string.
-
 ___
 
 ### signVerificationEthAddressClaim
 
-▸ **signVerificationEthAddressClaim**(`claim`): `HubAsyncResult`<`Uint8Array`\>
+▸ **signVerificationEthAddressClaim**(`claim`)
 
 Signs a verification claim for an Ethereum address.
 
@@ -193,12 +181,6 @@ console.log(verificationResult._unsafeUnwrap());
 | :------ | :------ | :------ |
 | `claim` | [`VerificationEthAddressClaim`](../modules/types.md#verificationethaddressclaim) | The body of the claim to be signed. |
 
-#### Returns
-
-`HubAsyncResult`<`Uint8Array`\>
-
-A HubAsyncResult containing the 256-bit signature as a Uint8Array.
-
 #### Inherited from
 
 BaseEip712Signer.signVerificationEthAddressClaim
@@ -207,7 +189,7 @@ ___
 
 ### signVerificationEthAddressClaimHex
 
-▸ **signVerificationEthAddressClaimHex**(`claim`): `HubAsyncResult`<`string`\>
+▸ **signVerificationEthAddressClaimHex**(`claim`)
 
 Signs an Ethereum address verification claim, returns hex.
 
@@ -239,17 +221,11 @@ console.log(verificationResult._unsafeUnwrap());
 | :------ | :------ | :------ |
 | `claim` | [`VerificationEthAddressClaim`](../modules/types.md#verificationethaddressclaim) | The body of the claim to be signed as an object |
 
-#### Returns
-
-`HubAsyncResult`<`string`\>
-
-A HubAsyncResult containing the 256-bit signature as a Uint8Array.
-
 ___
 
 ### fromSigner
 
-▸ `Static` **fromSigner**(`typedDataSigner`, `address`): `HubResult`<[`Eip712Signer`](Eip712Signer.md)\>
+▸ `Static` **fromSigner**(`typedDataSigner`, `address`)
 
 Creates an instance of Eip712Signer from a TypedDataSigner and an Ethereum address.
 
@@ -269,13 +245,6 @@ const eip712Signer = Eip712Signer.fromSigner(custodyWallet, custodyWallet.addres
 | :------ | :------ | :------ |
 | `typedDataSigner` | `TypedDataSigner` | The TypedDataSigner instance to use for signing. |
 | `address` | `string` | The Ethereum address associated with the signer. |
-
-#### Returns
-
-`HubResult`<[`Eip712Signer`](Eip712Signer.md)\>
-
-A HubResult that resolves to an Eip712Signer instance on success, or
-a failure with an error message on error.
 
 #### Overrides
 

--- a/packages/js/docs/classes/Eip712Signer.md
+++ b/packages/js/docs/classes/Eip712Signer.md
@@ -90,6 +90,12 @@ BaseEip712Signer.signerKeyHex
 
 Generates a 256-bit signature from an Ethereum address.
 
+#### Returns
+
+| Value | Description |
+| :---- | :---------- |
+| `HubAsyncResult<Uint8Array>` | A HubAsyncResult containing the 256-bit signature as a Uint8Array. |
+
 **`Example`**
 
 ```typescript
@@ -128,6 +134,12 @@ ___
 
 Generates a 256-bit hex signature from an Ethereum address.
 
+#### Returns
+
+| Value | Description |
+| :---- | :---------- |
+| `HubAsyncResult<string>` | A HubAsyncResult containing the 256-bit signature as a hex string. |
+
 **`Example`**
 
 ```typescript
@@ -159,6 +171,12 @@ ___
 ▸ **signVerificationEthAddressClaim**(`claim`)
 
 Signs a verification claim for an Ethereum address.
+
+#### Returns
+
+| Value | Description |
+| :---- | :---------- |
+| `HubAsyncResult<Uint8Array>` | A HubAsyncResult containing the 256-bit signature as a Uint8Array. |
 
 **`Example`**
 
@@ -192,6 +210,12 @@ ___
 ▸ **signVerificationEthAddressClaimHex**(`claim`)
 
 Signs an Ethereum address verification claim, returns hex.
+
+#### Returns
+
+| Value | Description |
+| :---- | :---------- |
+| `HubAsyncResult<string>` | A HubAsyncResult containing the 256-bit signature as a hex string. |
 
 **`Example`**
 
@@ -228,6 +252,12 @@ ___
 ▸ `Static` **fromSigner**(`typedDataSigner`, `address`)
 
 Creates an instance of Eip712Signer from a TypedDataSigner and an Ethereum address.
+
+#### Returns
+
+| Value | Description |
+| :---- | :---------- |
+| `HubResult<Eip712Signer>` | A HubResult containing an Eip712Signer instance. |
 
 **`Example`**
 

--- a/packages/js/docs/interfaces/protobufs.AdminServiceClient.md
+++ b/packages/js/docs/interfaces/protobufs.AdminServiceClient.md
@@ -21,20 +21,16 @@
 
 ### deleteAllMessagesFromDb
 
-▸ **deleteAllMessagesFromDb**(`request`, `callback`): `SurfaceCall`
+▸ **deleteAllMessagesFromDb**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`Empty`](../modules/protobufs.md#empty) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Empty`](../modules/protobufs.md#empty)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Empty`](../modules/protobufs.md#empty)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **deleteAllMessagesFromDb**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **deleteAllMessagesFromDb**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -42,13 +38,9 @@
 | :------ | :------ |
 | `request` | [`Empty`](../modules/protobufs.md#empty) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Empty`](../modules/protobufs.md#empty)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Empty`](../modules/protobufs.md#empty)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **deleteAllMessagesFromDb**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **deleteAllMessagesFromDb**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -57,30 +49,22 @@
 | `request` | [`Empty`](../modules/protobufs.md#empty) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Empty`](../modules/protobufs.md#empty)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Empty`](../modules/protobufs.md#empty)) =>  |
 
 ___
 
 ### rebuildSyncTrie
 
-▸ **rebuildSyncTrie**(`request`, `callback`): `SurfaceCall`
+▸ **rebuildSyncTrie**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`Empty`](../modules/protobufs.md#empty) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Empty`](../modules/protobufs.md#empty)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Empty`](../modules/protobufs.md#empty)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **rebuildSyncTrie**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **rebuildSyncTrie**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -88,13 +72,9 @@ ___
 | :------ | :------ |
 | `request` | [`Empty`](../modules/protobufs.md#empty) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Empty`](../modules/protobufs.md#empty)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Empty`](../modules/protobufs.md#empty)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **rebuildSyncTrie**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **rebuildSyncTrie**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -103,8 +83,4 @@ ___
 | `request` | [`Empty`](../modules/protobufs.md#empty) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Empty`](../modules/protobufs.md#empty)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Empty`](../modules/protobufs.md#empty)) =>  |

--- a/packages/js/docs/interfaces/protobufs.HubServiceClient.md
+++ b/packages/js/docs/interfaces/protobufs.HubServiceClient.md
@@ -50,7 +50,7 @@
 
 ### getAllCastMessagesByFid
 
-▸ **getAllCastMessagesByFid**(`request`, `callback`): `SurfaceCall`
+▸ **getAllCastMessagesByFid**(`request`, `callback`)
 
 Bulk Methods
 
@@ -59,13 +59,9 @@ Bulk Methods
 | Name | Type |
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllCastMessagesByFid**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getAllCastMessagesByFid**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -73,13 +69,9 @@ Bulk Methods
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllCastMessagesByFid**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getAllCastMessagesByFid**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -88,30 +80,22 @@ Bulk Methods
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getAllMessagesBySyncIds
 
-▸ **getAllMessagesBySyncIds**(`request`, `callback`): `SurfaceCall`
+▸ **getAllMessagesBySyncIds**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`SyncIds`](../modules/protobufs.md#syncids) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllMessagesBySyncIds**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getAllMessagesBySyncIds**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -119,13 +103,9 @@ ___
 | :------ | :------ |
 | `request` | [`SyncIds`](../modules/protobufs.md#syncids) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllMessagesBySyncIds**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getAllMessagesBySyncIds**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -134,30 +114,22 @@ ___
 | `request` | [`SyncIds`](../modules/protobufs.md#syncids) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getAllReactionMessagesByFid
 
-▸ **getAllReactionMessagesByFid**(`request`, `callback`): `SurfaceCall`
+▸ **getAllReactionMessagesByFid**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllReactionMessagesByFid**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getAllReactionMessagesByFid**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -165,13 +137,9 @@ ___
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllReactionMessagesByFid**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getAllReactionMessagesByFid**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -180,30 +148,22 @@ ___
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getAllSignerMessagesByFid
 
-▸ **getAllSignerMessagesByFid**(`request`, `callback`): `SurfaceCall`
+▸ **getAllSignerMessagesByFid**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllSignerMessagesByFid**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getAllSignerMessagesByFid**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -211,13 +171,9 @@ ___
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllSignerMessagesByFid**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getAllSignerMessagesByFid**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -226,30 +182,22 @@ ___
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getAllSyncIdsByPrefix
 
-▸ **getAllSyncIdsByPrefix**(`request`, `callback`): `SurfaceCall`
+▸ **getAllSyncIdsByPrefix**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`TrieNodePrefix`](../modules/protobufs.md#trienodeprefix) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`SyncIds`](../modules/protobufs.md#syncids)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`SyncIds`](../modules/protobufs.md#syncids)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllSyncIdsByPrefix**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getAllSyncIdsByPrefix**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -257,13 +205,9 @@ ___
 | :------ | :------ |
 | `request` | [`TrieNodePrefix`](../modules/protobufs.md#trienodeprefix) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`SyncIds`](../modules/protobufs.md#syncids)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`SyncIds`](../modules/protobufs.md#syncids)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllSyncIdsByPrefix**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getAllSyncIdsByPrefix**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -272,30 +216,22 @@ ___
 | `request` | [`TrieNodePrefix`](../modules/protobufs.md#trienodeprefix) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`SyncIds`](../modules/protobufs.md#syncids)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`SyncIds`](../modules/protobufs.md#syncids)) =>  |
 
 ___
 
 ### getAllUserDataMessagesByFid
 
-▸ **getAllUserDataMessagesByFid**(`request`, `callback`): `SurfaceCall`
+▸ **getAllUserDataMessagesByFid**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllUserDataMessagesByFid**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getAllUserDataMessagesByFid**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -303,13 +239,9 @@ ___
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllUserDataMessagesByFid**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getAllUserDataMessagesByFid**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -318,30 +250,22 @@ ___
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getAllVerificationMessagesByFid
 
-▸ **getAllVerificationMessagesByFid**(`request`, `callback`): `SurfaceCall`
+▸ **getAllVerificationMessagesByFid**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllVerificationMessagesByFid**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getAllVerificationMessagesByFid**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -349,13 +273,9 @@ ___
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getAllVerificationMessagesByFid**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getAllVerificationMessagesByFid**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -364,17 +284,13 @@ ___
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getCast
 
-▸ **getCast**(`request`, `callback`): `SurfaceCall`
+▸ **getCast**(`request`, `callback`)
 
 Casts
 
@@ -383,13 +299,9 @@ Casts
 | Name | Type |
 | :------ | :------ |
 | `request` | [`CastId`](../modules/protobufs.md#castid) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getCast**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getCast**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -397,13 +309,9 @@ Casts
 | :------ | :------ |
 | `request` | [`CastId`](../modules/protobufs.md#castid) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getCast**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getCast**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -412,30 +320,22 @@ Casts
 | `request` | [`CastId`](../modules/protobufs.md#castid) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
 ___
 
 ### getCastsByFid
 
-▸ **getCastsByFid**(`request`, `callback`): `SurfaceCall`
+▸ **getCastsByFid**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getCastsByFid**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getCastsByFid**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -443,13 +343,9 @@ ___
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getCastsByFid**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getCastsByFid**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -458,30 +354,22 @@ ___
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getCastsByMention
 
-▸ **getCastsByMention**(`request`, `callback`): `SurfaceCall`
+▸ **getCastsByMention**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getCastsByMention**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getCastsByMention**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -489,13 +377,9 @@ ___
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getCastsByMention**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getCastsByMention**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -504,30 +388,22 @@ ___
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getCastsByParent
 
-▸ **getCastsByParent**(`request`, `callback`): `SurfaceCall`
+▸ **getCastsByParent**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`CastId`](../modules/protobufs.md#castid) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getCastsByParent**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getCastsByParent**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -535,13 +411,9 @@ ___
 | :------ | :------ |
 | `request` | [`CastId`](../modules/protobufs.md#castid) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getCastsByParent**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getCastsByParent**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -550,30 +422,22 @@ ___
 | `request` | [`CastId`](../modules/protobufs.md#castid) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getEvent
 
-▸ **getEvent**(`request`, `callback`): `SurfaceCall`
+▸ **getEvent**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`EventRequest`](../modules/protobufs.md#eventrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`HubEvent`](../modules/protobufs.md#hubevent)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`HubEvent`](../modules/protobufs.md#hubevent)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getEvent**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getEvent**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -581,13 +445,9 @@ ___
 | :------ | :------ |
 | `request` | [`EventRequest`](../modules/protobufs.md#eventrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`HubEvent`](../modules/protobufs.md#hubevent)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`HubEvent`](../modules/protobufs.md#hubevent)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getEvent**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getEvent**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -596,30 +456,22 @@ ___
 | `request` | [`EventRequest`](../modules/protobufs.md#eventrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`HubEvent`](../modules/protobufs.md#hubevent)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`HubEvent`](../modules/protobufs.md#hubevent)) =>  |
 
 ___
 
 ### getFids
 
-▸ **getFids**(`request`, `callback`): `SurfaceCall`
+▸ **getFids**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`Empty`](../modules/protobufs.md#empty) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`FidsResponse`](../modules/protobufs.md#fidsresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`FidsResponse`](../modules/protobufs.md#fidsresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getFids**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getFids**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -627,13 +479,9 @@ ___
 | :------ | :------ |
 | `request` | [`Empty`](../modules/protobufs.md#empty) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`FidsResponse`](../modules/protobufs.md#fidsresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`FidsResponse`](../modules/protobufs.md#fidsresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getFids**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getFids**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -642,30 +490,22 @@ ___
 | `request` | [`Empty`](../modules/protobufs.md#empty) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`FidsResponse`](../modules/protobufs.md#fidsresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`FidsResponse`](../modules/protobufs.md#fidsresponse)) =>  |
 
 ___
 
 ### getIdRegistryEvent
 
-▸ **getIdRegistryEvent**(`request`, `callback`): `SurfaceCall`
+▸ **getIdRegistryEvent**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getIdRegistryEvent**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getIdRegistryEvent**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -673,13 +513,9 @@ ___
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getIdRegistryEvent**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getIdRegistryEvent**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -688,17 +524,13 @@ ___
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent)) =>  |
 
 ___
 
 ### getInfo
 
-▸ **getInfo**(`request`, `callback`): `SurfaceCall`
+▸ **getInfo**(`request`, `callback`)
 
 Sync Methods
 
@@ -707,13 +539,9 @@ Sync Methods
 | Name | Type |
 | :------ | :------ |
 | `request` | [`Empty`](../modules/protobufs.md#empty) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`HubInfoResponse`](../modules/protobufs.md#hubinforesponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`HubInfoResponse`](../modules/protobufs.md#hubinforesponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getInfo**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getInfo**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -721,13 +549,9 @@ Sync Methods
 | :------ | :------ |
 | `request` | [`Empty`](../modules/protobufs.md#empty) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`HubInfoResponse`](../modules/protobufs.md#hubinforesponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`HubInfoResponse`](../modules/protobufs.md#hubinforesponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getInfo**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getInfo**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -736,30 +560,22 @@ Sync Methods
 | `request` | [`Empty`](../modules/protobufs.md#empty) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`HubInfoResponse`](../modules/protobufs.md#hubinforesponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`HubInfoResponse`](../modules/protobufs.md#hubinforesponse)) =>  |
 
 ___
 
 ### getNameRegistryEvent
 
-▸ **getNameRegistryEvent**(`request`, `callback`): `SurfaceCall`
+▸ **getNameRegistryEvent**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`NameRegistryEventRequest`](../modules/protobufs.md#nameregistryeventrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getNameRegistryEvent**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getNameRegistryEvent**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -767,13 +583,9 @@ ___
 | :------ | :------ |
 | `request` | [`NameRegistryEventRequest`](../modules/protobufs.md#nameregistryeventrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getNameRegistryEvent**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getNameRegistryEvent**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -782,17 +594,13 @@ ___
 | `request` | [`NameRegistryEventRequest`](../modules/protobufs.md#nameregistryeventrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent)) =>  |
 
 ___
 
 ### getReaction
 
-▸ **getReaction**(`request`, `callback`): `SurfaceCall`
+▸ **getReaction**(`request`, `callback`)
 
 Reactions
 
@@ -801,13 +609,9 @@ Reactions
 | Name | Type |
 | :------ | :------ |
 | `request` | [`ReactionRequest`](../modules/protobufs.md#reactionrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getReaction**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getReaction**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -815,13 +619,9 @@ Reactions
 | :------ | :------ |
 | `request` | [`ReactionRequest`](../modules/protobufs.md#reactionrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getReaction**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getReaction**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -830,30 +630,22 @@ Reactions
 | `request` | [`ReactionRequest`](../modules/protobufs.md#reactionrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
 ___
 
 ### getReactionsByCast
 
-▸ **getReactionsByCast**(`request`, `callback`): `SurfaceCall`
+▸ **getReactionsByCast**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`ReactionsByCastRequest`](../modules/protobufs.md#reactionsbycastrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getReactionsByCast**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getReactionsByCast**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -861,13 +653,9 @@ ___
 | :------ | :------ |
 | `request` | [`ReactionsByCastRequest`](../modules/protobufs.md#reactionsbycastrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getReactionsByCast**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getReactionsByCast**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -876,30 +664,22 @@ ___
 | `request` | [`ReactionsByCastRequest`](../modules/protobufs.md#reactionsbycastrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getReactionsByFid
 
-▸ **getReactionsByFid**(`request`, `callback`): `SurfaceCall`
+▸ **getReactionsByFid**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`ReactionsByFidRequest`](../modules/protobufs.md#reactionsbyfidrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getReactionsByFid**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getReactionsByFid**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -907,13 +687,9 @@ ___
 | :------ | :------ |
 | `request` | [`ReactionsByFidRequest`](../modules/protobufs.md#reactionsbyfidrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getReactionsByFid**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getReactionsByFid**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -922,17 +698,13 @@ ___
 | `request` | [`ReactionsByFidRequest`](../modules/protobufs.md#reactionsbyfidrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getSigner
 
-▸ **getSigner**(`request`, `callback`): `SurfaceCall`
+▸ **getSigner**(`request`, `callback`)
 
 Signer
 
@@ -941,13 +713,9 @@ Signer
 | Name | Type |
 | :------ | :------ |
 | `request` | [`SignerRequest`](../modules/protobufs.md#signerrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getSigner**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getSigner**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -955,13 +723,9 @@ Signer
 | :------ | :------ |
 | `request` | [`SignerRequest`](../modules/protobufs.md#signerrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getSigner**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getSigner**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -970,30 +734,22 @@ Signer
 | `request` | [`SignerRequest`](../modules/protobufs.md#signerrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
 ___
 
 ### getSignersByFid
 
-▸ **getSignersByFid**(`request`, `callback`): `SurfaceCall`
+▸ **getSignersByFid**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getSignersByFid**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getSignersByFid**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -1001,13 +757,9 @@ ___
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getSignersByFid**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getSignersByFid**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -1016,30 +768,22 @@ ___
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getSyncMetadataByPrefix
 
-▸ **getSyncMetadataByPrefix**(`request`, `callback`): `SurfaceCall`
+▸ **getSyncMetadataByPrefix**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`TrieNodePrefix`](../modules/protobufs.md#trienodeprefix) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`TrieNodeMetadataResponse`](../modules/protobufs.md#trienodemetadataresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`TrieNodeMetadataResponse`](../modules/protobufs.md#trienodemetadataresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getSyncMetadataByPrefix**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getSyncMetadataByPrefix**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -1047,13 +791,9 @@ ___
 | :------ | :------ |
 | `request` | [`TrieNodePrefix`](../modules/protobufs.md#trienodeprefix) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`TrieNodeMetadataResponse`](../modules/protobufs.md#trienodemetadataresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`TrieNodeMetadataResponse`](../modules/protobufs.md#trienodemetadataresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getSyncMetadataByPrefix**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getSyncMetadataByPrefix**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -1062,30 +802,22 @@ ___
 | `request` | [`TrieNodePrefix`](../modules/protobufs.md#trienodeprefix) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`TrieNodeMetadataResponse`](../modules/protobufs.md#trienodemetadataresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`TrieNodeMetadataResponse`](../modules/protobufs.md#trienodemetadataresponse)) =>  |
 
 ___
 
 ### getSyncSnapshotByPrefix
 
-▸ **getSyncSnapshotByPrefix**(`request`, `callback`): `SurfaceCall`
+▸ **getSyncSnapshotByPrefix**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`TrieNodePrefix`](../modules/protobufs.md#trienodeprefix) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`TrieNodeSnapshotResponse`](../modules/protobufs.md#trienodesnapshotresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`TrieNodeSnapshotResponse`](../modules/protobufs.md#trienodesnapshotresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getSyncSnapshotByPrefix**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getSyncSnapshotByPrefix**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -1093,13 +825,9 @@ ___
 | :------ | :------ |
 | `request` | [`TrieNodePrefix`](../modules/protobufs.md#trienodeprefix) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`TrieNodeSnapshotResponse`](../modules/protobufs.md#trienodesnapshotresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`TrieNodeSnapshotResponse`](../modules/protobufs.md#trienodesnapshotresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getSyncSnapshotByPrefix**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getSyncSnapshotByPrefix**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -1108,17 +836,13 @@ ___
 | `request` | [`TrieNodePrefix`](../modules/protobufs.md#trienodeprefix) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`TrieNodeSnapshotResponse`](../modules/protobufs.md#trienodesnapshotresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`TrieNodeSnapshotResponse`](../modules/protobufs.md#trienodesnapshotresponse)) =>  |
 
 ___
 
 ### getUserData
 
-▸ **getUserData**(`request`, `callback`): `SurfaceCall`
+▸ **getUserData**(`request`, `callback`)
 
 User Data
 
@@ -1127,13 +851,9 @@ User Data
 | Name | Type |
 | :------ | :------ |
 | `request` | [`UserDataRequest`](../modules/protobufs.md#userdatarequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getUserData**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getUserData**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -1141,13 +861,9 @@ User Data
 | :------ | :------ |
 | `request` | [`UserDataRequest`](../modules/protobufs.md#userdatarequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getUserData**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getUserData**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -1156,30 +872,22 @@ User Data
 | `request` | [`UserDataRequest`](../modules/protobufs.md#userdatarequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
 ___
 
 ### getUserDataByFid
 
-▸ **getUserDataByFid**(`request`, `callback`): `SurfaceCall`
+▸ **getUserDataByFid**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getUserDataByFid**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getUserDataByFid**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -1187,13 +895,9 @@ ___
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getUserDataByFid**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getUserDataByFid**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -1202,17 +906,13 @@ ___
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### getVerification
 
-▸ **getVerification**(`request`, `callback`): `SurfaceCall`
+▸ **getVerification**(`request`, `callback`)
 
 Verifications
 
@@ -1221,13 +921,9 @@ Verifications
 | Name | Type |
 | :------ | :------ |
 | `request` | [`VerificationRequest`](../modules/protobufs.md#verificationrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getVerification**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getVerification**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -1235,13 +931,9 @@ Verifications
 | :------ | :------ |
 | `request` | [`VerificationRequest`](../modules/protobufs.md#verificationrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getVerification**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getVerification**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -1250,30 +942,22 @@ Verifications
 | `request` | [`VerificationRequest`](../modules/protobufs.md#verificationrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
 ___
 
 ### getVerificationsByFid
 
-▸ **getVerificationsByFid**(`request`, `callback`): `SurfaceCall`
+▸ **getVerificationsByFid**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getVerificationsByFid**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **getVerificationsByFid**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -1281,13 +965,9 @@ ___
 | :------ | :------ |
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **getVerificationsByFid**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **getVerificationsByFid**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -1296,30 +976,22 @@ ___
 | `request` | [`FidRequest`](../modules/protobufs.md#fidrequest) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`MessagesResponse`](../modules/protobufs.md#messagesresponse)) =>  |
 
 ___
 
 ### submitIdRegistryEvent
 
-▸ **submitIdRegistryEvent**(`request`, `callback`): `SurfaceCall`
+▸ **submitIdRegistryEvent**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **submitIdRegistryEvent**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **submitIdRegistryEvent**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -1327,13 +999,9 @@ ___
 | :------ | :------ |
 | `request` | [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **submitIdRegistryEvent**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **submitIdRegistryEvent**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -1342,17 +1010,13 @@ ___
 | `request` | [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`IdRegistryEvent`](../modules/protobufs.md#idregistryevent)) =>  |
 
 ___
 
 ### submitMessage
 
-▸ **submitMessage**(`request`, `callback`): `SurfaceCall`
+▸ **submitMessage**(`request`, `callback`)
 
 Submit Methods
 
@@ -1361,13 +1025,9 @@ Submit Methods
 | Name | Type |
 | :------ | :------ |
 | `request` | [`Message`](../modules/protobufs.md#message) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **submitMessage**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **submitMessage**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -1375,13 +1035,9 @@ Submit Methods
 | :------ | :------ |
 | `request` | [`Message`](../modules/protobufs.md#message) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **submitMessage**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **submitMessage**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -1390,30 +1046,22 @@ Submit Methods
 | `request` | [`Message`](../modules/protobufs.md#message) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`Message`](../modules/protobufs.md#message)) =>  |
 
 ___
 
 ### submitNameRegistryEvent
 
-▸ **submitNameRegistryEvent**(`request`, `callback`): `SurfaceCall`
+▸ **submitNameRegistryEvent**(`request`, `callback`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `request` | [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent) |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **submitNameRegistryEvent**(`request`, `metadata`, `callback`): `SurfaceCall`
+▸ **submitNameRegistryEvent**(`request`, `metadata`, `callback`)
 
 #### Parameters
 
@@ -1421,13 +1069,9 @@ ___
 | :------ | :------ |
 | `request` | [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent) |
 | `metadata` | `Metadata` |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent)) => `void` |
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent)) =>  |
 
-#### Returns
-
-`SurfaceCall`
-
-▸ **submitNameRegistryEvent**(`request`, `metadata`, `options`, `callback`): `SurfaceCall`
+▸ **submitNameRegistryEvent**(`request`, `metadata`, `options`, `callback`)
 
 #### Parameters
 
@@ -1436,17 +1080,13 @@ ___
 | `request` | [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent) |
 | `metadata` | `Metadata` |
 | `options` | `Partial`<`CallOptions`\> |
-| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent)) => `void` |
-
-#### Returns
-
-`SurfaceCall`
+| `callback` | (`error`: ``null`` \| `ServiceError`, `response`: [`NameRegistryEvent`](../modules/protobufs.md#nameregistryevent)) =>  |
 
 ___
 
 ### subscribe
 
-▸ **subscribe**(`request`, `options?`): `ClientReadableStream`<[`HubEvent`](../modules/protobufs.md#hubevent)\>
+▸ **subscribe**(`request`, `options?`)
 
 Event Methods
 
@@ -1457,11 +1097,7 @@ Event Methods
 | `request` | [`SubscribeRequest`](../modules/protobufs.md#subscriberequest) |
 | `options?` | `Partial`<`CallOptions`\> |
 
-#### Returns
-
-`ClientReadableStream`<[`HubEvent`](../modules/protobufs.md#hubevent)\>
-
-▸ **subscribe**(`request`, `metadata?`, `options?`): `ClientReadableStream`<[`HubEvent`](../modules/protobufs.md#hubevent)\>
+▸ **subscribe**(`request`, `metadata?`, `options?`)
 
 #### Parameters
 
@@ -1470,7 +1106,3 @@ Event Methods
 | `request` | [`SubscribeRequest`](../modules/protobufs.md#subscriberequest) |
 | `metadata?` | `Metadata` |
 | `options?` | `Partial`<`CallOptions`\> |
-
-#### Returns
-
-`ClientReadableStream`<[`HubEvent`](../modules/protobufs.md#hubevent)\>

--- a/packages/js/docs/modules.md
+++ b/packages/js/docs/modules.md
@@ -348,7 +348,7 @@ Make a message to add an EdDSA signer
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<VerificationAddEd25519Message>` | [`VerificationAddEd25519Message`](modules/types.md#verificationadded25519message) | A `HubAsyncResult` that contains the valid `VerificationAddEd25519Message`. |
+| `HubAsyncResult<VerificationAddEthAddressMessage>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage) | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage`. |
 
 **`Example`**
 
@@ -466,7 +466,7 @@ Make a message to set user data (pfp, bio, display name, etc)
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<UserDataMessage>` | [`UserDataMessage`](modules/types.md#userdatamessage) | A `HubAsyncResult` that contains the valid `UserDataMessage`. |
+| `HubAsyncResult<UserDataAddMessage>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage) | A `HubAsyncResult` that contains the valid `UserDataMessage`. |
 
 **`Example`**
 

--- a/packages/js/docs/modules.md
+++ b/packages/js/docs/modules.md
@@ -144,10 +144,6 @@ const castRemove = await makeCastRemove(removeBody, dataOptions, ed25519Signer);
 await client.submitMessage(castRemove._unsafeUnwrap());
 ```
 
-**`signature`**
-
-`makeCastRemove(bodyJson, dataOptions, signer): HubAsyncResult<CastRemoveMessage>`
-
 #### Parameters
 
 | Name | Type | Description |
@@ -262,10 +258,6 @@ const like = await makeReactionAdd(reactionLikeBody, dataOptions, ed25519Signer)
 await client.submitMessage(like._unsafeUnwrap());
 ```
 
-**`signature`**
-
-`makeReactCast(bodyJson, dataOptions, signer): HubAsyncResult<ReactionAddMessage>`
-
 #### Parameters
 
 | Name | Type | Description |
@@ -324,10 +316,6 @@ const unlike = await makeReactionRemove(reactionLikeBody, dataOptions, ed25519Si
 await client.submitMessage(unlike._unsafeUnwrap());
 ```
 
-**`signature`**
-
-`makeReactionRemove(bodyJson, dataOptions, signer): HubAsyncResult<ReactionRemoveMessage>`
-
 #### Parameters
 
 | Name | Type | Description |
@@ -383,10 +371,6 @@ const signerAdd = await makeSignerAdd({ signer: ed25519Signer.signerKeyHex }, da
 await client.submitMessage(signerAdd._unsafeUnwrap());
 ```
 
-**`signature`**
-
-`makeSignerAdd(bodyJson, dataOptions, signer): HubAsyncResult<SignerAddMessage>`
-
 #### Parameters
 
 | Name | Type | Description |
@@ -441,10 +425,6 @@ const dataOptions = {
 const signerRemove = await makeSignerRemove({ signer: ed25519Signer.signerKeyHex }, dataOptions, eip712Signer);
 await client.submitMessage(signerRemove._unsafeUnwrap());
 ```
-
-**`signature`**
-
-`makeSignerRemove(bodyJson, dataOptions, signer): HubAsyncResult<SignerRemoveMessage>`
 
 #### Parameters
 
@@ -502,10 +482,6 @@ const userDataPfpAdd = await makeUserDataAdd(userDataPfpBody, dataOptions, ed255
 await client.submitMessage(userDataPfpAdd._unsafeUnwrap());
 ```
 
-**`signature`**
-
-`makeUserData(bodyJson, dataOptions, signer): HubAsyncResult<UserDataAddMessage>`
-
 #### Parameters
 
 | Name | Type | Description |
@@ -526,7 +502,7 @@ TODO DOCS
 
 | Value | Type | Description |
 | :---- | :--- | :---------- |
-| `HubAsyncResult<VerificationAddMessage>` | [`VerificationAddMessage`](modules/types.md#verificationaddmessage) | A `HubAsyncResult` that contains the valid `VerificationAddMessage`. |
+| `HubAsyncResult<VerificationAddEthAddressMessage>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage) | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage`. |
 
 **`Example`**
 
@@ -587,10 +563,6 @@ const verificationMessage = await makeVerificationAddEthAddress(
 );
 await client.submitMessage(verificationMessage._unsafeUnwrap());
 ```
-
-**`signature`**
-
-`makeVerificationAddEthAddress(bodyJson, dataOptions, signer): HubAsyncResult<VerificationAddEthAddressMessage>`
 
 #### Parameters
 
@@ -664,10 +636,6 @@ const verificationRemoveMessage = await makeVerificationRemove(
 
 await client.submitMessage(verificationRemoveMessage._unsafeUnwrap());
 ```
-
-**`signature`**
-
-`makeVerificationRemove(bodyJson, dataOptions, signer): HubAsyncResult<VerificationRemoveMessage>`
 
 #### Parameters
 

--- a/packages/js/docs/modules.md
+++ b/packages/js/docs/modules.md
@@ -57,8 +57,8 @@ Make a message to add a cast
 
 #### Returns
 
-| Value                            | Type                                                | Description                                     |
-| :------------------------------- | :-------------------------------------------------- | :---------------------------------------------- |
+| Value | Type | Description |
+| :---- | :--- | :---------- |
 | `HubAsyncResult<CastAddMessage>` | [`CastAddMessage`](modules/types.md#castaddmessage) | A Result that contains the valid CastAddMessage |
 
 **`Example`**
@@ -96,7 +96,7 @@ await client.submitMessage(cast._unsafeUnwrap());
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `bodyJson` | [`CastAddBody`](modules/types.md#castaddbody) | A valid CastAdd body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the Cast. |
+| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the message. |
 | `signer` | `Ed25519Signer` | A valid Ed25519Signer that will sign the message. |
 
 ___
@@ -109,8 +109,8 @@ Make a message to remove a cast
 
 #### Returns
 
-| Value                                | Type                                                | Description                                      |
-| :----------------------------------- | :-------------------------------------------------- | :----------------------------------------------- |
+| Value | Type | Description |
+| :---- | :--- | :---------- |
 | `HubAsyncResult<CastRemoveMessage>` | [`CastRemoveMessage`](modules/types.md#castremovemessage) | A `HubAsyncResult` that contains the valid `CastRemoveMessage`. |
 
 **`Example`**
@@ -153,7 +153,7 @@ await client.submitMessage(castRemove._unsafeUnwrap());
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `bodyJson` | [`CastRemoveBody`](modules/types.md#castremovebody) | A valid CastRemove body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the Cast. |
+| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the message. |
 | `signer` | `Ed25519Signer` | A valid Ed25519Signer that will sign the message. |
 
 ___
@@ -220,6 +220,12 @@ ___
 
 Make a message to react a cast (like or recast)
 
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<ReactionAddMessage>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage) | A `HubAsyncResult` that contains the valid `ReactionAddMessage`. |
+
 **`Example`**
 
 ```typescript
@@ -262,11 +268,11 @@ await client.submitMessage(like._unsafeUnwrap());
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`ReactionBody`](modules/types.md#reactionbody) |
-| `dataOptions` | `MessageDataOptions` |
-| `signer` | `Ed25519Signer` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bodyJson` | [`ReactionBody`](modules/types.md#reactionbody) | A valid ReactionAdd body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the message. |
+| `signer` | `Ed25519Signer` | A valid Ed25519Signer that will sign the message. |
 
 ___
 
@@ -275,6 +281,12 @@ ___
 ▸ **makeReactionRemove**(`bodyJson`, `dataOptions`, `signer`)
 
 Make a message to undo a reaction to a cast (unlike or undo recast)
+
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<ReactionRemoveMessage>` | [`ReactionRemoveMessage`](modules/types.md#reactionremovemessage) | A `HubAsyncResult` that contains the valid `ReactionRemoveMessage`. |
 
 **`Example`**
 
@@ -318,11 +330,11 @@ await client.submitMessage(unlike._unsafeUnwrap());
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`ReactionBody`](modules/types.md#reactionbody) |
-| `dataOptions` | `MessageDataOptions` |
-| `signer` | `Ed25519Signer` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bodyJson` | [`ReactionBody`](modules/types.md#reactionbody) | A valid ReactionRemove body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the message. |
+| `signer` | `Ed25519Signer` | A valid Ed25519Signer that will sign the message. |
 
 ___
 
@@ -331,6 +343,12 @@ ___
 ▸ **makeSignerAdd**(`bodyJson`, `dataOptions`, `signer`)
 
 Make a message to add an EdDSA signer
+
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<VerificationAddEd25519Message>` | [`VerificationAddEd25519Message`](modules/types.md#verificationadded25519message) | A `HubAsyncResult` that contains the valid `VerificationAddEd25519Message`. |
 
 **`Example`**
 
@@ -371,11 +389,11 @@ await client.submitMessage(signerAdd._unsafeUnwrap());
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`SignerBody`](modules/types.md#signerbody) |
-| `dataOptions` | `MessageDataOptions` |
-| `signer` | `Eip712Signer` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bodyJson` | [`SignerBody`](modules/types.md#signerbody) | A valid VerificationAddEd25519 body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the message. |
+| `signer` | `Eip712Signer` | A valid Eip712Signer that will sign the message. |
 
 ___
 
@@ -384,6 +402,12 @@ ___
 ▸ **makeSignerRemove**(`bodyJson`, `dataOptions`, `signer`)
 
 Make a message to remove an EdDSA signer
+
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<SignerRemoveMessage>` | [`SignerRemoveMessage`](modules/types.md#signerremovemessage) | A `HubAsyncResult` that contains the valid `SignerRemoveMessage`. |
 
 **`Example`**
 
@@ -424,11 +448,11 @@ await client.submitMessage(signerRemove._unsafeUnwrap());
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`SignerBody`](modules/types.md#signerbody) |
-| `dataOptions` | `MessageDataOptions` |
-| `signer` | `Eip712Signer` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bodyJson` | [`SignerBody`](modules/types.md#signerbody) | A valid SignerRemove body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the message. |
+| `signer` | `Eip712Signer` | A valid Eip712Signer that will sign the message. |
 
 ___
 
@@ -437,6 +461,12 @@ ___
 ▸ **makeUserDataAdd**(`bodyJson`, `dataOptions`, `signer`)
 
 Make a message to set user data (pfp, bio, display name, etc)
+
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<UserDataMessage>` | [`UserDataMessage`](modules/types.md#userdatamessage) | A `HubAsyncResult` that contains the valid `UserDataMessage`. |
 
 **`Example`**
 
@@ -478,11 +508,11 @@ await client.submitMessage(userDataPfpAdd._unsafeUnwrap());
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`UserDataBody`](modules/types.md#userdatabody) |
-| `dataOptions` | `MessageDataOptions` |
-| `signer` | `Ed25519Signer` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bodyJson` | [`UserDataBody`](modules/types.md#userdatabody) | A valid UserData body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the message. |
+| `signer` | `Ed25519Signer` | A valid Eip712Signer that will sign the message. |
 
 ___
 
@@ -491,6 +521,12 @@ ___
 ▸ **makeVerificationAddEthAddress**(`bodyJson`, `dataOptions`, `signer`)
 
 TODO DOCS
+
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<VerificationAddMessage>` | [`VerificationAddMessage`](modules/types.md#verificationaddmessage) | A `HubAsyncResult` that contains the valid `VerificationAddMessage`. |
 
 **`Example`**
 
@@ -558,11 +594,11 @@ await client.submitMessage(verificationMessage._unsafeUnwrap());
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`VerificationAddEthAddressBody`](modules/types.md#verificationaddethaddressbody) |
-| `dataOptions` | `MessageDataOptions` |
-| `signer` | `Ed25519Signer` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bodyJson` | [`VerificationAddEthAddressBody`](modules/types.md#verificationaddethaddressbody) | A valid VerificationAdd body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the message. |
+| `signer` | `Ed25519Signer` | A valid Ed25519Signer that will sign the message. |
 
 ___
 
@@ -571,6 +607,12 @@ ___
 ▸ **makeVerificationRemove**(`bodyJson`, `dataOptions`, `signer`)
 
 TODO DOCS: description
+
+#### Returns
+
+| Value | Type | Description |
+| :---- | :--- | :---------- |
+| `HubAsyncResult<VerificationRemoveMessage>` | [`VerificationRemoveMessage`](modules/types.md#verificationremovemessage) | A `HubAsyncResult` that contains the valid `VerificationRemoveMessage`. |
 
 **`Example`**
 
@@ -629,8 +671,8 @@ await client.submitMessage(verificationRemoveMessage._unsafeUnwrap());
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`VerificationRemoveBody`](modules/types.md#verificationremovebody) |
-| `dataOptions` | `MessageDataOptions` |
-| `signer` | `Ed25519Signer` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bodyJson` | [`VerificationRemoveBody`](modules/types.md#verificationremovebody) | A valid VerificationRemove body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the message. |
+| `signer` | `Ed25519Signer` | A valid Ed25519Signer that will sign the message. |

--- a/packages/js/docs/modules.md
+++ b/packages/js/docs/modules.md
@@ -55,6 +55,12 @@
 
 Make a message to add a cast
 
+#### Returns
+
+| Value                            | Type          | Description                                     |
+| -------------------------------- | ------------- | ----------------------------------------------- |
+| `HubAsyncResult<CastAddMessage>` | `CastAddBody` | A Result that contains the valid CastAddMessage |
+
 **`Example`**
 
 ```typescript
@@ -85,17 +91,13 @@ const cast = await makeCastAdd({ text: 'hello world' }, dataOptions, ed25519Sign
 await client.submitMessage(cast._unsafeUnwrap());
 ```
 
-**`signature`**
-
-`makeCastAdd(bodyJson, dataOptions, signer): HubAsyncResult<CastAddMessage>`
-
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`CastAddBody`](modules/types.md#castaddbody) |
-| `dataOptions` | `MessageDataOptions` |
-| `signer` | `Ed25519Signer` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bodyJson` | [`CastAddBody`](modules/types.md#castaddbody) | The body of the message |
+| `dataOptions` | `MessageDataOptions` | The data of the message |
+| `signer` | `Ed25519Signer` | The signer of the message |
 
 ___
 

--- a/packages/js/docs/modules.md
+++ b/packages/js/docs/modules.md
@@ -57,9 +57,9 @@ Make a message to add a cast
 
 #### Returns
 
-| Value                            | Type          | Description                                     |
-| -------------------------------- | ------------- | ----------------------------------------------- |
-| `HubAsyncResult<CastAddMessage>` | `CastAddBody` | A Result that contains the valid CastAddMessage |
+| Value                            | Type                                          | Description                                     |
+| -------------------------------- | --------------------------------------------- | ----------------------------------------------- |
+| `HubAsyncResult<CastAddMessage>` | [`CastAddMessage`](modules/types.md#castaddmessage) | A Result that contains the valid CastAddMessage |
 
 **`Example`**
 
@@ -95,9 +95,9 @@ await client.submitMessage(cast._unsafeUnwrap());
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `bodyJson` | [`CastAddBody`](modules/types.md#castaddbody) | The body of the message |
-| `dataOptions` | `MessageDataOptions` | The data of the message |
-| `signer` | `Ed25519Signer` | The signer of the message |
+| `bodyJson` | [`CastAddBody`](modules/types.md#castaddbody) | A valid CastAdd body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the Cast. |
+| `signer` | `Ed25519Signer` | A valid Ed25519Signer that will sign the message. |
 
 ___
 

--- a/packages/js/docs/modules.md
+++ b/packages/js/docs/modules.md
@@ -57,8 +57,8 @@ Make a message to add a cast
 
 #### Returns
 
-| Value                            | Type                                          | Description                                     |
-| -------------------------------- | --------------------------------------------- | ----------------------------------------------- |
+| Value                            | Type                                                | Description                                     |
+| :------------------------------- | :-------------------------------------------------- | :---------------------------------------------- |
 | `HubAsyncResult<CastAddMessage>` | [`CastAddMessage`](modules/types.md#castaddmessage) | A Result that contains the valid CastAddMessage |
 
 **`Example`**
@@ -107,6 +107,12 @@ ___
 
 Make a message to remove a cast
 
+#### Returns
+
+| Value                                | Type                                                | Description                                      |
+| :----------------------------------- | :-------------------------------------------------- | :----------------------------------------------- |
+| `HubAsyncResult<CastRemoveMessage>` | [`CastRemoveMessage`](modules/types.md#castremovemessage) | A `HubAsyncResult` that contains the valid `CastRemoveMessage`. |
+
 **`Example`**
 
 ```typescript
@@ -144,11 +150,11 @@ await client.submitMessage(castRemove._unsafeUnwrap());
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `bodyJson` | [`CastRemoveBody`](modules/types.md#castremovebody) |
-| `dataOptions` | `MessageDataOptions` |
-| `signer` | `Ed25519Signer` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `bodyJson` | [`CastRemoveBody`](modules/types.md#castremovebody) | A valid CastRemove body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions` | Optional arguments to construct the Cast. |
+| `signer` | `Ed25519Signer` | A valid Ed25519Signer that will sign the message. |
 
 ___
 

--- a/packages/js/docs/modules.md
+++ b/packages/js/docs/modules.md
@@ -51,7 +51,7 @@
 
 ### makeCastAdd
 
-▸ **makeCastAdd**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`CastAddBody`](modules/types.md#castaddbody), [`MESSAGE_TYPE_CAST_ADD`](enums/protobufs.MessageType.md#message_type_cast_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **makeCastAdd**(`bodyJson`, `dataOptions`, `signer`)
 
 Make a message to add a cast
 
@@ -85,6 +85,10 @@ const cast = await makeCastAdd({ text: 'hello world' }, dataOptions, ed25519Sign
 await client.submitMessage(cast._unsafeUnwrap());
 ```
 
+**`signature`**
+
+`makeCastAdd(bodyJson, dataOptions, signer): HubAsyncResult<CastAddMessage>`
+
 #### Parameters
 
 | Name | Type |
@@ -93,15 +97,11 @@ await client.submitMessage(cast._unsafeUnwrap());
 | `dataOptions` | `MessageDataOptions` |
 | `signer` | `Ed25519Signer` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`CastAddBody`](modules/types.md#castaddbody), [`MESSAGE_TYPE_CAST_ADD`](enums/protobufs.MessageType.md#message_type_cast_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
 ___
 
 ### makeCastRemove
 
-▸ **makeCastRemove**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`CastRemoveBody`](modules/types.md#castremovebody), [`MESSAGE_TYPE_CAST_REMOVE`](enums/protobufs.MessageType.md#message_type_cast_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **makeCastRemove**(`bodyJson`, `dataOptions`, `signer`)
 
 Make a message to remove a cast
 
@@ -136,6 +136,10 @@ const castRemove = await makeCastRemove(removeBody, dataOptions, ed25519Signer);
 await client.submitMessage(castRemove._unsafeUnwrap());
 ```
 
+**`signature`**
+
+`makeCastRemove(bodyJson, dataOptions, signer): HubAsyncResult<CastRemoveMessage>`
+
 #### Parameters
 
 | Name | Type |
@@ -144,15 +148,11 @@ await client.submitMessage(castRemove._unsafeUnwrap());
 | `dataOptions` | `MessageDataOptions` |
 | `signer` | `Ed25519Signer` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`CastRemoveBody`](modules/types.md#castremovebody), [`MESSAGE_TYPE_CAST_REMOVE`](enums/protobufs.MessageType.md#message_type_cast_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
 ___
 
 ### makeMessageHash
 
-▸ **makeMessageHash**(`messageData`): `HubAsyncResult`<`string`\>
+▸ **makeMessageHash**(`messageData`)
 
 TODO DOCS: description
 
@@ -175,17 +175,11 @@ await client.submitMessage(message)
 | :------ | :------ |
 | `messageData` | [`MessageData`](modules/types.md#messagedata)<[`MessageBody`](modules/types.md#messagebody), [`MessageType`](enums/protobufs.MessageType.md)\> |
 
-#### Returns
-
-`HubAsyncResult`<`string`\>
-
-...
-
 ___
 
 ### makeMessageWithSignature
 
-▸ **makeMessageWithSignature**(`messageData`, `signerOptions`, `signature`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`MessageBody`](modules/types.md#messagebody), [`MessageType`](enums/protobufs.MessageType.md)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **makeMessageWithSignature**(`messageData`, `signerOptions`, `signature`)
 
 TODO DOCS: description
 
@@ -210,17 +204,11 @@ await client.submitMessage(message)
 | `signerOptions` | `MessageSignerOptions` |
 | `signature` | `string` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`MessageBody`](modules/types.md#messagebody), [`MessageType`](enums/protobufs.MessageType.md)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
-...
-
 ___
 
 ### makeReactionAdd
 
-▸ **makeReactionAdd**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_ADD`](enums/protobufs.MessageType.md#message_type_reaction_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **makeReactionAdd**(`bodyJson`, `dataOptions`, `signer`)
 
 Make a message to react a cast (like or recast)
 
@@ -260,6 +248,10 @@ const like = await makeReactionAdd(reactionLikeBody, dataOptions, ed25519Signer)
 await client.submitMessage(like._unsafeUnwrap());
 ```
 
+**`signature`**
+
+`makeReactCast(bodyJson, dataOptions, signer): HubAsyncResult<ReactionAddMessage>`
+
 #### Parameters
 
 | Name | Type |
@@ -268,15 +260,11 @@ await client.submitMessage(like._unsafeUnwrap());
 | `dataOptions` | `MessageDataOptions` |
 | `signer` | `Ed25519Signer` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_ADD`](enums/protobufs.MessageType.md#message_type_reaction_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
 ___
 
 ### makeReactionRemove
 
-▸ **makeReactionRemove**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_REMOVE`](enums/protobufs.MessageType.md#message_type_reaction_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **makeReactionRemove**(`bodyJson`, `dataOptions`, `signer`)
 
 Make a message to undo a reaction to a cast (unlike or undo recast)
 
@@ -316,6 +304,10 @@ const unlike = await makeReactionRemove(reactionLikeBody, dataOptions, ed25519Si
 await client.submitMessage(unlike._unsafeUnwrap());
 ```
 
+**`signature`**
+
+`makeReactionRemove(bodyJson, dataOptions, signer): HubAsyncResult<ReactionRemoveMessage>`
+
 #### Parameters
 
 | Name | Type |
@@ -324,15 +316,11 @@ await client.submitMessage(unlike._unsafeUnwrap());
 | `dataOptions` | `MessageDataOptions` |
 | `signer` | `Ed25519Signer` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`ReactionBody`](modules/types.md#reactionbody), [`MESSAGE_TYPE_REACTION_REMOVE`](enums/protobufs.MessageType.md#message_type_reaction_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
 ___
 
 ### makeSignerAdd
 
-▸ **makeSignerAdd**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`SignerBody`](modules/types.md#signerbody), [`MESSAGE_TYPE_SIGNER_ADD`](enums/protobufs.MessageType.md#message_type_signer_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **makeSignerAdd**(`bodyJson`, `dataOptions`, `signer`)
 
 Make a message to add an EdDSA signer
 
@@ -369,6 +357,10 @@ const signerAdd = await makeSignerAdd({ signer: ed25519Signer.signerKeyHex }, da
 await client.submitMessage(signerAdd._unsafeUnwrap());
 ```
 
+**`signature`**
+
+`makeSignerAdd(bodyJson, dataOptions, signer): HubAsyncResult<SignerAddMessage>`
+
 #### Parameters
 
 | Name | Type |
@@ -377,15 +369,11 @@ await client.submitMessage(signerAdd._unsafeUnwrap());
 | `dataOptions` | `MessageDataOptions` |
 | `signer` | `Eip712Signer` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`SignerBody`](modules/types.md#signerbody), [`MESSAGE_TYPE_SIGNER_ADD`](enums/protobufs.MessageType.md#message_type_signer_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
 ___
 
 ### makeSignerRemove
 
-▸ **makeSignerRemove**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`SignerBody`](modules/types.md#signerbody), [`MESSAGE_TYPE_SIGNER_REMOVE`](enums/protobufs.MessageType.md#message_type_signer_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **makeSignerRemove**(`bodyJson`, `dataOptions`, `signer`)
 
 Make a message to remove an EdDSA signer
 
@@ -422,6 +410,10 @@ const signerRemove = await makeSignerRemove({ signer: ed25519Signer.signerKeyHex
 await client.submitMessage(signerRemove._unsafeUnwrap());
 ```
 
+**`signature`**
+
+`makeSignerRemove(bodyJson, dataOptions, signer): HubAsyncResult<SignerRemoveMessage>`
+
 #### Parameters
 
 | Name | Type |
@@ -430,15 +422,11 @@ await client.submitMessage(signerRemove._unsafeUnwrap());
 | `dataOptions` | `MessageDataOptions` |
 | `signer` | `Eip712Signer` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`SignerBody`](modules/types.md#signerbody), [`MESSAGE_TYPE_SIGNER_REMOVE`](enums/protobufs.MessageType.md#message_type_signer_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
 ___
 
 ### makeUserDataAdd
 
-▸ **makeUserDataAdd**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`UserDataBody`](modules/types.md#userdatabody), [`MESSAGE_TYPE_USER_DATA_ADD`](enums/protobufs.MessageType.md#message_type_user_data_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **makeUserDataAdd**(`bodyJson`, `dataOptions`, `signer`)
 
 Make a message to set user data (pfp, bio, display name, etc)
 
@@ -476,6 +464,10 @@ const userDataPfpAdd = await makeUserDataAdd(userDataPfpBody, dataOptions, ed255
 await client.submitMessage(userDataPfpAdd._unsafeUnwrap());
 ```
 
+**`signature`**
+
+`makeUserData(bodyJson, dataOptions, signer): HubAsyncResult<UserDataAddMessage>`
+
 #### Parameters
 
 | Name | Type |
@@ -484,17 +476,13 @@ await client.submitMessage(userDataPfpAdd._unsafeUnwrap());
 | `dataOptions` | `MessageDataOptions` |
 | `signer` | `Ed25519Signer` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`UserDataBody`](modules/types.md#userdatabody), [`MESSAGE_TYPE_USER_DATA_ADD`](enums/protobufs.MessageType.md#message_type_user_data_add)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
 ___
 
 ### makeVerificationAddEthAddress
 
-▸ **makeVerificationAddEthAddress**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`VerificationAddEthAddressBody`](modules/types.md#verificationaddethaddressbody), [`MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS`](enums/protobufs.MessageType.md#message_type_verification_add_eth_address)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **makeVerificationAddEthAddress**(`bodyJson`, `dataOptions`, `signer`)
 
-TODO DOCS: description
+TODO DOCS
 
 **`Example`**
 
@@ -556,6 +544,10 @@ const verificationMessage = await makeVerificationAddEthAddress(
 await client.submitMessage(verificationMessage._unsafeUnwrap());
 ```
 
+**`signature`**
+
+`makeVerificationAddEthAddress(bodyJson, dataOptions, signer): HubAsyncResult<VerificationAddEthAddressMessage>`
+
 #### Parameters
 
 | Name | Type |
@@ -564,15 +556,11 @@ await client.submitMessage(verificationMessage._unsafeUnwrap());
 | `dataOptions` | `MessageDataOptions` |
 | `signer` | `Ed25519Signer` |
 
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`VerificationAddEthAddressBody`](modules/types.md#verificationaddethaddressbody), [`MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS`](enums/protobufs.MessageType.md#message_type_verification_add_eth_address)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
 ___
 
 ### makeVerificationRemove
 
-▸ **makeVerificationRemove**(`bodyJson`, `dataOptions`, `signer`): `HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`VerificationRemoveBody`](modules/types.md#verificationremovebody), [`MESSAGE_TYPE_VERIFICATION_REMOVE`](enums/protobufs.MessageType.md#message_type_verification_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **makeVerificationRemove**(`bodyJson`, `dataOptions`, `signer`)
 
 TODO DOCS: description
 
@@ -627,6 +615,10 @@ const verificationRemoveMessage = await makeVerificationRemove(
 await client.submitMessage(verificationRemoveMessage._unsafeUnwrap());
 ```
 
+**`signature`**
+
+`makeVerificationRemove(bodyJson, dataOptions, signer): HubAsyncResult<VerificationRemoveMessage>`
+
 #### Parameters
 
 | Name | Type |
@@ -634,7 +626,3 @@ await client.submitMessage(verificationRemoveMessage._unsafeUnwrap());
 | `bodyJson` | [`VerificationRemoveBody`](modules/types.md#verificationremovebody) |
 | `dataOptions` | `MessageDataOptions` |
 | `signer` | `Ed25519Signer` |
-
-#### Returns
-
-`HubAsyncResult`<`Readonly`<{ `_protobuf`: [`Message`](modules/protobufs.md#message) ; `data`: [`MessageData`](modules/types.md#messagedata)<[`VerificationRemoveBody`](modules/types.md#verificationremovebody), [`MESSAGE_TYPE_VERIFICATION_REMOVE`](enums/protobufs.MessageType.md#message_type_verification_remove)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>

--- a/packages/js/docs/modules/protobufs.md
+++ b/packages/js/docs/modules/protobufs.md
@@ -374,22 +374,22 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `service` | { `deleteAllMessagesFromDb`: { `path`: ``"/AdminService/DeleteAllMessagesFromDb"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `responseSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `responseStream`: ``false``  } ; `rebuildSyncTrie`: { `path`: ``"/AdminService/RebuildSyncTrie"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `responseSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `responseStream`: ``false``  }  } |
-| `service.deleteAllMessagesFromDb` | { `path`: ``"/AdminService/DeleteAllMessagesFromDb"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `responseSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service` | { `deleteAllMessagesFromDb`: { `path`: ``"/AdminService/DeleteAllMessagesFromDb"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `responseStream`: ``false``  } ; `rebuildSyncTrie`: { `path`: ``"/AdminService/RebuildSyncTrie"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `responseStream`: ``false``  }  } |
+| `service.deleteAllMessagesFromDb` | { `path`: ``"/AdminService/DeleteAllMessagesFromDb"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `responseStream`: ``false``  } |
 | `service.deleteAllMessagesFromDb.path` | ``"/AdminService/DeleteAllMessagesFromDb"`` |
-| `service.deleteAllMessagesFromDb.requestDeserialize` | (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) |
-| `service.deleteAllMessagesFromDb.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` |
+| `service.deleteAllMessagesFromDb.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.deleteAllMessagesFromDb.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) =>  |
 | `service.deleteAllMessagesFromDb.requestStream` | ``false`` |
-| `service.deleteAllMessagesFromDb.responseDeserialize` | (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) |
-| `service.deleteAllMessagesFromDb.responseSerialize` | (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` |
+| `service.deleteAllMessagesFromDb.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.deleteAllMessagesFromDb.responseSerialize` | (`value`: [`Empty`](protobufs.md#empty)) =>  |
 | `service.deleteAllMessagesFromDb.responseStream` | ``false`` |
-| `service.rebuildSyncTrie` | { `path`: ``"/AdminService/RebuildSyncTrie"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `responseSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.rebuildSyncTrie` | { `path`: ``"/AdminService/RebuildSyncTrie"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `responseStream`: ``false``  } |
 | `service.rebuildSyncTrie.path` | ``"/AdminService/RebuildSyncTrie"`` |
-| `service.rebuildSyncTrie.requestDeserialize` | (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) |
-| `service.rebuildSyncTrie.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` |
+| `service.rebuildSyncTrie.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.rebuildSyncTrie.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) =>  |
 | `service.rebuildSyncTrie.requestStream` | ``false`` |
-| `service.rebuildSyncTrie.responseDeserialize` | (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) |
-| `service.rebuildSyncTrie.responseSerialize` | (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` |
+| `service.rebuildSyncTrie.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.rebuildSyncTrie.responseSerialize` | (`value`: [`Empty`](protobufs.md#empty)) =>  |
 | `service.rebuildSyncTrie.responseStream` | ``false`` |
 
 ___
@@ -402,21 +402,21 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `deleteAllMessagesFromDb` | { `path`: ``"/AdminService/DeleteAllMessagesFromDb"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `responseSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `responseStream`: ``false``  } |
+| `deleteAllMessagesFromDb` | { `path`: ``"/AdminService/DeleteAllMessagesFromDb"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `responseStream`: ``false``  } |
 | `deleteAllMessagesFromDb.path` | ``"/AdminService/DeleteAllMessagesFromDb"`` |
-| `deleteAllMessagesFromDb.requestDeserialize` | (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) |
-| `deleteAllMessagesFromDb.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` |
+| `deleteAllMessagesFromDb.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `deleteAllMessagesFromDb.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) =>  |
 | `deleteAllMessagesFromDb.requestStream` | ``false`` |
-| `deleteAllMessagesFromDb.responseDeserialize` | (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) |
-| `deleteAllMessagesFromDb.responseSerialize` | (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` |
+| `deleteAllMessagesFromDb.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `deleteAllMessagesFromDb.responseSerialize` | (`value`: [`Empty`](protobufs.md#empty)) =>  |
 | `deleteAllMessagesFromDb.responseStream` | ``false`` |
-| `rebuildSyncTrie` | { `path`: ``"/AdminService/RebuildSyncTrie"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `responseSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `responseStream`: ``false``  } |
+| `rebuildSyncTrie` | { `path`: ``"/AdminService/RebuildSyncTrie"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `responseStream`: ``false``  } |
 | `rebuildSyncTrie.path` | ``"/AdminService/RebuildSyncTrie"`` |
-| `rebuildSyncTrie.requestDeserialize` | (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) |
-| `rebuildSyncTrie.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` |
+| `rebuildSyncTrie.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `rebuildSyncTrie.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) =>  |
 | `rebuildSyncTrie.requestStream` | ``false`` |
-| `rebuildSyncTrie.responseDeserialize` | (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) |
-| `rebuildSyncTrie.responseSerialize` | (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` |
+| `rebuildSyncTrie.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `rebuildSyncTrie.responseSerialize` | (`value`: [`Empty`](protobufs.md#empty)) =>  |
 | `rebuildSyncTrie.responseStream` | ``false`` |
 
 ___
@@ -429,12 +429,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`CastAddBody`](protobufs.md#castaddbody) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`CastAddBody`](protobufs.md#castaddbody) |
-| `encode` | (`message`: [`CastAddBody`](protobufs.md#castaddbody), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`CastAddBody`](protobufs.md#castaddbody) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`CastAddBody`](protobufs.md#castaddbody) |
-| `toJSON` | (`message`: [`CastAddBody`](protobufs.md#castaddbody)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`CastAddBody`](protobufs.md#castaddbody), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`CastAddBody`](protobufs.md#castaddbody)) =>  |
 
 ___
 
@@ -446,12 +446,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`CastId`](protobufs.md#castid) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`CastId`](protobufs.md#castid) |
-| `encode` | (`message`: [`CastId`](protobufs.md#castid), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`CastId`](protobufs.md#castid) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`CastId`](protobufs.md#castid) |
-| `toJSON` | (`message`: [`CastId`](protobufs.md#castid)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`CastId`](protobufs.md#castid), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`CastId`](protobufs.md#castid)) =>  |
 
 ___
 
@@ -463,12 +463,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`CastRemoveBody`](protobufs.md#castremovebody) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`CastRemoveBody`](protobufs.md#castremovebody) |
-| `encode` | (`message`: [`CastRemoveBody`](protobufs.md#castremovebody), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`CastRemoveBody`](protobufs.md#castremovebody) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`CastRemoveBody`](protobufs.md#castremovebody) |
-| `toJSON` | (`message`: [`CastRemoveBody`](protobufs.md#castremovebody)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`CastRemoveBody`](protobufs.md#castremovebody), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`CastRemoveBody`](protobufs.md#castremovebody)) =>  |
 
 ___
 
@@ -480,12 +480,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`ContactInfoContent`](protobufs.md#contactinfocontent) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`ContactInfoContent`](protobufs.md#contactinfocontent) |
-| `encode` | (`message`: [`ContactInfoContent`](protobufs.md#contactinfocontent), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`ContactInfoContent`](protobufs.md#contactinfocontent) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`ContactInfoContent`](protobufs.md#contactinfocontent) |
-| `toJSON` | (`message`: [`ContactInfoContent`](protobufs.md#contactinfocontent)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`ContactInfoContent`](protobufs.md#contactinfocontent), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`ContactInfoContent`](protobufs.md#contactinfocontent)) =>  |
 
 ___
 
@@ -497,12 +497,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`DbTrieNode`](protobufs.md#dbtrienode) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`DbTrieNode`](protobufs.md#dbtrienode) |
-| `encode` | (`message`: [`DbTrieNode`](protobufs.md#dbtrienode), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`DbTrieNode`](protobufs.md#dbtrienode) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`DbTrieNode`](protobufs.md#dbtrienode) |
-| `toJSON` | (`message`: [`DbTrieNode`](protobufs.md#dbtrienode)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`DbTrieNode`](protobufs.md#dbtrienode), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`DbTrieNode`](protobufs.md#dbtrienode)) =>  |
 
 ___
 
@@ -514,12 +514,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`Empty`](protobufs.md#empty) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`Empty`](protobufs.md#empty) |
-| `encode` | (`_`: [`Empty`](protobufs.md#empty), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`_`: `any`) => [`Empty`](protobufs.md#empty) |
-| `fromPartial` | <I_1\>(`_`: `I_1`) => [`Empty`](protobufs.md#empty) |
-| `toJSON` | (`_`: [`Empty`](protobufs.md#empty)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`_`: [`Empty`](protobufs.md#empty), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`_`: `any`) =>  |
+| `fromPartial` | <I_1\>(`_`: `I_1`) =>  |
+| `toJSON` | (`_`: [`Empty`](protobufs.md#empty)) =>  |
 
 ___
 
@@ -531,12 +531,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`EventRequest`](protobufs.md#eventrequest) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`EventRequest`](protobufs.md#eventrequest) |
-| `encode` | (`message`: [`EventRequest`](protobufs.md#eventrequest), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`EventRequest`](protobufs.md#eventrequest) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`EventRequest`](protobufs.md#eventrequest) |
-| `toJSON` | (`message`: [`EventRequest`](protobufs.md#eventrequest)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`EventRequest`](protobufs.md#eventrequest), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`EventRequest`](protobufs.md#eventrequest)) =>  |
 
 ___
 
@@ -548,12 +548,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `encode` | (`message`: [`FidRequest`](protobufs.md#fidrequest), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `toJSON` | (`message`: [`FidRequest`](protobufs.md#fidrequest)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`FidRequest`](protobufs.md#fidrequest), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`FidRequest`](protobufs.md#fidrequest)) =>  |
 
 ___
 
@@ -565,12 +565,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`FidsResponse`](protobufs.md#fidsresponse) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`FidsResponse`](protobufs.md#fidsresponse) |
-| `encode` | (`message`: [`FidsResponse`](protobufs.md#fidsresponse), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`FidsResponse`](protobufs.md#fidsresponse) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`FidsResponse`](protobufs.md#fidsresponse) |
-| `toJSON` | (`message`: [`FidsResponse`](protobufs.md#fidsresponse)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`FidsResponse`](protobufs.md#fidsresponse), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`FidsResponse`](protobufs.md#fidsresponse)) =>  |
 
 ___
 
@@ -582,12 +582,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`GossipAddressInfo`](protobufs.md#gossipaddressinfo) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`GossipAddressInfo`](protobufs.md#gossipaddressinfo) |
-| `encode` | (`message`: [`GossipAddressInfo`](protobufs.md#gossipaddressinfo), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`GossipAddressInfo`](protobufs.md#gossipaddressinfo) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`GossipAddressInfo`](protobufs.md#gossipaddressinfo) |
-| `toJSON` | (`message`: [`GossipAddressInfo`](protobufs.md#gossipaddressinfo)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`GossipAddressInfo`](protobufs.md#gossipaddressinfo), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`GossipAddressInfo`](protobufs.md#gossipaddressinfo)) =>  |
 
 ___
 
@@ -599,12 +599,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`GossipMessage`](protobufs.md#gossipmessage) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`GossipMessage`](protobufs.md#gossipmessage) |
-| `encode` | (`message`: [`GossipMessage`](protobufs.md#gossipmessage), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`GossipMessage`](protobufs.md#gossipmessage) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`GossipMessage`](protobufs.md#gossipmessage) |
-| `toJSON` | (`message`: [`GossipMessage`](protobufs.md#gossipmessage)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`GossipMessage`](protobufs.md#gossipmessage), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`GossipMessage`](protobufs.md#gossipmessage)) =>  |
 
 ___
 
@@ -616,12 +616,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`HubEvent`](protobufs.md#hubevent) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`HubEvent`](protobufs.md#hubevent) |
-| `encode` | (`message`: [`HubEvent`](protobufs.md#hubevent), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`HubEvent`](protobufs.md#hubevent) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`HubEvent`](protobufs.md#hubevent) |
-| `toJSON` | (`message`: [`HubEvent`](protobufs.md#hubevent)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`HubEvent`](protobufs.md#hubevent), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`HubEvent`](protobufs.md#hubevent)) =>  |
 
 ___
 
@@ -633,12 +633,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`HubInfoResponse`](protobufs.md#hubinforesponse) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`HubInfoResponse`](protobufs.md#hubinforesponse) |
-| `encode` | (`message`: [`HubInfoResponse`](protobufs.md#hubinforesponse), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`HubInfoResponse`](protobufs.md#hubinforesponse) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`HubInfoResponse`](protobufs.md#hubinforesponse) |
-| `toJSON` | (`message`: [`HubInfoResponse`](protobufs.md#hubinforesponse)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`HubInfoResponse`](protobufs.md#hubinforesponse), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`HubInfoResponse`](protobufs.md#hubinforesponse)) =>  |
 
 ___
 
@@ -666,254 +666,254 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `service` | { `getAllCastMessagesByFid`: { `path`: ``"/HubService/GetAllCastMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getAllMessagesBySyncIds`: { `path`: ``"/HubService/GetAllMessagesBySyncIds"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`SyncIds`](protobufs.md#syncids) ; `requestSerialize`: (`value`: [`SyncIds`](protobufs.md#syncids)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getAllReactionMessagesByFid`: { `path`: ``"/HubService/GetAllReactionMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getAllSignerMessagesByFid`: { `path`: ``"/HubService/GetAllSignerMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getAllSyncIdsByPrefix`: { `path`: ``"/HubService/GetAllSyncIdsByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`SyncIds`](protobufs.md#syncids) ; `responseSerialize`: (`value`: [`SyncIds`](protobufs.md#syncids)) => `Buffer` ; `responseStream`: ``false``  } ; `getAllUserDataMessagesByFid`: { `path`: ``"/HubService/GetAllUserDataMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getAllVerificationMessagesByFid`: { `path`: ``"/HubService/GetAllVerificationMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getCast`: { `path`: ``"/HubService/GetCast"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`CastId`](protobufs.md#castid) ; `requestSerialize`: (`value`: [`CastId`](protobufs.md#castid)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } ; `getCastsByFid`: { `path`: ``"/HubService/GetCastsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getCastsByMention`: { `path`: ``"/HubService/GetCastsByMention"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getCastsByParent`: { `path`: ``"/HubService/GetCastsByParent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`CastId`](protobufs.md#castid) ; `requestSerialize`: (`value`: [`CastId`](protobufs.md#castid)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getEvent`: { `path`: ``"/HubService/GetEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`EventRequest`](protobufs.md#eventrequest) ; `requestSerialize`: (`value`: [`EventRequest`](protobufs.md#eventrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`HubEvent`](protobufs.md#hubevent) ; `responseSerialize`: (`value`: [`HubEvent`](protobufs.md#hubevent)) => `Buffer` ; `responseStream`: ``false``  } ; `getFids`: { `path`: ``"/HubService/GetFids"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`FidsResponse`](protobufs.md#fidsresponse) ; `responseSerialize`: (`value`: [`FidsResponse`](protobufs.md#fidsresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getIdRegistryEvent`: { `path`: ``"/HubService/GetIdRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) ; `responseSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` ; `responseStream`: ``false``  } ; `getInfo`: { `path`: ``"/HubService/GetInfo"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`HubInfoResponse`](protobufs.md#hubinforesponse) ; `responseSerialize`: (`value`: [`HubInfoResponse`](protobufs.md#hubinforesponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getNameRegistryEvent`: { `path`: ``"/HubService/GetNameRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest) ; `requestSerialize`: (`value`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) ; `responseSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` ; `responseStream`: ``false``  } ; `getReaction`: { `path`: ``"/HubService/GetReaction"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`ReactionRequest`](protobufs.md#reactionrequest) ; `requestSerialize`: (`value`: [`ReactionRequest`](protobufs.md#reactionrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } ; `getReactionsByCast`: { `path`: ``"/HubService/GetReactionsByCast"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest) ; `requestSerialize`: (`value`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getReactionsByFid`: { `path`: ``"/HubService/GetReactionsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest) ; `requestSerialize`: (`value`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getSigner`: { `path`: ``"/HubService/GetSigner"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`SignerRequest`](protobufs.md#signerrequest) ; `requestSerialize`: (`value`: [`SignerRequest`](protobufs.md#signerrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } ; `getSignersByFid`: { `path`: ``"/HubService/GetSignersByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getSyncMetadataByPrefix`: { `path`: ``"/HubService/GetSyncMetadataByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse) ; `responseSerialize`: (`value`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getSyncSnapshotByPrefix`: { `path`: ``"/HubService/GetSyncSnapshotByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse) ; `responseSerialize`: (`value`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getUserData`: { `path`: ``"/HubService/GetUserData"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`UserDataRequest`](protobufs.md#userdatarequest) ; `requestSerialize`: (`value`: [`UserDataRequest`](protobufs.md#userdatarequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } ; `getUserDataByFid`: { `path`: ``"/HubService/GetUserDataByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `getVerification`: { `path`: ``"/HubService/GetVerification"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`VerificationRequest`](protobufs.md#verificationrequest) ; `requestSerialize`: (`value`: [`VerificationRequest`](protobufs.md#verificationrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } ; `getVerificationsByFid`: { `path`: ``"/HubService/GetVerificationsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } ; `submitIdRegistryEvent`: { `path`: ``"/HubService/SubmitIdRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) ; `requestSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) ; `responseSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` ; `responseStream`: ``false``  } ; `submitMessage`: { `path`: ``"/HubService/SubmitMessage"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `requestSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } ; `submitNameRegistryEvent`: { `path`: ``"/HubService/SubmitNameRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) ; `requestSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) ; `responseSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` ; `responseStream`: ``false``  } ; `subscribe`: { `path`: ``"/HubService/Subscribe"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`SubscribeRequest`](protobufs.md#subscriberequest) ; `requestSerialize`: (`value`: [`SubscribeRequest`](protobufs.md#subscriberequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`HubEvent`](protobufs.md#hubevent) ; `responseSerialize`: (`value`: [`HubEvent`](protobufs.md#hubevent)) => `Buffer` ; `responseStream`: ``true``  }  } |
-| `service.getAllCastMessagesByFid` | { `path`: ``"/HubService/GetAllCastMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service` | { `getAllCastMessagesByFid`: { `path`: ``"/HubService/GetAllCastMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getAllMessagesBySyncIds`: { `path`: ``"/HubService/GetAllMessagesBySyncIds"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`SyncIds`](protobufs.md#syncids)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getAllReactionMessagesByFid`: { `path`: ``"/HubService/GetAllReactionMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getAllSignerMessagesByFid`: { `path`: ``"/HubService/GetAllSignerMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getAllSyncIdsByPrefix`: { `path`: ``"/HubService/GetAllSyncIdsByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`SyncIds`](protobufs.md#syncids)) =>  ; `responseStream`: ``false``  } ; `getAllUserDataMessagesByFid`: { `path`: ``"/HubService/GetAllUserDataMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getAllVerificationMessagesByFid`: { `path`: ``"/HubService/GetAllVerificationMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getCast`: { `path`: ``"/HubService/GetCast"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`CastId`](protobufs.md#castid)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } ; `getCastsByFid`: { `path`: ``"/HubService/GetCastsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getCastsByMention`: { `path`: ``"/HubService/GetCastsByMention"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getCastsByParent`: { `path`: ``"/HubService/GetCastsByParent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`CastId`](protobufs.md#castid)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getEvent`: { `path`: ``"/HubService/GetEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`EventRequest`](protobufs.md#eventrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`HubEvent`](protobufs.md#hubevent)) =>  ; `responseStream`: ``false``  } ; `getFids`: { `path`: ``"/HubService/GetFids"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`FidsResponse`](protobufs.md#fidsresponse)) =>  ; `responseStream`: ``false``  } ; `getIdRegistryEvent`: { `path`: ``"/HubService/GetIdRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  ; `responseStream`: ``false``  } ; `getInfo`: { `path`: ``"/HubService/GetInfo"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`HubInfoResponse`](protobufs.md#hubinforesponse)) =>  ; `responseStream`: ``false``  } ; `getNameRegistryEvent`: { `path`: ``"/HubService/GetNameRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  ; `responseStream`: ``false``  } ; `getReaction`: { `path`: ``"/HubService/GetReaction"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`ReactionRequest`](protobufs.md#reactionrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } ; `getReactionsByCast`: { `path`: ``"/HubService/GetReactionsByCast"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getReactionsByFid`: { `path`: ``"/HubService/GetReactionsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getSigner`: { `path`: ``"/HubService/GetSigner"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`SignerRequest`](protobufs.md#signerrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } ; `getSignersByFid`: { `path`: ``"/HubService/GetSignersByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getSyncMetadataByPrefix`: { `path`: ``"/HubService/GetSyncMetadataByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse)) =>  ; `responseStream`: ``false``  } ; `getSyncSnapshotByPrefix`: { `path`: ``"/HubService/GetSyncSnapshotByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse)) =>  ; `responseStream`: ``false``  } ; `getUserData`: { `path`: ``"/HubService/GetUserData"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`UserDataRequest`](protobufs.md#userdatarequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } ; `getUserDataByFid`: { `path`: ``"/HubService/GetUserDataByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `getVerification`: { `path`: ``"/HubService/GetVerification"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`VerificationRequest`](protobufs.md#verificationrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } ; `getVerificationsByFid`: { `path`: ``"/HubService/GetVerificationsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } ; `submitIdRegistryEvent`: { `path`: ``"/HubService/SubmitIdRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  ; `responseStream`: ``false``  } ; `submitMessage`: { `path`: ``"/HubService/SubmitMessage"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } ; `submitNameRegistryEvent`: { `path`: ``"/HubService/SubmitNameRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  ; `responseStream`: ``false``  } ; `subscribe`: { `path`: ``"/HubService/Subscribe"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`SubscribeRequest`](protobufs.md#subscriberequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`HubEvent`](protobufs.md#hubevent)) =>  ; `responseStream`: ``true``  }  } |
+| `service.getAllCastMessagesByFid` | { `path`: ``"/HubService/GetAllCastMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getAllCastMessagesByFid.path` | ``"/HubService/GetAllCastMessagesByFid"`` |
-| `service.getAllCastMessagesByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `service.getAllCastMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` |
+| `service.getAllCastMessagesByFid.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllCastMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  |
 | `service.getAllCastMessagesByFid.requestStream` | ``false`` |
-| `service.getAllCastMessagesByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getAllCastMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getAllCastMessagesByFid.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllCastMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getAllCastMessagesByFid.responseStream` | ``false`` |
-| `service.getAllMessagesBySyncIds` | { `path`: ``"/HubService/GetAllMessagesBySyncIds"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`SyncIds`](protobufs.md#syncids) ; `requestSerialize`: (`value`: [`SyncIds`](protobufs.md#syncids)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getAllMessagesBySyncIds` | { `path`: ``"/HubService/GetAllMessagesBySyncIds"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`SyncIds`](protobufs.md#syncids)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getAllMessagesBySyncIds.path` | ``"/HubService/GetAllMessagesBySyncIds"`` |
-| `service.getAllMessagesBySyncIds.requestDeserialize` | (`value`: `Buffer`) => [`SyncIds`](protobufs.md#syncids) |
-| `service.getAllMessagesBySyncIds.requestSerialize` | (`value`: [`SyncIds`](protobufs.md#syncids)) => `Buffer` |
+| `service.getAllMessagesBySyncIds.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllMessagesBySyncIds.requestSerialize` | (`value`: [`SyncIds`](protobufs.md#syncids)) =>  |
 | `service.getAllMessagesBySyncIds.requestStream` | ``false`` |
-| `service.getAllMessagesBySyncIds.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getAllMessagesBySyncIds.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getAllMessagesBySyncIds.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllMessagesBySyncIds.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getAllMessagesBySyncIds.responseStream` | ``false`` |
-| `service.getAllReactionMessagesByFid` | { `path`: ``"/HubService/GetAllReactionMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getAllReactionMessagesByFid` | { `path`: ``"/HubService/GetAllReactionMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getAllReactionMessagesByFid.path` | ``"/HubService/GetAllReactionMessagesByFid"`` |
-| `service.getAllReactionMessagesByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `service.getAllReactionMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` |
+| `service.getAllReactionMessagesByFid.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllReactionMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  |
 | `service.getAllReactionMessagesByFid.requestStream` | ``false`` |
-| `service.getAllReactionMessagesByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getAllReactionMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getAllReactionMessagesByFid.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllReactionMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getAllReactionMessagesByFid.responseStream` | ``false`` |
-| `service.getAllSignerMessagesByFid` | { `path`: ``"/HubService/GetAllSignerMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getAllSignerMessagesByFid` | { `path`: ``"/HubService/GetAllSignerMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getAllSignerMessagesByFid.path` | ``"/HubService/GetAllSignerMessagesByFid"`` |
-| `service.getAllSignerMessagesByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `service.getAllSignerMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` |
+| `service.getAllSignerMessagesByFid.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllSignerMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  |
 | `service.getAllSignerMessagesByFid.requestStream` | ``false`` |
-| `service.getAllSignerMessagesByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getAllSignerMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getAllSignerMessagesByFid.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllSignerMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getAllSignerMessagesByFid.responseStream` | ``false`` |
-| `service.getAllSyncIdsByPrefix` | { `path`: ``"/HubService/GetAllSyncIdsByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`SyncIds`](protobufs.md#syncids) ; `responseSerialize`: (`value`: [`SyncIds`](protobufs.md#syncids)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getAllSyncIdsByPrefix` | { `path`: ``"/HubService/GetAllSyncIdsByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`SyncIds`](protobufs.md#syncids)) =>  ; `responseStream`: ``false``  } |
 | `service.getAllSyncIdsByPrefix.path` | ``"/HubService/GetAllSyncIdsByPrefix"`` |
-| `service.getAllSyncIdsByPrefix.requestDeserialize` | (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) |
-| `service.getAllSyncIdsByPrefix.requestSerialize` | (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` |
+| `service.getAllSyncIdsByPrefix.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllSyncIdsByPrefix.requestSerialize` | (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  |
 | `service.getAllSyncIdsByPrefix.requestStream` | ``false`` |
-| `service.getAllSyncIdsByPrefix.responseDeserialize` | (`value`: `Buffer`) => [`SyncIds`](protobufs.md#syncids) |
-| `service.getAllSyncIdsByPrefix.responseSerialize` | (`value`: [`SyncIds`](protobufs.md#syncids)) => `Buffer` |
+| `service.getAllSyncIdsByPrefix.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllSyncIdsByPrefix.responseSerialize` | (`value`: [`SyncIds`](protobufs.md#syncids)) =>  |
 | `service.getAllSyncIdsByPrefix.responseStream` | ``false`` |
-| `service.getAllUserDataMessagesByFid` | { `path`: ``"/HubService/GetAllUserDataMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getAllUserDataMessagesByFid` | { `path`: ``"/HubService/GetAllUserDataMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getAllUserDataMessagesByFid.path` | ``"/HubService/GetAllUserDataMessagesByFid"`` |
-| `service.getAllUserDataMessagesByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `service.getAllUserDataMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` |
+| `service.getAllUserDataMessagesByFid.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllUserDataMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  |
 | `service.getAllUserDataMessagesByFid.requestStream` | ``false`` |
-| `service.getAllUserDataMessagesByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getAllUserDataMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getAllUserDataMessagesByFid.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllUserDataMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getAllUserDataMessagesByFid.responseStream` | ``false`` |
-| `service.getAllVerificationMessagesByFid` | { `path`: ``"/HubService/GetAllVerificationMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getAllVerificationMessagesByFid` | { `path`: ``"/HubService/GetAllVerificationMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getAllVerificationMessagesByFid.path` | ``"/HubService/GetAllVerificationMessagesByFid"`` |
-| `service.getAllVerificationMessagesByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `service.getAllVerificationMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` |
+| `service.getAllVerificationMessagesByFid.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllVerificationMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  |
 | `service.getAllVerificationMessagesByFid.requestStream` | ``false`` |
-| `service.getAllVerificationMessagesByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getAllVerificationMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getAllVerificationMessagesByFid.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getAllVerificationMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getAllVerificationMessagesByFid.responseStream` | ``false`` |
-| `service.getCast` | { `path`: ``"/HubService/GetCast"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`CastId`](protobufs.md#castid) ; `requestSerialize`: (`value`: [`CastId`](protobufs.md#castid)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getCast` | { `path`: ``"/HubService/GetCast"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`CastId`](protobufs.md#castid)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } |
 | `service.getCast.path` | ``"/HubService/GetCast"`` |
-| `service.getCast.requestDeserialize` | (`value`: `Buffer`) => [`CastId`](protobufs.md#castid) |
-| `service.getCast.requestSerialize` | (`value`: [`CastId`](protobufs.md#castid)) => `Buffer` |
+| `service.getCast.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getCast.requestSerialize` | (`value`: [`CastId`](protobufs.md#castid)) =>  |
 | `service.getCast.requestStream` | ``false`` |
-| `service.getCast.responseDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) |
-| `service.getCast.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` |
+| `service.getCast.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getCast.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  |
 | `service.getCast.responseStream` | ``false`` |
-| `service.getCastsByFid` | { `path`: ``"/HubService/GetCastsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getCastsByFid` | { `path`: ``"/HubService/GetCastsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getCastsByFid.path` | ``"/HubService/GetCastsByFid"`` |
-| `service.getCastsByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `service.getCastsByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` |
+| `service.getCastsByFid.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getCastsByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  |
 | `service.getCastsByFid.requestStream` | ``false`` |
-| `service.getCastsByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getCastsByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getCastsByFid.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getCastsByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getCastsByFid.responseStream` | ``false`` |
-| `service.getCastsByMention` | { `path`: ``"/HubService/GetCastsByMention"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getCastsByMention` | { `path`: ``"/HubService/GetCastsByMention"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getCastsByMention.path` | ``"/HubService/GetCastsByMention"`` |
-| `service.getCastsByMention.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `service.getCastsByMention.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` |
+| `service.getCastsByMention.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getCastsByMention.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  |
 | `service.getCastsByMention.requestStream` | ``false`` |
-| `service.getCastsByMention.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getCastsByMention.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getCastsByMention.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getCastsByMention.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getCastsByMention.responseStream` | ``false`` |
-| `service.getCastsByParent` | { `path`: ``"/HubService/GetCastsByParent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`CastId`](protobufs.md#castid) ; `requestSerialize`: (`value`: [`CastId`](protobufs.md#castid)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getCastsByParent` | { `path`: ``"/HubService/GetCastsByParent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`CastId`](protobufs.md#castid)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getCastsByParent.path` | ``"/HubService/GetCastsByParent"`` |
-| `service.getCastsByParent.requestDeserialize` | (`value`: `Buffer`) => [`CastId`](protobufs.md#castid) |
-| `service.getCastsByParent.requestSerialize` | (`value`: [`CastId`](protobufs.md#castid)) => `Buffer` |
+| `service.getCastsByParent.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getCastsByParent.requestSerialize` | (`value`: [`CastId`](protobufs.md#castid)) =>  |
 | `service.getCastsByParent.requestStream` | ``false`` |
-| `service.getCastsByParent.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getCastsByParent.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getCastsByParent.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getCastsByParent.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getCastsByParent.responseStream` | ``false`` |
-| `service.getEvent` | { `path`: ``"/HubService/GetEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`EventRequest`](protobufs.md#eventrequest) ; `requestSerialize`: (`value`: [`EventRequest`](protobufs.md#eventrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`HubEvent`](protobufs.md#hubevent) ; `responseSerialize`: (`value`: [`HubEvent`](protobufs.md#hubevent)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getEvent` | { `path`: ``"/HubService/GetEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`EventRequest`](protobufs.md#eventrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`HubEvent`](protobufs.md#hubevent)) =>  ; `responseStream`: ``false``  } |
 | `service.getEvent.path` | ``"/HubService/GetEvent"`` |
-| `service.getEvent.requestDeserialize` | (`value`: `Buffer`) => [`EventRequest`](protobufs.md#eventrequest) |
-| `service.getEvent.requestSerialize` | (`value`: [`EventRequest`](protobufs.md#eventrequest)) => `Buffer` |
+| `service.getEvent.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getEvent.requestSerialize` | (`value`: [`EventRequest`](protobufs.md#eventrequest)) =>  |
 | `service.getEvent.requestStream` | ``false`` |
-| `service.getEvent.responseDeserialize` | (`value`: `Buffer`) => [`HubEvent`](protobufs.md#hubevent) |
-| `service.getEvent.responseSerialize` | (`value`: [`HubEvent`](protobufs.md#hubevent)) => `Buffer` |
+| `service.getEvent.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getEvent.responseSerialize` | (`value`: [`HubEvent`](protobufs.md#hubevent)) =>  |
 | `service.getEvent.responseStream` | ``false`` |
-| `service.getFids` | { `path`: ``"/HubService/GetFids"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`FidsResponse`](protobufs.md#fidsresponse) ; `responseSerialize`: (`value`: [`FidsResponse`](protobufs.md#fidsresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getFids` | { `path`: ``"/HubService/GetFids"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`FidsResponse`](protobufs.md#fidsresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getFids.path` | ``"/HubService/GetFids"`` |
-| `service.getFids.requestDeserialize` | (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) |
-| `service.getFids.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` |
+| `service.getFids.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getFids.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) =>  |
 | `service.getFids.requestStream` | ``false`` |
-| `service.getFids.responseDeserialize` | (`value`: `Buffer`) => [`FidsResponse`](protobufs.md#fidsresponse) |
-| `service.getFids.responseSerialize` | (`value`: [`FidsResponse`](protobufs.md#fidsresponse)) => `Buffer` |
+| `service.getFids.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getFids.responseSerialize` | (`value`: [`FidsResponse`](protobufs.md#fidsresponse)) =>  |
 | `service.getFids.responseStream` | ``false`` |
-| `service.getIdRegistryEvent` | { `path`: ``"/HubService/GetIdRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) ; `responseSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getIdRegistryEvent` | { `path`: ``"/HubService/GetIdRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  ; `responseStream`: ``false``  } |
 | `service.getIdRegistryEvent.path` | ``"/HubService/GetIdRegistryEvent"`` |
-| `service.getIdRegistryEvent.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `service.getIdRegistryEvent.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` |
+| `service.getIdRegistryEvent.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getIdRegistryEvent.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  |
 | `service.getIdRegistryEvent.requestStream` | ``false`` |
-| `service.getIdRegistryEvent.responseDeserialize` | (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) |
-| `service.getIdRegistryEvent.responseSerialize` | (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` |
+| `service.getIdRegistryEvent.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getIdRegistryEvent.responseSerialize` | (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  |
 | `service.getIdRegistryEvent.responseStream` | ``false`` |
-| `service.getInfo` | { `path`: ``"/HubService/GetInfo"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`HubInfoResponse`](protobufs.md#hubinforesponse) ; `responseSerialize`: (`value`: [`HubInfoResponse`](protobufs.md#hubinforesponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getInfo` | { `path`: ``"/HubService/GetInfo"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`HubInfoResponse`](protobufs.md#hubinforesponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getInfo.path` | ``"/HubService/GetInfo"`` |
-| `service.getInfo.requestDeserialize` | (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) |
-| `service.getInfo.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` |
+| `service.getInfo.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getInfo.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) =>  |
 | `service.getInfo.requestStream` | ``false`` |
-| `service.getInfo.responseDeserialize` | (`value`: `Buffer`) => [`HubInfoResponse`](protobufs.md#hubinforesponse) |
-| `service.getInfo.responseSerialize` | (`value`: [`HubInfoResponse`](protobufs.md#hubinforesponse)) => `Buffer` |
+| `service.getInfo.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getInfo.responseSerialize` | (`value`: [`HubInfoResponse`](protobufs.md#hubinforesponse)) =>  |
 | `service.getInfo.responseStream` | ``false`` |
-| `service.getNameRegistryEvent` | { `path`: ``"/HubService/GetNameRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest) ; `requestSerialize`: (`value`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) ; `responseSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getNameRegistryEvent` | { `path`: ``"/HubService/GetNameRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  ; `responseStream`: ``false``  } |
 | `service.getNameRegistryEvent.path` | ``"/HubService/GetNameRegistryEvent"`` |
-| `service.getNameRegistryEvent.requestDeserialize` | (`value`: `Buffer`) => [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest) |
-| `service.getNameRegistryEvent.requestSerialize` | (`value`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest)) => `Buffer` |
+| `service.getNameRegistryEvent.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getNameRegistryEvent.requestSerialize` | (`value`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest)) =>  |
 | `service.getNameRegistryEvent.requestStream` | ``false`` |
-| `service.getNameRegistryEvent.responseDeserialize` | (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) |
-| `service.getNameRegistryEvent.responseSerialize` | (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` |
+| `service.getNameRegistryEvent.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getNameRegistryEvent.responseSerialize` | (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  |
 | `service.getNameRegistryEvent.responseStream` | ``false`` |
-| `service.getReaction` | { `path`: ``"/HubService/GetReaction"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`ReactionRequest`](protobufs.md#reactionrequest) ; `requestSerialize`: (`value`: [`ReactionRequest`](protobufs.md#reactionrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getReaction` | { `path`: ``"/HubService/GetReaction"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`ReactionRequest`](protobufs.md#reactionrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } |
 | `service.getReaction.path` | ``"/HubService/GetReaction"`` |
-| `service.getReaction.requestDeserialize` | (`value`: `Buffer`) => [`ReactionRequest`](protobufs.md#reactionrequest) |
-| `service.getReaction.requestSerialize` | (`value`: [`ReactionRequest`](protobufs.md#reactionrequest)) => `Buffer` |
+| `service.getReaction.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getReaction.requestSerialize` | (`value`: [`ReactionRequest`](protobufs.md#reactionrequest)) =>  |
 | `service.getReaction.requestStream` | ``false`` |
-| `service.getReaction.responseDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) |
-| `service.getReaction.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` |
+| `service.getReaction.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getReaction.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  |
 | `service.getReaction.responseStream` | ``false`` |
-| `service.getReactionsByCast` | { `path`: ``"/HubService/GetReactionsByCast"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest) ; `requestSerialize`: (`value`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getReactionsByCast` | { `path`: ``"/HubService/GetReactionsByCast"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getReactionsByCast.path` | ``"/HubService/GetReactionsByCast"`` |
-| `service.getReactionsByCast.requestDeserialize` | (`value`: `Buffer`) => [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest) |
-| `service.getReactionsByCast.requestSerialize` | (`value`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest)) => `Buffer` |
+| `service.getReactionsByCast.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getReactionsByCast.requestSerialize` | (`value`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest)) =>  |
 | `service.getReactionsByCast.requestStream` | ``false`` |
-| `service.getReactionsByCast.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getReactionsByCast.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getReactionsByCast.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getReactionsByCast.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getReactionsByCast.responseStream` | ``false`` |
-| `service.getReactionsByFid` | { `path`: ``"/HubService/GetReactionsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest) ; `requestSerialize`: (`value`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getReactionsByFid` | { `path`: ``"/HubService/GetReactionsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getReactionsByFid.path` | ``"/HubService/GetReactionsByFid"`` |
-| `service.getReactionsByFid.requestDeserialize` | (`value`: `Buffer`) => [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest) |
-| `service.getReactionsByFid.requestSerialize` | (`value`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest)) => `Buffer` |
+| `service.getReactionsByFid.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getReactionsByFid.requestSerialize` | (`value`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest)) =>  |
 | `service.getReactionsByFid.requestStream` | ``false`` |
-| `service.getReactionsByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getReactionsByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getReactionsByFid.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getReactionsByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getReactionsByFid.responseStream` | ``false`` |
-| `service.getSigner` | { `path`: ``"/HubService/GetSigner"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`SignerRequest`](protobufs.md#signerrequest) ; `requestSerialize`: (`value`: [`SignerRequest`](protobufs.md#signerrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getSigner` | { `path`: ``"/HubService/GetSigner"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`SignerRequest`](protobufs.md#signerrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } |
 | `service.getSigner.path` | ``"/HubService/GetSigner"`` |
-| `service.getSigner.requestDeserialize` | (`value`: `Buffer`) => [`SignerRequest`](protobufs.md#signerrequest) |
-| `service.getSigner.requestSerialize` | (`value`: [`SignerRequest`](protobufs.md#signerrequest)) => `Buffer` |
+| `service.getSigner.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getSigner.requestSerialize` | (`value`: [`SignerRequest`](protobufs.md#signerrequest)) =>  |
 | `service.getSigner.requestStream` | ``false`` |
-| `service.getSigner.responseDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) |
-| `service.getSigner.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` |
+| `service.getSigner.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getSigner.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  |
 | `service.getSigner.responseStream` | ``false`` |
-| `service.getSignersByFid` | { `path`: ``"/HubService/GetSignersByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getSignersByFid` | { `path`: ``"/HubService/GetSignersByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getSignersByFid.path` | ``"/HubService/GetSignersByFid"`` |
-| `service.getSignersByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `service.getSignersByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` |
+| `service.getSignersByFid.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getSignersByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  |
 | `service.getSignersByFid.requestStream` | ``false`` |
-| `service.getSignersByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getSignersByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getSignersByFid.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getSignersByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getSignersByFid.responseStream` | ``false`` |
-| `service.getSyncMetadataByPrefix` | { `path`: ``"/HubService/GetSyncMetadataByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse) ; `responseSerialize`: (`value`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getSyncMetadataByPrefix` | { `path`: ``"/HubService/GetSyncMetadataByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getSyncMetadataByPrefix.path` | ``"/HubService/GetSyncMetadataByPrefix"`` |
-| `service.getSyncMetadataByPrefix.requestDeserialize` | (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) |
-| `service.getSyncMetadataByPrefix.requestSerialize` | (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` |
+| `service.getSyncMetadataByPrefix.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getSyncMetadataByPrefix.requestSerialize` | (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  |
 | `service.getSyncMetadataByPrefix.requestStream` | ``false`` |
-| `service.getSyncMetadataByPrefix.responseDeserialize` | (`value`: `Buffer`) => [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse) |
-| `service.getSyncMetadataByPrefix.responseSerialize` | (`value`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse)) => `Buffer` |
+| `service.getSyncMetadataByPrefix.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getSyncMetadataByPrefix.responseSerialize` | (`value`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse)) =>  |
 | `service.getSyncMetadataByPrefix.responseStream` | ``false`` |
-| `service.getSyncSnapshotByPrefix` | { `path`: ``"/HubService/GetSyncSnapshotByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse) ; `responseSerialize`: (`value`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getSyncSnapshotByPrefix` | { `path`: ``"/HubService/GetSyncSnapshotByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getSyncSnapshotByPrefix.path` | ``"/HubService/GetSyncSnapshotByPrefix"`` |
-| `service.getSyncSnapshotByPrefix.requestDeserialize` | (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) |
-| `service.getSyncSnapshotByPrefix.requestSerialize` | (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` |
+| `service.getSyncSnapshotByPrefix.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getSyncSnapshotByPrefix.requestSerialize` | (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  |
 | `service.getSyncSnapshotByPrefix.requestStream` | ``false`` |
-| `service.getSyncSnapshotByPrefix.responseDeserialize` | (`value`: `Buffer`) => [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse) |
-| `service.getSyncSnapshotByPrefix.responseSerialize` | (`value`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse)) => `Buffer` |
+| `service.getSyncSnapshotByPrefix.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getSyncSnapshotByPrefix.responseSerialize` | (`value`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse)) =>  |
 | `service.getSyncSnapshotByPrefix.responseStream` | ``false`` |
-| `service.getUserData` | { `path`: ``"/HubService/GetUserData"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`UserDataRequest`](protobufs.md#userdatarequest) ; `requestSerialize`: (`value`: [`UserDataRequest`](protobufs.md#userdatarequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getUserData` | { `path`: ``"/HubService/GetUserData"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`UserDataRequest`](protobufs.md#userdatarequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } |
 | `service.getUserData.path` | ``"/HubService/GetUserData"`` |
-| `service.getUserData.requestDeserialize` | (`value`: `Buffer`) => [`UserDataRequest`](protobufs.md#userdatarequest) |
-| `service.getUserData.requestSerialize` | (`value`: [`UserDataRequest`](protobufs.md#userdatarequest)) => `Buffer` |
+| `service.getUserData.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getUserData.requestSerialize` | (`value`: [`UserDataRequest`](protobufs.md#userdatarequest)) =>  |
 | `service.getUserData.requestStream` | ``false`` |
-| `service.getUserData.responseDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) |
-| `service.getUserData.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` |
+| `service.getUserData.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getUserData.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  |
 | `service.getUserData.responseStream` | ``false`` |
-| `service.getUserDataByFid` | { `path`: ``"/HubService/GetUserDataByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getUserDataByFid` | { `path`: ``"/HubService/GetUserDataByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getUserDataByFid.path` | ``"/HubService/GetUserDataByFid"`` |
-| `service.getUserDataByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `service.getUserDataByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` |
+| `service.getUserDataByFid.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getUserDataByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  |
 | `service.getUserDataByFid.requestStream` | ``false`` |
-| `service.getUserDataByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getUserDataByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getUserDataByFid.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getUserDataByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getUserDataByFid.responseStream` | ``false`` |
-| `service.getVerification` | { `path`: ``"/HubService/GetVerification"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`VerificationRequest`](protobufs.md#verificationrequest) ; `requestSerialize`: (`value`: [`VerificationRequest`](protobufs.md#verificationrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getVerification` | { `path`: ``"/HubService/GetVerification"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`VerificationRequest`](protobufs.md#verificationrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } |
 | `service.getVerification.path` | ``"/HubService/GetVerification"`` |
-| `service.getVerification.requestDeserialize` | (`value`: `Buffer`) => [`VerificationRequest`](protobufs.md#verificationrequest) |
-| `service.getVerification.requestSerialize` | (`value`: [`VerificationRequest`](protobufs.md#verificationrequest)) => `Buffer` |
+| `service.getVerification.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getVerification.requestSerialize` | (`value`: [`VerificationRequest`](protobufs.md#verificationrequest)) =>  |
 | `service.getVerification.requestStream` | ``false`` |
-| `service.getVerification.responseDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) |
-| `service.getVerification.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` |
+| `service.getVerification.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getVerification.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  |
 | `service.getVerification.responseStream` | ``false`` |
-| `service.getVerificationsByFid` | { `path`: ``"/HubService/GetVerificationsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.getVerificationsByFid` | { `path`: ``"/HubService/GetVerificationsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } |
 | `service.getVerificationsByFid.path` | ``"/HubService/GetVerificationsByFid"`` |
-| `service.getVerificationsByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) |
-| `service.getVerificationsByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` |
+| `service.getVerificationsByFid.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getVerificationsByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  |
 | `service.getVerificationsByFid.requestStream` | ``false`` |
-| `service.getVerificationsByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `service.getVerificationsByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` |
+| `service.getVerificationsByFid.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.getVerificationsByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 | `service.getVerificationsByFid.responseStream` | ``false`` |
-| `service.submitIdRegistryEvent` | { `path`: ``"/HubService/SubmitIdRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) ; `requestSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) ; `responseSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.submitIdRegistryEvent` | { `path`: ``"/HubService/SubmitIdRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  ; `responseStream`: ``false``  } |
 | `service.submitIdRegistryEvent.path` | ``"/HubService/SubmitIdRegistryEvent"`` |
-| `service.submitIdRegistryEvent.requestDeserialize` | (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) |
-| `service.submitIdRegistryEvent.requestSerialize` | (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` |
+| `service.submitIdRegistryEvent.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.submitIdRegistryEvent.requestSerialize` | (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  |
 | `service.submitIdRegistryEvent.requestStream` | ``false`` |
-| `service.submitIdRegistryEvent.responseDeserialize` | (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) |
-| `service.submitIdRegistryEvent.responseSerialize` | (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` |
+| `service.submitIdRegistryEvent.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.submitIdRegistryEvent.responseSerialize` | (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  |
 | `service.submitIdRegistryEvent.responseStream` | ``false`` |
-| `service.submitMessage` | { `path`: ``"/HubService/SubmitMessage"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `requestSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.submitMessage` | { `path`: ``"/HubService/SubmitMessage"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } |
 | `service.submitMessage.path` | ``"/HubService/SubmitMessage"`` |
-| `service.submitMessage.requestDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) |
-| `service.submitMessage.requestSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` |
+| `service.submitMessage.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.submitMessage.requestSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  |
 | `service.submitMessage.requestStream` | ``false`` |
-| `service.submitMessage.responseDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) |
-| `service.submitMessage.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` |
+| `service.submitMessage.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.submitMessage.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  |
 | `service.submitMessage.responseStream` | ``false`` |
-| `service.submitNameRegistryEvent` | { `path`: ``"/HubService/SubmitNameRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) ; `requestSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) ; `responseSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` ; `responseStream`: ``false``  } |
+| `service.submitNameRegistryEvent` | { `path`: ``"/HubService/SubmitNameRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  ; `responseStream`: ``false``  } |
 | `service.submitNameRegistryEvent.path` | ``"/HubService/SubmitNameRegistryEvent"`` |
-| `service.submitNameRegistryEvent.requestDeserialize` | (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) |
-| `service.submitNameRegistryEvent.requestSerialize` | (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` |
+| `service.submitNameRegistryEvent.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.submitNameRegistryEvent.requestSerialize` | (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  |
 | `service.submitNameRegistryEvent.requestStream` | ``false`` |
-| `service.submitNameRegistryEvent.responseDeserialize` | (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) |
-| `service.submitNameRegistryEvent.responseSerialize` | (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` |
+| `service.submitNameRegistryEvent.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.submitNameRegistryEvent.responseSerialize` | (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  |
 | `service.submitNameRegistryEvent.responseStream` | ``false`` |
-| `service.subscribe` | { `path`: ``"/HubService/Subscribe"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`SubscribeRequest`](protobufs.md#subscriberequest) ; `requestSerialize`: (`value`: [`SubscribeRequest`](protobufs.md#subscriberequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`HubEvent`](protobufs.md#hubevent) ; `responseSerialize`: (`value`: [`HubEvent`](protobufs.md#hubevent)) => `Buffer` ; `responseStream`: ``true``  } |
+| `service.subscribe` | { `path`: ``"/HubService/Subscribe"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`SubscribeRequest`](protobufs.md#subscriberequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`HubEvent`](protobufs.md#hubevent)) =>  ; `responseStream`: ``true``  } |
 | `service.subscribe.path` | ``"/HubService/Subscribe"`` |
-| `service.subscribe.requestDeserialize` | (`value`: `Buffer`) => [`SubscribeRequest`](protobufs.md#subscriberequest) |
-| `service.subscribe.requestSerialize` | (`value`: [`SubscribeRequest`](protobufs.md#subscriberequest)) => `Buffer` |
+| `service.subscribe.requestDeserialize` | (`value`: `Buffer`) =>  |
+| `service.subscribe.requestSerialize` | (`value`: [`SubscribeRequest`](protobufs.md#subscriberequest)) =>  |
 | `service.subscribe.requestStream` | ``false`` |
-| `service.subscribe.responseDeserialize` | (`value`: `Buffer`) => [`HubEvent`](protobufs.md#hubevent) |
-| `service.subscribe.responseSerialize` | (`value`: [`HubEvent`](protobufs.md#hubevent)) => `Buffer` |
+| `service.subscribe.responseDeserialize` | (`value`: `Buffer`) =>  |
+| `service.subscribe.responseSerialize` | (`value`: [`HubEvent`](protobufs.md#hubevent)) =>  |
 | `service.subscribe.responseStream` | ``true`` |
 
 ___
@@ -926,253 +926,253 @@ ___
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `getAllCastMessagesByFid` | { `path`: ``"/HubService/GetAllCastMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | Bulk Methods |
+| `getAllCastMessagesByFid` | { `path`: ``"/HubService/GetAllCastMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | Bulk Methods |
 | `getAllCastMessagesByFid.path` | ``"/HubService/GetAllCastMessagesByFid"`` | - |
-| `getAllCastMessagesByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) | - |
-| `getAllCastMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` | - |
+| `getAllCastMessagesByFid.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllCastMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  | - |
 | `getAllCastMessagesByFid.requestStream` | ``false`` | - |
-| `getAllCastMessagesByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getAllCastMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getAllCastMessagesByFid.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllCastMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getAllCastMessagesByFid.responseStream` | ``false`` | - |
-| `getAllMessagesBySyncIds` | { `path`: ``"/HubService/GetAllMessagesBySyncIds"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`SyncIds`](protobufs.md#syncids) ; `requestSerialize`: (`value`: [`SyncIds`](protobufs.md#syncids)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getAllMessagesBySyncIds` | { `path`: ``"/HubService/GetAllMessagesBySyncIds"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`SyncIds`](protobufs.md#syncids)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getAllMessagesBySyncIds.path` | ``"/HubService/GetAllMessagesBySyncIds"`` | - |
-| `getAllMessagesBySyncIds.requestDeserialize` | (`value`: `Buffer`) => [`SyncIds`](protobufs.md#syncids) | - |
-| `getAllMessagesBySyncIds.requestSerialize` | (`value`: [`SyncIds`](protobufs.md#syncids)) => `Buffer` | - |
+| `getAllMessagesBySyncIds.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllMessagesBySyncIds.requestSerialize` | (`value`: [`SyncIds`](protobufs.md#syncids)) =>  | - |
 | `getAllMessagesBySyncIds.requestStream` | ``false`` | - |
-| `getAllMessagesBySyncIds.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getAllMessagesBySyncIds.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getAllMessagesBySyncIds.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllMessagesBySyncIds.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getAllMessagesBySyncIds.responseStream` | ``false`` | - |
-| `getAllReactionMessagesByFid` | { `path`: ``"/HubService/GetAllReactionMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getAllReactionMessagesByFid` | { `path`: ``"/HubService/GetAllReactionMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getAllReactionMessagesByFid.path` | ``"/HubService/GetAllReactionMessagesByFid"`` | - |
-| `getAllReactionMessagesByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) | - |
-| `getAllReactionMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` | - |
+| `getAllReactionMessagesByFid.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllReactionMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  | - |
 | `getAllReactionMessagesByFid.requestStream` | ``false`` | - |
-| `getAllReactionMessagesByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getAllReactionMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getAllReactionMessagesByFid.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllReactionMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getAllReactionMessagesByFid.responseStream` | ``false`` | - |
-| `getAllSignerMessagesByFid` | { `path`: ``"/HubService/GetAllSignerMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getAllSignerMessagesByFid` | { `path`: ``"/HubService/GetAllSignerMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getAllSignerMessagesByFid.path` | ``"/HubService/GetAllSignerMessagesByFid"`` | - |
-| `getAllSignerMessagesByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) | - |
-| `getAllSignerMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` | - |
+| `getAllSignerMessagesByFid.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllSignerMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  | - |
 | `getAllSignerMessagesByFid.requestStream` | ``false`` | - |
-| `getAllSignerMessagesByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getAllSignerMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getAllSignerMessagesByFid.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllSignerMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getAllSignerMessagesByFid.responseStream` | ``false`` | - |
-| `getAllSyncIdsByPrefix` | { `path`: ``"/HubService/GetAllSyncIdsByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`SyncIds`](protobufs.md#syncids) ; `responseSerialize`: (`value`: [`SyncIds`](protobufs.md#syncids)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getAllSyncIdsByPrefix` | { `path`: ``"/HubService/GetAllSyncIdsByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`SyncIds`](protobufs.md#syncids)) =>  ; `responseStream`: ``false``  } | - |
 | `getAllSyncIdsByPrefix.path` | ``"/HubService/GetAllSyncIdsByPrefix"`` | - |
-| `getAllSyncIdsByPrefix.requestDeserialize` | (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) | - |
-| `getAllSyncIdsByPrefix.requestSerialize` | (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` | - |
+| `getAllSyncIdsByPrefix.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllSyncIdsByPrefix.requestSerialize` | (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  | - |
 | `getAllSyncIdsByPrefix.requestStream` | ``false`` | - |
-| `getAllSyncIdsByPrefix.responseDeserialize` | (`value`: `Buffer`) => [`SyncIds`](protobufs.md#syncids) | - |
-| `getAllSyncIdsByPrefix.responseSerialize` | (`value`: [`SyncIds`](protobufs.md#syncids)) => `Buffer` | - |
+| `getAllSyncIdsByPrefix.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllSyncIdsByPrefix.responseSerialize` | (`value`: [`SyncIds`](protobufs.md#syncids)) =>  | - |
 | `getAllSyncIdsByPrefix.responseStream` | ``false`` | - |
-| `getAllUserDataMessagesByFid` | { `path`: ``"/HubService/GetAllUserDataMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getAllUserDataMessagesByFid` | { `path`: ``"/HubService/GetAllUserDataMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getAllUserDataMessagesByFid.path` | ``"/HubService/GetAllUserDataMessagesByFid"`` | - |
-| `getAllUserDataMessagesByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) | - |
-| `getAllUserDataMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` | - |
+| `getAllUserDataMessagesByFid.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllUserDataMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  | - |
 | `getAllUserDataMessagesByFid.requestStream` | ``false`` | - |
-| `getAllUserDataMessagesByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getAllUserDataMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getAllUserDataMessagesByFid.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllUserDataMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getAllUserDataMessagesByFid.responseStream` | ``false`` | - |
-| `getAllVerificationMessagesByFid` | { `path`: ``"/HubService/GetAllVerificationMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getAllVerificationMessagesByFid` | { `path`: ``"/HubService/GetAllVerificationMessagesByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getAllVerificationMessagesByFid.path` | ``"/HubService/GetAllVerificationMessagesByFid"`` | - |
-| `getAllVerificationMessagesByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) | - |
-| `getAllVerificationMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` | - |
+| `getAllVerificationMessagesByFid.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllVerificationMessagesByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  | - |
 | `getAllVerificationMessagesByFid.requestStream` | ``false`` | - |
-| `getAllVerificationMessagesByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getAllVerificationMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getAllVerificationMessagesByFid.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getAllVerificationMessagesByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getAllVerificationMessagesByFid.responseStream` | ``false`` | - |
-| `getCast` | { `path`: ``"/HubService/GetCast"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`CastId`](protobufs.md#castid) ; `requestSerialize`: (`value`: [`CastId`](protobufs.md#castid)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } | Casts |
+| `getCast` | { `path`: ``"/HubService/GetCast"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`CastId`](protobufs.md#castid)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } | Casts |
 | `getCast.path` | ``"/HubService/GetCast"`` | - |
-| `getCast.requestDeserialize` | (`value`: `Buffer`) => [`CastId`](protobufs.md#castid) | - |
-| `getCast.requestSerialize` | (`value`: [`CastId`](protobufs.md#castid)) => `Buffer` | - |
+| `getCast.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getCast.requestSerialize` | (`value`: [`CastId`](protobufs.md#castid)) =>  | - |
 | `getCast.requestStream` | ``false`` | - |
-| `getCast.responseDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) | - |
-| `getCast.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` | - |
+| `getCast.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getCast.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  | - |
 | `getCast.responseStream` | ``false`` | - |
-| `getCastsByFid` | { `path`: ``"/HubService/GetCastsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getCastsByFid` | { `path`: ``"/HubService/GetCastsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getCastsByFid.path` | ``"/HubService/GetCastsByFid"`` | - |
-| `getCastsByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) | - |
-| `getCastsByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` | - |
+| `getCastsByFid.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getCastsByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  | - |
 | `getCastsByFid.requestStream` | ``false`` | - |
-| `getCastsByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getCastsByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getCastsByFid.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getCastsByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getCastsByFid.responseStream` | ``false`` | - |
-| `getCastsByMention` | { `path`: ``"/HubService/GetCastsByMention"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getCastsByMention` | { `path`: ``"/HubService/GetCastsByMention"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getCastsByMention.path` | ``"/HubService/GetCastsByMention"`` | - |
-| `getCastsByMention.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) | - |
-| `getCastsByMention.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` | - |
+| `getCastsByMention.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getCastsByMention.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  | - |
 | `getCastsByMention.requestStream` | ``false`` | - |
-| `getCastsByMention.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getCastsByMention.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getCastsByMention.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getCastsByMention.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getCastsByMention.responseStream` | ``false`` | - |
-| `getCastsByParent` | { `path`: ``"/HubService/GetCastsByParent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`CastId`](protobufs.md#castid) ; `requestSerialize`: (`value`: [`CastId`](protobufs.md#castid)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getCastsByParent` | { `path`: ``"/HubService/GetCastsByParent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`CastId`](protobufs.md#castid)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getCastsByParent.path` | ``"/HubService/GetCastsByParent"`` | - |
-| `getCastsByParent.requestDeserialize` | (`value`: `Buffer`) => [`CastId`](protobufs.md#castid) | - |
-| `getCastsByParent.requestSerialize` | (`value`: [`CastId`](protobufs.md#castid)) => `Buffer` | - |
+| `getCastsByParent.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getCastsByParent.requestSerialize` | (`value`: [`CastId`](protobufs.md#castid)) =>  | - |
 | `getCastsByParent.requestStream` | ``false`` | - |
-| `getCastsByParent.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getCastsByParent.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getCastsByParent.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getCastsByParent.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getCastsByParent.responseStream` | ``false`` | - |
-| `getEvent` | { `path`: ``"/HubService/GetEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`EventRequest`](protobufs.md#eventrequest) ; `requestSerialize`: (`value`: [`EventRequest`](protobufs.md#eventrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`HubEvent`](protobufs.md#hubevent) ; `responseSerialize`: (`value`: [`HubEvent`](protobufs.md#hubevent)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getEvent` | { `path`: ``"/HubService/GetEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`EventRequest`](protobufs.md#eventrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`HubEvent`](protobufs.md#hubevent)) =>  ; `responseStream`: ``false``  } | - |
 | `getEvent.path` | ``"/HubService/GetEvent"`` | - |
-| `getEvent.requestDeserialize` | (`value`: `Buffer`) => [`EventRequest`](protobufs.md#eventrequest) | - |
-| `getEvent.requestSerialize` | (`value`: [`EventRequest`](protobufs.md#eventrequest)) => `Buffer` | - |
+| `getEvent.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getEvent.requestSerialize` | (`value`: [`EventRequest`](protobufs.md#eventrequest)) =>  | - |
 | `getEvent.requestStream` | ``false`` | - |
-| `getEvent.responseDeserialize` | (`value`: `Buffer`) => [`HubEvent`](protobufs.md#hubevent) | - |
-| `getEvent.responseSerialize` | (`value`: [`HubEvent`](protobufs.md#hubevent)) => `Buffer` | - |
+| `getEvent.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getEvent.responseSerialize` | (`value`: [`HubEvent`](protobufs.md#hubevent)) =>  | - |
 | `getEvent.responseStream` | ``false`` | - |
-| `getFids` | { `path`: ``"/HubService/GetFids"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`FidsResponse`](protobufs.md#fidsresponse) ; `responseSerialize`: (`value`: [`FidsResponse`](protobufs.md#fidsresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getFids` | { `path`: ``"/HubService/GetFids"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`FidsResponse`](protobufs.md#fidsresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getFids.path` | ``"/HubService/GetFids"`` | - |
-| `getFids.requestDeserialize` | (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) | - |
-| `getFids.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` | - |
+| `getFids.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getFids.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) =>  | - |
 | `getFids.requestStream` | ``false`` | - |
-| `getFids.responseDeserialize` | (`value`: `Buffer`) => [`FidsResponse`](protobufs.md#fidsresponse) | - |
-| `getFids.responseSerialize` | (`value`: [`FidsResponse`](protobufs.md#fidsresponse)) => `Buffer` | - |
+| `getFids.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getFids.responseSerialize` | (`value`: [`FidsResponse`](protobufs.md#fidsresponse)) =>  | - |
 | `getFids.responseStream` | ``false`` | - |
-| `getIdRegistryEvent` | { `path`: ``"/HubService/GetIdRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) ; `responseSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getIdRegistryEvent` | { `path`: ``"/HubService/GetIdRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  ; `responseStream`: ``false``  } | - |
 | `getIdRegistryEvent.path` | ``"/HubService/GetIdRegistryEvent"`` | - |
-| `getIdRegistryEvent.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) | - |
-| `getIdRegistryEvent.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` | - |
+| `getIdRegistryEvent.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getIdRegistryEvent.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  | - |
 | `getIdRegistryEvent.requestStream` | ``false`` | - |
-| `getIdRegistryEvent.responseDeserialize` | (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) | - |
-| `getIdRegistryEvent.responseSerialize` | (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` | - |
+| `getIdRegistryEvent.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getIdRegistryEvent.responseSerialize` | (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  | - |
 | `getIdRegistryEvent.responseStream` | ``false`` | - |
-| `getInfo` | { `path`: ``"/HubService/GetInfo"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`HubInfoResponse`](protobufs.md#hubinforesponse) ; `responseSerialize`: (`value`: [`HubInfoResponse`](protobufs.md#hubinforesponse)) => `Buffer` ; `responseStream`: ``false``  } | Sync Methods |
+| `getInfo` | { `path`: ``"/HubService/GetInfo"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Empty`](protobufs.md#empty)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`HubInfoResponse`](protobufs.md#hubinforesponse)) =>  ; `responseStream`: ``false``  } | Sync Methods |
 | `getInfo.path` | ``"/HubService/GetInfo"`` | - |
-| `getInfo.requestDeserialize` | (`value`: `Buffer`) => [`Empty`](protobufs.md#empty) | - |
-| `getInfo.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) => `Buffer` | - |
+| `getInfo.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getInfo.requestSerialize` | (`value`: [`Empty`](protobufs.md#empty)) =>  | - |
 | `getInfo.requestStream` | ``false`` | - |
-| `getInfo.responseDeserialize` | (`value`: `Buffer`) => [`HubInfoResponse`](protobufs.md#hubinforesponse) | - |
-| `getInfo.responseSerialize` | (`value`: [`HubInfoResponse`](protobufs.md#hubinforesponse)) => `Buffer` | - |
+| `getInfo.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getInfo.responseSerialize` | (`value`: [`HubInfoResponse`](protobufs.md#hubinforesponse)) =>  | - |
 | `getInfo.responseStream` | ``false`` | - |
-| `getNameRegistryEvent` | { `path`: ``"/HubService/GetNameRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest) ; `requestSerialize`: (`value`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) ; `responseSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getNameRegistryEvent` | { `path`: ``"/HubService/GetNameRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  ; `responseStream`: ``false``  } | - |
 | `getNameRegistryEvent.path` | ``"/HubService/GetNameRegistryEvent"`` | - |
-| `getNameRegistryEvent.requestDeserialize` | (`value`: `Buffer`) => [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest) | - |
-| `getNameRegistryEvent.requestSerialize` | (`value`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest)) => `Buffer` | - |
+| `getNameRegistryEvent.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getNameRegistryEvent.requestSerialize` | (`value`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest)) =>  | - |
 | `getNameRegistryEvent.requestStream` | ``false`` | - |
-| `getNameRegistryEvent.responseDeserialize` | (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) | - |
-| `getNameRegistryEvent.responseSerialize` | (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` | - |
+| `getNameRegistryEvent.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getNameRegistryEvent.responseSerialize` | (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  | - |
 | `getNameRegistryEvent.responseStream` | ``false`` | - |
-| `getReaction` | { `path`: ``"/HubService/GetReaction"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`ReactionRequest`](protobufs.md#reactionrequest) ; `requestSerialize`: (`value`: [`ReactionRequest`](protobufs.md#reactionrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } | Reactions |
+| `getReaction` | { `path`: ``"/HubService/GetReaction"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`ReactionRequest`](protobufs.md#reactionrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } | Reactions |
 | `getReaction.path` | ``"/HubService/GetReaction"`` | - |
-| `getReaction.requestDeserialize` | (`value`: `Buffer`) => [`ReactionRequest`](protobufs.md#reactionrequest) | - |
-| `getReaction.requestSerialize` | (`value`: [`ReactionRequest`](protobufs.md#reactionrequest)) => `Buffer` | - |
+| `getReaction.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getReaction.requestSerialize` | (`value`: [`ReactionRequest`](protobufs.md#reactionrequest)) =>  | - |
 | `getReaction.requestStream` | ``false`` | - |
-| `getReaction.responseDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) | - |
-| `getReaction.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` | - |
+| `getReaction.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getReaction.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  | - |
 | `getReaction.responseStream` | ``false`` | - |
-| `getReactionsByCast` | { `path`: ``"/HubService/GetReactionsByCast"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest) ; `requestSerialize`: (`value`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getReactionsByCast` | { `path`: ``"/HubService/GetReactionsByCast"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getReactionsByCast.path` | ``"/HubService/GetReactionsByCast"`` | - |
-| `getReactionsByCast.requestDeserialize` | (`value`: `Buffer`) => [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest) | - |
-| `getReactionsByCast.requestSerialize` | (`value`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest)) => `Buffer` | - |
+| `getReactionsByCast.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getReactionsByCast.requestSerialize` | (`value`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest)) =>  | - |
 | `getReactionsByCast.requestStream` | ``false`` | - |
-| `getReactionsByCast.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getReactionsByCast.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getReactionsByCast.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getReactionsByCast.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getReactionsByCast.responseStream` | ``false`` | - |
-| `getReactionsByFid` | { `path`: ``"/HubService/GetReactionsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest) ; `requestSerialize`: (`value`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getReactionsByFid` | { `path`: ``"/HubService/GetReactionsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getReactionsByFid.path` | ``"/HubService/GetReactionsByFid"`` | - |
-| `getReactionsByFid.requestDeserialize` | (`value`: `Buffer`) => [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest) | - |
-| `getReactionsByFid.requestSerialize` | (`value`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest)) => `Buffer` | - |
+| `getReactionsByFid.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getReactionsByFid.requestSerialize` | (`value`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest)) =>  | - |
 | `getReactionsByFid.requestStream` | ``false`` | - |
-| `getReactionsByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getReactionsByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getReactionsByFid.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getReactionsByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getReactionsByFid.responseStream` | ``false`` | - |
-| `getSigner` | { `path`: ``"/HubService/GetSigner"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`SignerRequest`](protobufs.md#signerrequest) ; `requestSerialize`: (`value`: [`SignerRequest`](protobufs.md#signerrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } | Signer |
+| `getSigner` | { `path`: ``"/HubService/GetSigner"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`SignerRequest`](protobufs.md#signerrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } | Signer |
 | `getSigner.path` | ``"/HubService/GetSigner"`` | - |
-| `getSigner.requestDeserialize` | (`value`: `Buffer`) => [`SignerRequest`](protobufs.md#signerrequest) | - |
-| `getSigner.requestSerialize` | (`value`: [`SignerRequest`](protobufs.md#signerrequest)) => `Buffer` | - |
+| `getSigner.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getSigner.requestSerialize` | (`value`: [`SignerRequest`](protobufs.md#signerrequest)) =>  | - |
 | `getSigner.requestStream` | ``false`` | - |
-| `getSigner.responseDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) | - |
-| `getSigner.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` | - |
+| `getSigner.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getSigner.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  | - |
 | `getSigner.responseStream` | ``false`` | - |
-| `getSignersByFid` | { `path`: ``"/HubService/GetSignersByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getSignersByFid` | { `path`: ``"/HubService/GetSignersByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getSignersByFid.path` | ``"/HubService/GetSignersByFid"`` | - |
-| `getSignersByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) | - |
-| `getSignersByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` | - |
+| `getSignersByFid.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getSignersByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  | - |
 | `getSignersByFid.requestStream` | ``false`` | - |
-| `getSignersByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getSignersByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getSignersByFid.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getSignersByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getSignersByFid.responseStream` | ``false`` | - |
-| `getSyncMetadataByPrefix` | { `path`: ``"/HubService/GetSyncMetadataByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse) ; `responseSerialize`: (`value`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getSyncMetadataByPrefix` | { `path`: ``"/HubService/GetSyncMetadataByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getSyncMetadataByPrefix.path` | ``"/HubService/GetSyncMetadataByPrefix"`` | - |
-| `getSyncMetadataByPrefix.requestDeserialize` | (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) | - |
-| `getSyncMetadataByPrefix.requestSerialize` | (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` | - |
+| `getSyncMetadataByPrefix.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getSyncMetadataByPrefix.requestSerialize` | (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  | - |
 | `getSyncMetadataByPrefix.requestStream` | ``false`` | - |
-| `getSyncMetadataByPrefix.responseDeserialize` | (`value`: `Buffer`) => [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse) | - |
-| `getSyncMetadataByPrefix.responseSerialize` | (`value`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse)) => `Buffer` | - |
+| `getSyncMetadataByPrefix.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getSyncMetadataByPrefix.responseSerialize` | (`value`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse)) =>  | - |
 | `getSyncMetadataByPrefix.responseStream` | ``false`` | - |
-| `getSyncSnapshotByPrefix` | { `path`: ``"/HubService/GetSyncSnapshotByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse) ; `responseSerialize`: (`value`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getSyncSnapshotByPrefix` | { `path`: ``"/HubService/GetSyncSnapshotByPrefix"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getSyncSnapshotByPrefix.path` | ``"/HubService/GetSyncSnapshotByPrefix"`` | - |
-| `getSyncSnapshotByPrefix.requestDeserialize` | (`value`: `Buffer`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) | - |
-| `getSyncSnapshotByPrefix.requestSerialize` | (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `Buffer` | - |
+| `getSyncSnapshotByPrefix.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getSyncSnapshotByPrefix.requestSerialize` | (`value`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  | - |
 | `getSyncSnapshotByPrefix.requestStream` | ``false`` | - |
-| `getSyncSnapshotByPrefix.responseDeserialize` | (`value`: `Buffer`) => [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse) | - |
-| `getSyncSnapshotByPrefix.responseSerialize` | (`value`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse)) => `Buffer` | - |
+| `getSyncSnapshotByPrefix.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getSyncSnapshotByPrefix.responseSerialize` | (`value`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse)) =>  | - |
 | `getSyncSnapshotByPrefix.responseStream` | ``false`` | - |
-| `getUserData` | { `path`: ``"/HubService/GetUserData"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`UserDataRequest`](protobufs.md#userdatarequest) ; `requestSerialize`: (`value`: [`UserDataRequest`](protobufs.md#userdatarequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } | User Data |
+| `getUserData` | { `path`: ``"/HubService/GetUserData"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`UserDataRequest`](protobufs.md#userdatarequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } | User Data |
 | `getUserData.path` | ``"/HubService/GetUserData"`` | - |
-| `getUserData.requestDeserialize` | (`value`: `Buffer`) => [`UserDataRequest`](protobufs.md#userdatarequest) | - |
-| `getUserData.requestSerialize` | (`value`: [`UserDataRequest`](protobufs.md#userdatarequest)) => `Buffer` | - |
+| `getUserData.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getUserData.requestSerialize` | (`value`: [`UserDataRequest`](protobufs.md#userdatarequest)) =>  | - |
 | `getUserData.requestStream` | ``false`` | - |
-| `getUserData.responseDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) | - |
-| `getUserData.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` | - |
+| `getUserData.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getUserData.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  | - |
 | `getUserData.responseStream` | ``false`` | - |
-| `getUserDataByFid` | { `path`: ``"/HubService/GetUserDataByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getUserDataByFid` | { `path`: ``"/HubService/GetUserDataByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getUserDataByFid.path` | ``"/HubService/GetUserDataByFid"`` | - |
-| `getUserDataByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) | - |
-| `getUserDataByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` | - |
+| `getUserDataByFid.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getUserDataByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  | - |
 | `getUserDataByFid.requestStream` | ``false`` | - |
-| `getUserDataByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getUserDataByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getUserDataByFid.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getUserDataByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getUserDataByFid.responseStream` | ``false`` | - |
-| `getVerification` | { `path`: ``"/HubService/GetVerification"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`VerificationRequest`](protobufs.md#verificationrequest) ; `requestSerialize`: (`value`: [`VerificationRequest`](protobufs.md#verificationrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } | Verifications |
+| `getVerification` | { `path`: ``"/HubService/GetVerification"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`VerificationRequest`](protobufs.md#verificationrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } | Verifications |
 | `getVerification.path` | ``"/HubService/GetVerification"`` | - |
-| `getVerification.requestDeserialize` | (`value`: `Buffer`) => [`VerificationRequest`](protobufs.md#verificationrequest) | - |
-| `getVerification.requestSerialize` | (`value`: [`VerificationRequest`](protobufs.md#verificationrequest)) => `Buffer` | - |
+| `getVerification.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getVerification.requestSerialize` | (`value`: [`VerificationRequest`](protobufs.md#verificationrequest)) =>  | - |
 | `getVerification.requestStream` | ``false`` | - |
-| `getVerification.responseDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) | - |
-| `getVerification.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` | - |
+| `getVerification.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getVerification.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  | - |
 | `getVerification.responseStream` | ``false`` | - |
-| `getVerificationsByFid` | { `path`: ``"/HubService/GetVerificationsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `getVerificationsByFid` | { `path`: ``"/HubService/GetVerificationsByFid"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  ; `responseStream`: ``false``  } | - |
 | `getVerificationsByFid.path` | ``"/HubService/GetVerificationsByFid"`` | - |
-| `getVerificationsByFid.requestDeserialize` | (`value`: `Buffer`) => [`FidRequest`](protobufs.md#fidrequest) | - |
-| `getVerificationsByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) => `Buffer` | - |
+| `getVerificationsByFid.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getVerificationsByFid.requestSerialize` | (`value`: [`FidRequest`](protobufs.md#fidrequest)) =>  | - |
 | `getVerificationsByFid.requestStream` | ``false`` | - |
-| `getVerificationsByFid.responseDeserialize` | (`value`: `Buffer`) => [`MessagesResponse`](protobufs.md#messagesresponse) | - |
-| `getVerificationsByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `Buffer` | - |
+| `getVerificationsByFid.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `getVerificationsByFid.responseSerialize` | (`value`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  | - |
 | `getVerificationsByFid.responseStream` | ``false`` | - |
-| `submitIdRegistryEvent` | { `path`: ``"/HubService/SubmitIdRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) ; `requestSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) ; `responseSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `submitIdRegistryEvent` | { `path`: ``"/HubService/SubmitIdRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  ; `responseStream`: ``false``  } | - |
 | `submitIdRegistryEvent.path` | ``"/HubService/SubmitIdRegistryEvent"`` | - |
-| `submitIdRegistryEvent.requestDeserialize` | (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) | - |
-| `submitIdRegistryEvent.requestSerialize` | (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` | - |
+| `submitIdRegistryEvent.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `submitIdRegistryEvent.requestSerialize` | (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  | - |
 | `submitIdRegistryEvent.requestStream` | ``false`` | - |
-| `submitIdRegistryEvent.responseDeserialize` | (`value`: `Buffer`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) | - |
-| `submitIdRegistryEvent.responseSerialize` | (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `Buffer` | - |
+| `submitIdRegistryEvent.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `submitIdRegistryEvent.responseSerialize` | (`value`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  | - |
 | `submitIdRegistryEvent.responseStream` | ``false`` | - |
-| `submitMessage` | { `path`: ``"/HubService/SubmitMessage"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `requestSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`Message`](protobufs.md#message) ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) => `Buffer` ; `responseStream`: ``false``  } | Submit Methods |
+| `submitMessage` | { `path`: ``"/HubService/SubmitMessage"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`Message`](protobufs.md#message)) =>  ; `responseStream`: ``false``  } | Submit Methods |
 | `submitMessage.path` | ``"/HubService/SubmitMessage"`` | - |
-| `submitMessage.requestDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) | - |
-| `submitMessage.requestSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` | - |
+| `submitMessage.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `submitMessage.requestSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  | - |
 | `submitMessage.requestStream` | ``false`` | - |
-| `submitMessage.responseDeserialize` | (`value`: `Buffer`) => [`Message`](protobufs.md#message) | - |
-| `submitMessage.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) => `Buffer` | - |
+| `submitMessage.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `submitMessage.responseSerialize` | (`value`: [`Message`](protobufs.md#message)) =>  | - |
 | `submitMessage.responseStream` | ``false`` | - |
-| `submitNameRegistryEvent` | { `path`: ``"/HubService/SubmitNameRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) ; `requestSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) ; `responseSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` ; `responseStream`: ``false``  } | - |
+| `submitNameRegistryEvent` | { `path`: ``"/HubService/SubmitNameRegistryEvent"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  ; `responseStream`: ``false``  } | - |
 | `submitNameRegistryEvent.path` | ``"/HubService/SubmitNameRegistryEvent"`` | - |
-| `submitNameRegistryEvent.requestDeserialize` | (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) | - |
-| `submitNameRegistryEvent.requestSerialize` | (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` | - |
+| `submitNameRegistryEvent.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `submitNameRegistryEvent.requestSerialize` | (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  | - |
 | `submitNameRegistryEvent.requestStream` | ``false`` | - |
-| `submitNameRegistryEvent.responseDeserialize` | (`value`: `Buffer`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) | - |
-| `submitNameRegistryEvent.responseSerialize` | (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `Buffer` | - |
+| `submitNameRegistryEvent.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `submitNameRegistryEvent.responseSerialize` | (`value`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  | - |
 | `submitNameRegistryEvent.responseStream` | ``false`` | - |
-| `subscribe` | { `path`: ``"/HubService/Subscribe"`` ; `requestDeserialize`: (`value`: `Buffer`) => [`SubscribeRequest`](protobufs.md#subscriberequest) ; `requestSerialize`: (`value`: [`SubscribeRequest`](protobufs.md#subscriberequest)) => `Buffer` ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) => [`HubEvent`](protobufs.md#hubevent) ; `responseSerialize`: (`value`: [`HubEvent`](protobufs.md#hubevent)) => `Buffer` ; `responseStream`: ``true``  } | Event Methods |
+| `subscribe` | { `path`: ``"/HubService/Subscribe"`` ; `requestDeserialize`: (`value`: `Buffer`) =>  ; `requestSerialize`: (`value`: [`SubscribeRequest`](protobufs.md#subscriberequest)) =>  ; `requestStream`: ``false`` ; `responseDeserialize`: (`value`: `Buffer`) =>  ; `responseSerialize`: (`value`: [`HubEvent`](protobufs.md#hubevent)) =>  ; `responseStream`: ``true``  } | Event Methods |
 | `subscribe.path` | ``"/HubService/Subscribe"`` | - |
-| `subscribe.requestDeserialize` | (`value`: `Buffer`) => [`SubscribeRequest`](protobufs.md#subscriberequest) | - |
-| `subscribe.requestSerialize` | (`value`: [`SubscribeRequest`](protobufs.md#subscriberequest)) => `Buffer` | - |
+| `subscribe.requestDeserialize` | (`value`: `Buffer`) =>  | - |
+| `subscribe.requestSerialize` | (`value`: [`SubscribeRequest`](protobufs.md#subscriberequest)) =>  | - |
 | `subscribe.requestStream` | ``false`` | - |
-| `subscribe.responseDeserialize` | (`value`: `Buffer`) => [`HubEvent`](protobufs.md#hubevent) | - |
-| `subscribe.responseSerialize` | (`value`: [`HubEvent`](protobufs.md#hubevent)) => `Buffer` | - |
+| `subscribe.responseDeserialize` | (`value`: `Buffer`) =>  | - |
+| `subscribe.responseSerialize` | (`value`: [`HubEvent`](protobufs.md#hubevent)) =>  | - |
 | `subscribe.responseStream` | ``true`` | - |
 
 ___
@@ -1185,12 +1185,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`HubState`](protobufs.md#hubstate) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`HubState`](protobufs.md#hubstate) |
-| `encode` | (`message`: [`HubState`](protobufs.md#hubstate), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`HubState`](protobufs.md#hubstate) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`HubState`](protobufs.md#hubstate) |
-| `toJSON` | (`message`: [`HubState`](protobufs.md#hubstate)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`HubState`](protobufs.md#hubstate), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`HubState`](protobufs.md#hubstate)) =>  |
 
 ___
 
@@ -1202,12 +1202,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) |
-| `encode` | (`message`: [`IdRegistryEvent`](protobufs.md#idregistryevent), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`IdRegistryEvent`](protobufs.md#idregistryevent) |
-| `toJSON` | (`message`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`IdRegistryEvent`](protobufs.md#idregistryevent), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`IdRegistryEvent`](protobufs.md#idregistryevent)) =>  |
 
 ___
 
@@ -1219,12 +1219,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`MergeIdRegistryEventBody`](protobufs.md#mergeidregistryeventbody) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`MergeIdRegistryEventBody`](protobufs.md#mergeidregistryeventbody) |
-| `encode` | (`message`: [`MergeIdRegistryEventBody`](protobufs.md#mergeidregistryeventbody), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`MergeIdRegistryEventBody`](protobufs.md#mergeidregistryeventbody) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`MergeIdRegistryEventBody`](protobufs.md#mergeidregistryeventbody) |
-| `toJSON` | (`message`: [`MergeIdRegistryEventBody`](protobufs.md#mergeidregistryeventbody)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`MergeIdRegistryEventBody`](protobufs.md#mergeidregistryeventbody), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`MergeIdRegistryEventBody`](protobufs.md#mergeidregistryeventbody)) =>  |
 
 ___
 
@@ -1236,12 +1236,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`MergeMessageBody`](protobufs.md#mergemessagebody) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`MergeMessageBody`](protobufs.md#mergemessagebody) |
-| `encode` | (`message`: [`MergeMessageBody`](protobufs.md#mergemessagebody), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`MergeMessageBody`](protobufs.md#mergemessagebody) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`MergeMessageBody`](protobufs.md#mergemessagebody) |
-| `toJSON` | (`message`: [`MergeMessageBody`](protobufs.md#mergemessagebody)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`MergeMessageBody`](protobufs.md#mergemessagebody), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`MergeMessageBody`](protobufs.md#mergemessagebody)) =>  |
 
 ___
 
@@ -1253,12 +1253,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`MergeNameRegistryEventBody`](protobufs.md#mergenameregistryeventbody) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`MergeNameRegistryEventBody`](protobufs.md#mergenameregistryeventbody) |
-| `encode` | (`message`: [`MergeNameRegistryEventBody`](protobufs.md#mergenameregistryeventbody), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`MergeNameRegistryEventBody`](protobufs.md#mergenameregistryeventbody) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`MergeNameRegistryEventBody`](protobufs.md#mergenameregistryeventbody) |
-| `toJSON` | (`message`: [`MergeNameRegistryEventBody`](protobufs.md#mergenameregistryeventbody)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`MergeNameRegistryEventBody`](protobufs.md#mergenameregistryeventbody), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`MergeNameRegistryEventBody`](protobufs.md#mergenameregistryeventbody)) =>  |
 
 ___
 
@@ -1270,12 +1270,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`Message`](protobufs.md#message) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`Message`](protobufs.md#message) |
-| `encode` | (`message`: [`Message`](protobufs.md#message), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`Message`](protobufs.md#message) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`Message`](protobufs.md#message) |
-| `toJSON` | (`message`: [`Message`](protobufs.md#message)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`Message`](protobufs.md#message), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`Message`](protobufs.md#message)) =>  |
 
 ___
 
@@ -1287,12 +1287,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`MessageData`](protobufs.md#messagedata) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`MessageData`](protobufs.md#messagedata) |
-| `encode` | (`message`: [`MessageData`](protobufs.md#messagedata), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`MessageData`](protobufs.md#messagedata) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`MessageData`](protobufs.md#messagedata) |
-| `toJSON` | (`message`: [`MessageData`](protobufs.md#messagedata)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`MessageData`](protobufs.md#messagedata), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`MessageData`](protobufs.md#messagedata)) =>  |
 
 ___
 
@@ -1304,12 +1304,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `encode` | (`message`: [`MessagesResponse`](protobufs.md#messagesresponse), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`MessagesResponse`](protobufs.md#messagesresponse) |
-| `toJSON` | (`message`: [`MessagesResponse`](protobufs.md#messagesresponse)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`MessagesResponse`](protobufs.md#messagesresponse), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`MessagesResponse`](protobufs.md#messagesresponse)) =>  |
 
 ___
 
@@ -1321,12 +1321,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) |
-| `encode` | (`message`: [`NameRegistryEvent`](protobufs.md#nameregistryevent), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`NameRegistryEvent`](protobufs.md#nameregistryevent) |
-| `toJSON` | (`message`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`NameRegistryEvent`](protobufs.md#nameregistryevent), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`NameRegistryEvent`](protobufs.md#nameregistryevent)) =>  |
 
 ___
 
@@ -1338,12 +1338,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest) |
-| `encode` | (`message`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest) |
-| `toJSON` | (`message`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`NameRegistryEventRequest`](protobufs.md#nameregistryeventrequest)) =>  |
 
 ___
 
@@ -1355,12 +1355,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`PruneMessageBody`](protobufs.md#prunemessagebody) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`PruneMessageBody`](protobufs.md#prunemessagebody) |
-| `encode` | (`message`: [`PruneMessageBody`](protobufs.md#prunemessagebody), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`PruneMessageBody`](protobufs.md#prunemessagebody) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`PruneMessageBody`](protobufs.md#prunemessagebody) |
-| `toJSON` | (`message`: [`PruneMessageBody`](protobufs.md#prunemessagebody)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`PruneMessageBody`](protobufs.md#prunemessagebody), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`PruneMessageBody`](protobufs.md#prunemessagebody)) =>  |
 
 ___
 
@@ -1372,12 +1372,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`ReactionBody`](protobufs.md#reactionbody) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`ReactionBody`](protobufs.md#reactionbody) |
-| `encode` | (`message`: [`ReactionBody`](protobufs.md#reactionbody), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`ReactionBody`](protobufs.md#reactionbody) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`ReactionBody`](protobufs.md#reactionbody) |
-| `toJSON` | (`message`: [`ReactionBody`](protobufs.md#reactionbody)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`ReactionBody`](protobufs.md#reactionbody), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`ReactionBody`](protobufs.md#reactionbody)) =>  |
 
 ___
 
@@ -1389,12 +1389,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`ReactionRequest`](protobufs.md#reactionrequest) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`ReactionRequest`](protobufs.md#reactionrequest) |
-| `encode` | (`message`: [`ReactionRequest`](protobufs.md#reactionrequest), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`ReactionRequest`](protobufs.md#reactionrequest) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`ReactionRequest`](protobufs.md#reactionrequest) |
-| `toJSON` | (`message`: [`ReactionRequest`](protobufs.md#reactionrequest)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`ReactionRequest`](protobufs.md#reactionrequest), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`ReactionRequest`](protobufs.md#reactionrequest)) =>  |
 
 ___
 
@@ -1406,12 +1406,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest) |
-| `encode` | (`message`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest) |
-| `toJSON` | (`message`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`ReactionsByCastRequest`](protobufs.md#reactionsbycastrequest)) =>  |
 
 ___
 
@@ -1423,12 +1423,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest) |
-| `encode` | (`message`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest) |
-| `toJSON` | (`message`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`ReactionsByFidRequest`](protobufs.md#reactionsbyfidrequest)) =>  |
 
 ___
 
@@ -1440,12 +1440,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`RevokeMessageBody`](protobufs.md#revokemessagebody) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`RevokeMessageBody`](protobufs.md#revokemessagebody) |
-| `encode` | (`message`: [`RevokeMessageBody`](protobufs.md#revokemessagebody), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`RevokeMessageBody`](protobufs.md#revokemessagebody) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`RevokeMessageBody`](protobufs.md#revokemessagebody) |
-| `toJSON` | (`message`: [`RevokeMessageBody`](protobufs.md#revokemessagebody)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`RevokeMessageBody`](protobufs.md#revokemessagebody), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`RevokeMessageBody`](protobufs.md#revokemessagebody)) =>  |
 
 ___
 
@@ -1457,12 +1457,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`RevokeSignerJobPayload`](protobufs.md#revokesignerjobpayload) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`RevokeSignerJobPayload`](protobufs.md#revokesignerjobpayload) |
-| `encode` | (`message`: [`RevokeSignerJobPayload`](protobufs.md#revokesignerjobpayload), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`RevokeSignerJobPayload`](protobufs.md#revokesignerjobpayload) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`RevokeSignerJobPayload`](protobufs.md#revokesignerjobpayload) |
-| `toJSON` | (`message`: [`RevokeSignerJobPayload`](protobufs.md#revokesignerjobpayload)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`RevokeSignerJobPayload`](protobufs.md#revokesignerjobpayload), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`RevokeSignerJobPayload`](protobufs.md#revokesignerjobpayload)) =>  |
 
 ___
 
@@ -1474,12 +1474,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`SignerBody`](protobufs.md#signerbody) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`SignerBody`](protobufs.md#signerbody) |
-| `encode` | (`message`: [`SignerBody`](protobufs.md#signerbody), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`SignerBody`](protobufs.md#signerbody) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`SignerBody`](protobufs.md#signerbody) |
-| `toJSON` | (`message`: [`SignerBody`](protobufs.md#signerbody)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`SignerBody`](protobufs.md#signerbody), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`SignerBody`](protobufs.md#signerbody)) =>  |
 
 ___
 
@@ -1491,12 +1491,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`SignerRequest`](protobufs.md#signerrequest) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`SignerRequest`](protobufs.md#signerrequest) |
-| `encode` | (`message`: [`SignerRequest`](protobufs.md#signerrequest), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`SignerRequest`](protobufs.md#signerrequest) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`SignerRequest`](protobufs.md#signerrequest) |
-| `toJSON` | (`message`: [`SignerRequest`](protobufs.md#signerrequest)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`SignerRequest`](protobufs.md#signerrequest), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`SignerRequest`](protobufs.md#signerrequest)) =>  |
 
 ___
 
@@ -1508,12 +1508,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`SubscribeRequest`](protobufs.md#subscriberequest) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`SubscribeRequest`](protobufs.md#subscriberequest) |
-| `encode` | (`message`: [`SubscribeRequest`](protobufs.md#subscriberequest), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`SubscribeRequest`](protobufs.md#subscriberequest) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`SubscribeRequest`](protobufs.md#subscriberequest) |
-| `toJSON` | (`message`: [`SubscribeRequest`](protobufs.md#subscriberequest)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`SubscribeRequest`](protobufs.md#subscriberequest), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`SubscribeRequest`](protobufs.md#subscriberequest)) =>  |
 
 ___
 
@@ -1525,12 +1525,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`SyncIds`](protobufs.md#syncids) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`SyncIds`](protobufs.md#syncids) |
-| `encode` | (`message`: [`SyncIds`](protobufs.md#syncids), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`SyncIds`](protobufs.md#syncids) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`SyncIds`](protobufs.md#syncids) |
-| `toJSON` | (`message`: [`SyncIds`](protobufs.md#syncids)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`SyncIds`](protobufs.md#syncids), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`SyncIds`](protobufs.md#syncids)) =>  |
 
 ___
 
@@ -1542,12 +1542,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse) |
-| `encode` | (`message`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse) |
-| `toJSON` | (`message`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`TrieNodeMetadataResponse`](protobufs.md#trienodemetadataresponse)) =>  |
 
 ___
 
@@ -1559,12 +1559,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) |
-| `encode` | (`message`: [`TrieNodePrefix`](protobufs.md#trienodeprefix), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`TrieNodePrefix`](protobufs.md#trienodeprefix) |
-| `toJSON` | (`message`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`TrieNodePrefix`](protobufs.md#trienodeprefix), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`TrieNodePrefix`](protobufs.md#trienodeprefix)) =>  |
 
 ___
 
@@ -1576,12 +1576,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse) |
-| `encode` | (`message`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse) |
-| `toJSON` | (`message`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`TrieNodeSnapshotResponse`](protobufs.md#trienodesnapshotresponse)) =>  |
 
 ___
 
@@ -1593,12 +1593,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`UpdateNameRegistryEventExpiryJobPayload`](protobufs.md#updatenameregistryeventexpiryjobpayload) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`UpdateNameRegistryEventExpiryJobPayload`](protobufs.md#updatenameregistryeventexpiryjobpayload) |
-| `encode` | (`message`: [`UpdateNameRegistryEventExpiryJobPayload`](protobufs.md#updatenameregistryeventexpiryjobpayload), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`UpdateNameRegistryEventExpiryJobPayload`](protobufs.md#updatenameregistryeventexpiryjobpayload) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`UpdateNameRegistryEventExpiryJobPayload`](protobufs.md#updatenameregistryeventexpiryjobpayload) |
-| `toJSON` | (`message`: [`UpdateNameRegistryEventExpiryJobPayload`](protobufs.md#updatenameregistryeventexpiryjobpayload)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`UpdateNameRegistryEventExpiryJobPayload`](protobufs.md#updatenameregistryeventexpiryjobpayload), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`UpdateNameRegistryEventExpiryJobPayload`](protobufs.md#updatenameregistryeventexpiryjobpayload)) =>  |
 
 ___
 
@@ -1610,12 +1610,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`UserDataBody`](protobufs.md#userdatabody) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`UserDataBody`](protobufs.md#userdatabody) |
-| `encode` | (`message`: [`UserDataBody`](protobufs.md#userdatabody), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`UserDataBody`](protobufs.md#userdatabody) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`UserDataBody`](protobufs.md#userdatabody) |
-| `toJSON` | (`message`: [`UserDataBody`](protobufs.md#userdatabody)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`UserDataBody`](protobufs.md#userdatabody), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`UserDataBody`](protobufs.md#userdatabody)) =>  |
 
 ___
 
@@ -1627,12 +1627,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`UserDataRequest`](protobufs.md#userdatarequest) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`UserDataRequest`](protobufs.md#userdatarequest) |
-| `encode` | (`message`: [`UserDataRequest`](protobufs.md#userdatarequest), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`UserDataRequest`](protobufs.md#userdatarequest) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`UserDataRequest`](protobufs.md#userdatarequest) |
-| `toJSON` | (`message`: [`UserDataRequest`](protobufs.md#userdatarequest)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`UserDataRequest`](protobufs.md#userdatarequest), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`UserDataRequest`](protobufs.md#userdatarequest)) =>  |
 
 ___
 
@@ -1644,12 +1644,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`VerificationAddEthAddressBody`](protobufs.md#verificationaddethaddressbody) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`VerificationAddEthAddressBody`](protobufs.md#verificationaddethaddressbody) |
-| `encode` | (`message`: [`VerificationAddEthAddressBody`](protobufs.md#verificationaddethaddressbody), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`VerificationAddEthAddressBody`](protobufs.md#verificationaddethaddressbody) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`VerificationAddEthAddressBody`](protobufs.md#verificationaddethaddressbody) |
-| `toJSON` | (`message`: [`VerificationAddEthAddressBody`](protobufs.md#verificationaddethaddressbody)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`VerificationAddEthAddressBody`](protobufs.md#verificationaddethaddressbody), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`VerificationAddEthAddressBody`](protobufs.md#verificationaddethaddressbody)) =>  |
 
 ___
 
@@ -1661,12 +1661,12 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`VerificationRemoveBody`](protobufs.md#verificationremovebody) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`VerificationRemoveBody`](protobufs.md#verificationremovebody) |
-| `encode` | (`message`: [`VerificationRemoveBody`](protobufs.md#verificationremovebody), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`VerificationRemoveBody`](protobufs.md#verificationremovebody) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`VerificationRemoveBody`](protobufs.md#verificationremovebody) |
-| `toJSON` | (`message`: [`VerificationRemoveBody`](protobufs.md#verificationremovebody)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`VerificationRemoveBody`](protobufs.md#verificationremovebody), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`VerificationRemoveBody`](protobufs.md#verificationremovebody)) =>  |
 
 ___
 
@@ -1678,18 +1678,18 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `create` | <I\>(`base?`: `I`) => [`VerificationRequest`](protobufs.md#verificationrequest) |
-| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) => [`VerificationRequest`](protobufs.md#verificationrequest) |
-| `encode` | (`message`: [`VerificationRequest`](protobufs.md#verificationrequest), `writer?`: `Writer`) => `Writer` |
-| `fromJSON` | (`object`: `any`) => [`VerificationRequest`](protobufs.md#verificationrequest) |
-| `fromPartial` | <I_1\>(`object`: `I_1`) => [`VerificationRequest`](protobufs.md#verificationrequest) |
-| `toJSON` | (`message`: [`VerificationRequest`](protobufs.md#verificationrequest)) => `unknown` |
+| `create` | <I\>(`base?`: `I`) =>  |
+| `decode` | (`input`: `Reader` \| `Uint8Array`, `length?`: `number`) =>  |
+| `encode` | (`message`: [`VerificationRequest`](protobufs.md#verificationrequest), `writer?`: `Writer`) =>  |
+| `fromJSON` | (`object`: `any`) =>  |
+| `fromPartial` | <I_1\>(`object`: `I_1`) =>  |
+| `toJSON` | (`message`: [`VerificationRequest`](protobufs.md#verificationrequest)) =>  |
 
 ## Functions
 
 ### farcasterNetworkFromJSON
 
-▸ **farcasterNetworkFromJSON**(`object`): [`FarcasterNetwork`](../enums/protobufs.FarcasterNetwork.md)
+▸ **farcasterNetworkFromJSON**(`object`)
 
 #### Parameters
 
@@ -1697,15 +1697,11 @@ ___
 | :------ | :------ |
 | `object` | `any` |
 
-#### Returns
-
-[`FarcasterNetwork`](../enums/protobufs.FarcasterNetwork.md)
-
 ___
 
 ### farcasterNetworkToJSON
 
-▸ **farcasterNetworkToJSON**(`object`): `string`
+▸ **farcasterNetworkToJSON**(`object`)
 
 #### Parameters
 
@@ -1713,31 +1709,23 @@ ___
 | :------ | :------ |
 | `object` | [`FarcasterNetwork`](../enums/protobufs.FarcasterNetwork.md) |
 
-#### Returns
-
-`string`
-
 ___
 
 ### getAdminClient
 
-▸ **getAdminClient**(`address`): [`AdminServiceClient`](protobufs.md#adminserviceclient)
+▸ **getAdminClient**(`address`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `address` | `string` |
-
-#### Returns
-
-[`AdminServiceClient`](protobufs.md#adminserviceclient)
 
 ___
 
 ### getClient
 
-▸ **getClient**(`address`): [`HubServiceClient`](protobufs.md#hubserviceclient)
+▸ **getClient**(`address`)
 
 #### Parameters
 
@@ -1745,25 +1733,17 @@ ___
 | :------ | :------ |
 | `address` | `string` |
 
-#### Returns
-
-[`HubServiceClient`](protobufs.md#hubserviceclient)
-
 ___
 
 ### getServer
 
-▸ **getServer**(): `Server`
-
-#### Returns
-
-`Server`
+▸ **getServer**()
 
 ___
 
 ### gossipVersionFromJSON
 
-▸ **gossipVersionFromJSON**(`object`): [`GossipVersion`](../enums/protobufs.GossipVersion.md)
+▸ **gossipVersionFromJSON**(`object`)
 
 #### Parameters
 
@@ -1771,15 +1751,11 @@ ___
 | :------ | :------ |
 | `object` | `any` |
 
-#### Returns
-
-[`GossipVersion`](../enums/protobufs.GossipVersion.md)
-
 ___
 
 ### gossipVersionToJSON
 
-▸ **gossipVersionToJSON**(`object`): `string`
+▸ **gossipVersionToJSON**(`object`)
 
 #### Parameters
 
@@ -1787,15 +1763,11 @@ ___
 | :------ | :------ |
 | `object` | [`GossipVersion`](../enums/protobufs.GossipVersion.md) |
 
-#### Returns
-
-`string`
-
 ___
 
 ### hashSchemeFromJSON
 
-▸ **hashSchemeFromJSON**(`object`): [`HashScheme`](../enums/protobufs.HashScheme.md)
+▸ **hashSchemeFromJSON**(`object`)
 
 #### Parameters
 
@@ -1803,15 +1775,11 @@ ___
 | :------ | :------ |
 | `object` | `any` |
 
-#### Returns
-
-[`HashScheme`](../enums/protobufs.HashScheme.md)
-
 ___
 
 ### hashSchemeToJSON
 
-▸ **hashSchemeToJSON**(`object`): `string`
+▸ **hashSchemeToJSON**(`object`)
 
 #### Parameters
 
@@ -1819,15 +1787,11 @@ ___
 | :------ | :------ |
 | `object` | [`HashScheme`](../enums/protobufs.HashScheme.md) |
 
-#### Returns
-
-`string`
-
 ___
 
 ### hubEventTypeFromJSON
 
-▸ **hubEventTypeFromJSON**(`object`): [`HubEventType`](../enums/protobufs.HubEventType.md)
+▸ **hubEventTypeFromJSON**(`object`)
 
 #### Parameters
 
@@ -1835,15 +1799,11 @@ ___
 | :------ | :------ |
 | `object` | `any` |
 
-#### Returns
-
-[`HubEventType`](../enums/protobufs.HubEventType.md)
-
 ___
 
 ### hubEventTypeToJSON
 
-▸ **hubEventTypeToJSON**(`object`): `string`
+▸ **hubEventTypeToJSON**(`object`)
 
 #### Parameters
 
@@ -1851,15 +1811,11 @@ ___
 | :------ | :------ |
 | `object` | [`HubEventType`](../enums/protobufs.HubEventType.md) |
 
-#### Returns
-
-`string`
-
 ___
 
 ### idRegistryEventTypeFromJSON
 
-▸ **idRegistryEventTypeFromJSON**(`object`): [`IdRegistryEventType`](../enums/protobufs.IdRegistryEventType.md)
+▸ **idRegistryEventTypeFromJSON**(`object`)
 
 #### Parameters
 
@@ -1867,15 +1823,11 @@ ___
 | :------ | :------ |
 | `object` | `any` |
 
-#### Returns
-
-[`IdRegistryEventType`](../enums/protobufs.IdRegistryEventType.md)
-
 ___
 
 ### idRegistryEventTypeToJSON
 
-▸ **idRegistryEventTypeToJSON**(`object`): `string`
+▸ **idRegistryEventTypeToJSON**(`object`)
 
 #### Parameters
 
@@ -1883,15 +1835,11 @@ ___
 | :------ | :------ |
 | `object` | [`IdRegistryEventType`](../enums/protobufs.IdRegistryEventType.md) |
 
-#### Returns
-
-`string`
-
 ___
 
 ### isCastAddData
 
-▸ **isCastAddData**(`data`): data is CastAddData
+▸ **isCastAddData**(`data`)
 
 Message typeguards
 
@@ -1901,15 +1849,11 @@ Message typeguards
 | :------ | :------ |
 | `data` | [`MessageData`](protobufs.md#messagedata) |
 
-#### Returns
-
-data is CastAddData
-
 ___
 
 ### isCastAddMessage
 
-▸ **isCastAddMessage**(`message`): message is CastAddMessage
+▸ **isCastAddMessage**(`message`)
 
 #### Parameters
 
@@ -1917,15 +1861,11 @@ ___
 | :------ | :------ |
 | `message` | [`Message`](protobufs.md#message) |
 
-#### Returns
-
-message is CastAddMessage
-
 ___
 
 ### isCastRemoveData
 
-▸ **isCastRemoveData**(`data`): data is CastRemoveData
+▸ **isCastRemoveData**(`data`)
 
 #### Parameters
 
@@ -1933,15 +1873,11 @@ ___
 | :------ | :------ |
 | `data` | [`MessageData`](protobufs.md#messagedata) |
 
-#### Returns
-
-data is CastRemoveData
-
 ___
 
 ### isCastRemoveMessage
 
-▸ **isCastRemoveMessage**(`message`): message is CastRemoveMessage
+▸ **isCastRemoveMessage**(`message`)
 
 #### Parameters
 
@@ -1949,15 +1885,11 @@ ___
 | :------ | :------ |
 | `message` | [`Message`](protobufs.md#message) |
 
-#### Returns
-
-message is CastRemoveMessage
-
 ___
 
 ### isMergeIdRegistryEventHubEvent
 
-▸ **isMergeIdRegistryEventHubEvent**(`event`): event is MergeIdRegistryEventHubEvent
+▸ **isMergeIdRegistryEventHubEvent**(`event`)
 
 #### Parameters
 
@@ -1965,15 +1897,11 @@ ___
 | :------ | :------ |
 | `event` | [`HubEvent`](protobufs.md#hubevent) |
 
-#### Returns
-
-event is MergeIdRegistryEventHubEvent
-
 ___
 
 ### isMergeMessageHubEvent
 
-▸ **isMergeMessageHubEvent**(`event`): event is MergeMessageHubEvent
+▸ **isMergeMessageHubEvent**(`event`)
 
 Hub event typeguards
 
@@ -1983,63 +1911,47 @@ Hub event typeguards
 | :------ | :------ |
 | `event` | [`HubEvent`](protobufs.md#hubevent) |
 
-#### Returns
-
-event is MergeMessageHubEvent
-
 ___
 
 ### isMergeNameRegistryEventHubEvent
 
-▸ **isMergeNameRegistryEventHubEvent**(`event`): event is MergeNameRegistryEventHubEvent
+▸ **isMergeNameRegistryEventHubEvent**(`event`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `event` | [`HubEvent`](protobufs.md#hubevent) |
-
-#### Returns
-
-event is MergeNameRegistryEventHubEvent
 
 ___
 
 ### isPruneMessageHubEvent
 
-▸ **isPruneMessageHubEvent**(`event`): event is PruneMessageHubEvent
+▸ **isPruneMessageHubEvent**(`event`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `event` | [`HubEvent`](protobufs.md#hubevent) |
-
-#### Returns
-
-event is PruneMessageHubEvent
 
 ___
 
 ### isReactionAddData
 
-▸ **isReactionAddData**(`data`): data is ReactionAddData
+▸ **isReactionAddData**(`data`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `data` | [`MessageData`](protobufs.md#messagedata) |
-
-#### Returns
-
-data is ReactionAddData
 
 ___
 
 ### isReactionAddMessage
 
-▸ **isReactionAddMessage**(`message`): message is ReactionAddMessage
+▸ **isReactionAddMessage**(`message`)
 
 #### Parameters
 
@@ -2047,15 +1959,11 @@ ___
 | :------ | :------ |
 | `message` | [`Message`](protobufs.md#message) |
 
-#### Returns
-
-message is ReactionAddMessage
-
 ___
 
 ### isReactionRemoveData
 
-▸ **isReactionRemoveData**(`data`): data is ReactionRemoveData
+▸ **isReactionRemoveData**(`data`)
 
 #### Parameters
 
@@ -2063,15 +1971,11 @@ ___
 | :------ | :------ |
 | `data` | [`MessageData`](protobufs.md#messagedata) |
 
-#### Returns
-
-data is ReactionRemoveData
-
 ___
 
 ### isReactionRemoveMessage
 
-▸ **isReactionRemoveMessage**(`message`): message is ReactionRemoveMessage
+▸ **isReactionRemoveMessage**(`message`)
 
 #### Parameters
 
@@ -2079,15 +1983,11 @@ ___
 | :------ | :------ |
 | `message` | [`Message`](protobufs.md#message) |
 
-#### Returns
-
-message is ReactionRemoveMessage
-
 ___
 
 ### isRevokeMessageHubEvent
 
-▸ **isRevokeMessageHubEvent**(`event`): event is RevokeMessageHubEvent
+▸ **isRevokeMessageHubEvent**(`event`)
 
 #### Parameters
 
@@ -2095,127 +1995,95 @@ ___
 | :------ | :------ |
 | `event` | [`HubEvent`](protobufs.md#hubevent) |
 
-#### Returns
-
-event is RevokeMessageHubEvent
-
 ___
 
 ### isSignerAddData
 
-▸ **isSignerAddData**(`data`): data is SignerAddData
+▸ **isSignerAddData**(`data`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `data` | [`MessageData`](protobufs.md#messagedata) |
-
-#### Returns
-
-data is SignerAddData
 
 ___
 
 ### isSignerAddMessage
 
-▸ **isSignerAddMessage**(`message`): message is SignerAddMessage
+▸ **isSignerAddMessage**(`message`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `message` | [`Message`](protobufs.md#message) |
-
-#### Returns
-
-message is SignerAddMessage
 
 ___
 
 ### isSignerRemoveData
 
-▸ **isSignerRemoveData**(`data`): data is SignerRemoveData
+▸ **isSignerRemoveData**(`data`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `data` | [`MessageData`](protobufs.md#messagedata) |
-
-#### Returns
-
-data is SignerRemoveData
 
 ___
 
 ### isSignerRemoveMessage
 
-▸ **isSignerRemoveMessage**(`message`): message is SignerRemoveMessage
+▸ **isSignerRemoveMessage**(`message`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `message` | [`Message`](protobufs.md#message) |
-
-#### Returns
-
-message is SignerRemoveMessage
 
 ___
 
 ### isUserDataAddData
 
-▸ **isUserDataAddData**(`data`): data is UserDataAddData
+▸ **isUserDataAddData**(`data`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `data` | [`MessageData`](protobufs.md#messagedata) |
-
-#### Returns
-
-data is UserDataAddData
 
 ___
 
 ### isUserDataAddMessage
 
-▸ **isUserDataAddMessage**(`message`): message is UserDataAddMessage
+▸ **isUserDataAddMessage**(`message`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `message` | [`Message`](protobufs.md#message) |
-
-#### Returns
-
-message is UserDataAddMessage
 
 ___
 
 ### isVerificationAddEthAddressData
 
-▸ **isVerificationAddEthAddressData**(`data`): data is VerificationAddEthAddressData
+▸ **isVerificationAddEthAddressData**(`data`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `data` | [`MessageData`](protobufs.md#messagedata) |
-
-#### Returns
-
-data is VerificationAddEthAddressData
 
 ___
 
 ### isVerificationAddEthAddressMessage
 
-▸ **isVerificationAddEthAddressMessage**(`message`): message is VerificationAddEthAddressMessage
+▸ **isVerificationAddEthAddressMessage**(`message`)
 
 #### Parameters
 
@@ -2223,15 +2091,11 @@ ___
 | :------ | :------ |
 | `message` | [`Message`](protobufs.md#message) |
 
-#### Returns
-
-message is VerificationAddEthAddressMessage
-
 ___
 
 ### isVerificationRemoveData
 
-▸ **isVerificationRemoveData**(`data`): data is VerificationRemoveData
+▸ **isVerificationRemoveData**(`data`)
 
 #### Parameters
 
@@ -2239,15 +2103,11 @@ ___
 | :------ | :------ |
 | `data` | [`MessageData`](protobufs.md#messagedata) |
 
-#### Returns
-
-data is VerificationRemoveData
-
 ___
 
 ### isVerificationRemoveMessage
 
-▸ **isVerificationRemoveMessage**(`message`): message is VerificationRemoveMessage
+▸ **isVerificationRemoveMessage**(`message`)
 
 #### Parameters
 
@@ -2255,15 +2115,11 @@ ___
 | :------ | :------ |
 | `message` | [`Message`](protobufs.md#message) |
 
-#### Returns
-
-message is VerificationRemoveMessage
-
 ___
 
 ### messageTypeFromJSON
 
-▸ **messageTypeFromJSON**(`object`): [`MessageType`](../enums/protobufs.MessageType.md)
+▸ **messageTypeFromJSON**(`object`)
 
 #### Parameters
 
@@ -2271,15 +2127,11 @@ ___
 | :------ | :------ |
 | `object` | `any` |
 
-#### Returns
-
-[`MessageType`](../enums/protobufs.MessageType.md)
-
 ___
 
 ### messageTypeToJSON
 
-▸ **messageTypeToJSON**(`object`): `string`
+▸ **messageTypeToJSON**(`object`)
 
 #### Parameters
 
@@ -2287,15 +2139,11 @@ ___
 | :------ | :------ |
 | `object` | [`MessageType`](../enums/protobufs.MessageType.md) |
 
-#### Returns
-
-`string`
-
 ___
 
 ### nameRegistryEventTypeFromJSON
 
-▸ **nameRegistryEventTypeFromJSON**(`object`): [`NameRegistryEventType`](../enums/protobufs.NameRegistryEventType.md)
+▸ **nameRegistryEventTypeFromJSON**(`object`)
 
 #### Parameters
 
@@ -2303,15 +2151,11 @@ ___
 | :------ | :------ |
 | `object` | `any` |
 
-#### Returns
-
-[`NameRegistryEventType`](../enums/protobufs.NameRegistryEventType.md)
-
 ___
 
 ### nameRegistryEventTypeToJSON
 
-▸ **nameRegistryEventTypeToJSON**(`object`): `string`
+▸ **nameRegistryEventTypeToJSON**(`object`)
 
 #### Parameters
 
@@ -2319,15 +2163,11 @@ ___
 | :------ | :------ |
 | `object` | [`NameRegistryEventType`](../enums/protobufs.NameRegistryEventType.md) |
 
-#### Returns
-
-`string`
-
 ___
 
 ### reactionTypeFromJSON
 
-▸ **reactionTypeFromJSON**(`object`): [`ReactionType`](../enums/protobufs.ReactionType.md)
+▸ **reactionTypeFromJSON**(`object`)
 
 #### Parameters
 
@@ -2335,15 +2175,11 @@ ___
 | :------ | :------ |
 | `object` | `any` |
 
-#### Returns
-
-[`ReactionType`](../enums/protobufs.ReactionType.md)
-
 ___
 
 ### reactionTypeToJSON
 
-▸ **reactionTypeToJSON**(`object`): `string`
+▸ **reactionTypeToJSON**(`object`)
 
 #### Parameters
 
@@ -2351,15 +2187,11 @@ ___
 | :------ | :------ |
 | `object` | [`ReactionType`](../enums/protobufs.ReactionType.md) |
 
-#### Returns
-
-`string`
-
 ___
 
 ### signatureSchemeFromJSON
 
-▸ **signatureSchemeFromJSON**(`object`): [`SignatureScheme`](../enums/protobufs.SignatureScheme.md)
+▸ **signatureSchemeFromJSON**(`object`)
 
 #### Parameters
 
@@ -2367,15 +2199,11 @@ ___
 | :------ | :------ |
 | `object` | `any` |
 
-#### Returns
-
-[`SignatureScheme`](../enums/protobufs.SignatureScheme.md)
-
 ___
 
 ### signatureSchemeToJSON
 
-▸ **signatureSchemeToJSON**(`object`): `string`
+▸ **signatureSchemeToJSON**(`object`)
 
 #### Parameters
 
@@ -2383,15 +2211,11 @@ ___
 | :------ | :------ |
 | `object` | [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) |
 
-#### Returns
-
-`string`
-
 ___
 
 ### userDataTypeFromJSON
 
-▸ **userDataTypeFromJSON**(`object`): [`UserDataType`](../enums/protobufs.UserDataType.md)
+▸ **userDataTypeFromJSON**(`object`)
 
 #### Parameters
 
@@ -2399,22 +2223,14 @@ ___
 | :------ | :------ |
 | `object` | `any` |
 
-#### Returns
-
-[`UserDataType`](../enums/protobufs.UserDataType.md)
-
 ___
 
 ### userDataTypeToJSON
 
-▸ **userDataTypeToJSON**(`object`): `string`
+▸ **userDataTypeToJSON**(`object`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `object` | [`UserDataType`](../enums/protobufs.UserDataType.md) |
-
-#### Returns
-
-`string`

--- a/packages/js/docs/modules/utils.md
+++ b/packages/js/docs/modules/utils.md
@@ -46,7 +46,7 @@
 
 ### deserializeBlockHash
 
-▸ **deserializeBlockHash**(`bytes`): `HubResult`<`string`\>
+▸ **deserializeBlockHash**(`bytes`)
 
 Deserialize a block hash from a byte array to hex string.
 
@@ -56,15 +56,11 @@ Deserialize a block hash from a byte array to hex string.
 | :------ | :------ |
 | `bytes` | `Uint8Array` |
 
-#### Returns
-
-`HubResult`<`string`\>
-
 ___
 
 ### deserializeCastAddBody
 
-▸ **deserializeCastAddBody**(`protobuf`): `HubResult`<[`CastAddBody`](types.md#castaddbody)\>
+▸ **deserializeCastAddBody**(`protobuf`)
 
 #### Parameters
 
@@ -72,15 +68,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`CastAddBody`](protobufs.md#castaddbody) |
 
-#### Returns
-
-`HubResult`<[`CastAddBody`](types.md#castaddbody)\>
-
 ___
 
 ### deserializeCastId
 
-▸ **deserializeCastId**(`protobuf`): `HubResult`<[`CastId`](types.md#castid)\>
+▸ **deserializeCastId**(`protobuf`)
 
 #### Parameters
 
@@ -88,15 +80,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`CastId`](protobufs.md#castid) |
 
-#### Returns
-
-`HubResult`<[`CastId`](types.md#castid)\>
-
 ___
 
 ### deserializeCastRemoveBody
 
-▸ **deserializeCastRemoveBody**(`protobuf`): `HubResult`<[`CastRemoveBody`](types.md#castremovebody)\>
+▸ **deserializeCastRemoveBody**(`protobuf`)
 
 #### Parameters
 
@@ -104,15 +92,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`CastRemoveBody`](protobufs.md#castremovebody) |
 
-#### Returns
-
-`HubResult`<[`CastRemoveBody`](types.md#castremovebody)\>
-
 ___
 
 ### deserializeEd25519PublicKey
 
-▸ **deserializeEd25519PublicKey**(`publicKey`): `HubResult`<`string`\>
+▸ **deserializeEd25519PublicKey**(`publicKey`)
 
 #### Parameters
 
@@ -120,15 +104,11 @@ ___
 | :------ | :------ |
 | `publicKey` | `Uint8Array` |
 
-#### Returns
-
-`HubResult`<`string`\>
-
 ___
 
 ### deserializeEd25519Signature
 
-▸ **deserializeEd25519Signature**(`bytes`): `HubResult`<`string`\>
+▸ **deserializeEd25519Signature**(`bytes`)
 
 Deserialize an Ed25519 signature from a byte array to hex string.
 
@@ -138,15 +118,11 @@ Deserialize an Ed25519 signature from a byte array to hex string.
 | :------ | :------ |
 | `bytes` | `Uint8Array` |
 
-#### Returns
-
-`HubResult`<`string`\>
-
 ___
 
 ### deserializeEip712Signature
 
-▸ **deserializeEip712Signature**(`bytes`): `HubResult`<`string`\>
+▸ **deserializeEip712Signature**(`bytes`)
 
 Deserialize an EIP-712 signature from a byte array to hex string.
 
@@ -156,15 +132,11 @@ Deserialize an EIP-712 signature from a byte array to hex string.
 | :------ | :------ |
 | `bytes` | `Uint8Array` |
 
-#### Returns
-
-`HubResult`<`string`\>
-
 ___
 
 ### deserializeEthAddress
 
-▸ **deserializeEthAddress**(`ethAddress`): `HubResult`<`string`\>
+▸ **deserializeEthAddress**(`ethAddress`)
 
 #### Parameters
 
@@ -172,15 +144,11 @@ ___
 | :------ | :------ |
 | `ethAddress` | `Uint8Array` |
 
-#### Returns
-
-`HubResult`<`string`\>
-
 ___
 
 ### deserializeFname
 
-▸ **deserializeFname**(`fname`): `HubResult`<`string`\>
+▸ **deserializeFname**(`fname`)
 
 #### Parameters
 
@@ -188,15 +156,11 @@ ___
 | :------ | :------ |
 | `fname` | `Uint8Array` |
 
-#### Returns
-
-`HubResult`<`string`\>
-
 ___
 
 ### deserializeHubEvent
 
-▸ **deserializeHubEvent**(`protobuf`): `HubResult`<[`HubEvent`](types.md#hubevent)\>
+▸ **deserializeHubEvent**(`protobuf`)
 
 #### Parameters
 
@@ -204,15 +168,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`HubEvent`](protobufs.md#hubevent) |
 
-#### Returns
-
-`HubResult`<[`HubEvent`](types.md#hubevent)\>
-
 ___
 
 ### deserializeIdRegistryEvent
 
-▸ **deserializeIdRegistryEvent**(`protobuf`): `HubResult`<`Readonly`<{ `_protobuf`: [`IdRegistryEvent`](protobufs.md#idregistryevent) ; `blockHash`: `string` ; `blockNumber`: `number` ; `fid`: `number` ; `from`: `undefined` \| `string` ; `logIndex`: `number` ; `to`: `string` ; `transactionHash`: `string` ; `type`: [`IdRegistryEventType`](../enums/protobufs.IdRegistryEventType.md)  }\>\>
+▸ **deserializeIdRegistryEvent**(`protobuf`)
 
 #### Parameters
 
@@ -220,15 +180,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`IdRegistryEvent`](protobufs.md#idregistryevent) |
 
-#### Returns
-
-`HubResult`<`Readonly`<{ `_protobuf`: [`IdRegistryEvent`](protobufs.md#idregistryevent) ; `blockHash`: `string` ; `blockNumber`: `number` ; `fid`: `number` ; `from`: `undefined` \| `string` ; `logIndex`: `number` ; `to`: `string` ; `transactionHash`: `string` ; `type`: [`IdRegistryEventType`](../enums/protobufs.IdRegistryEventType.md)  }\>\>
-
 ___
 
 ### deserializeMessage
 
-▸ **deserializeMessage**(`protobuf`): `HubResult`<`Readonly`<{ `_protobuf`: [`Message`](protobufs.md#message) ; `data`: [`MessageData`](types.md#messagedata)<[`MessageBody`](types.md#messagebody), [`MessageType`](../enums/protobufs.MessageType.md)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
+▸ **deserializeMessage**(`protobuf`)
 
 #### Parameters
 
@@ -236,15 +192,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`Message`](protobufs.md#message) |
 
-#### Returns
-
-`HubResult`<`Readonly`<{ `_protobuf`: [`Message`](protobufs.md#message) ; `data`: [`MessageData`](types.md#messagedata)<[`MessageBody`](types.md#messagebody), [`MessageType`](../enums/protobufs.MessageType.md)\> ; `hash`: `string` ; `hashScheme`: [`HashScheme`](../enums/protobufs.HashScheme.md) ; `signature`: `string` ; `signatureScheme`: [`SignatureScheme`](../enums/protobufs.SignatureScheme.md) ; `signer`: `string`  }\>\>
-
 ___
 
 ### deserializeMessageData
 
-▸ **deserializeMessageData**(`protobuf`): `HubResult`<[`MessageData`](types.md#messagedata)<[`MessageBody`](types.md#messagebody), [`MessageType`](../enums/protobufs.MessageType.md)\>\>
+▸ **deserializeMessageData**(`protobuf`)
 
 #### Parameters
 
@@ -252,15 +204,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`MessageData`](protobufs.md#messagedata) |
 
-#### Returns
-
-`HubResult`<[`MessageData`](types.md#messagedata)<[`MessageBody`](types.md#messagebody), [`MessageType`](../enums/protobufs.MessageType.md)\>\>
-
 ___
 
 ### deserializeMessageHash
 
-▸ **deserializeMessageHash**(`bytes`): `HubResult`<`string`\>
+▸ **deserializeMessageHash**(`bytes`)
 
 Deserialize a message hash from a byte array to hex string.
 
@@ -270,15 +218,11 @@ Deserialize a message hash from a byte array to hex string.
 | :------ | :------ |
 | `bytes` | `Uint8Array` |
 
-#### Returns
-
-`HubResult`<`string`\>
-
 ___
 
 ### deserializeNameRegistryEvent
 
-▸ **deserializeNameRegistryEvent**(`protobuf`): `HubResult`<`Readonly`<{ `_protobuf`: [`NameRegistryEvent`](protobufs.md#nameregistryevent) ; `blockHash`: `string` ; `blockNumber`: `number` ; `expiry`: `undefined` \| `number` ; `fname`: `string` ; `from`: `string` ; `logIndex`: `number` ; `to`: `string` ; `transactionHash`: `string` ; `type`: [`NameRegistryEventType`](../enums/protobufs.NameRegistryEventType.md)  }\>\>
+▸ **deserializeNameRegistryEvent**(`protobuf`)
 
 #### Parameters
 
@@ -286,15 +230,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`NameRegistryEvent`](protobufs.md#nameregistryevent) |
 
-#### Returns
-
-`HubResult`<`Readonly`<{ `_protobuf`: [`NameRegistryEvent`](protobufs.md#nameregistryevent) ; `blockHash`: `string` ; `blockNumber`: `number` ; `expiry`: `undefined` \| `number` ; `fname`: `string` ; `from`: `string` ; `logIndex`: `number` ; `to`: `string` ; `transactionHash`: `string` ; `type`: [`NameRegistryEventType`](../enums/protobufs.NameRegistryEventType.md)  }\>\>
-
 ___
 
 ### deserializeReactionBody
 
-▸ **deserializeReactionBody**(`protobuf`): `HubResult`<[`ReactionBody`](types.md#reactionbody)\>
+▸ **deserializeReactionBody**(`protobuf`)
 
 #### Parameters
 
@@ -302,15 +242,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`ReactionBody`](protobufs.md#reactionbody) |
 
-#### Returns
-
-`HubResult`<[`ReactionBody`](types.md#reactionbody)\>
-
 ___
 
 ### deserializeSignerBody
 
-▸ **deserializeSignerBody**(`protobuf`): `HubResult`<[`SignerBody`](types.md#signerbody)\>
+▸ **deserializeSignerBody**(`protobuf`)
 
 #### Parameters
 
@@ -318,15 +254,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`SignerBody`](protobufs.md#signerbody) |
 
-#### Returns
-
-`HubResult`<[`SignerBody`](types.md#signerbody)\>
-
 ___
 
 ### deserializeTransactionHash
 
-▸ **deserializeTransactionHash**(`bytes`): `HubResult`<`string`\>
+▸ **deserializeTransactionHash**(`bytes`)
 
 Deserialize a transaction hash from a byte array to hex string.
 
@@ -336,15 +268,11 @@ Deserialize a transaction hash from a byte array to hex string.
 | :------ | :------ |
 | `bytes` | `Uint8Array` |
 
-#### Returns
-
-`HubResult`<`string`\>
-
 ___
 
 ### deserializeUserDataBody
 
-▸ **deserializeUserDataBody**(`protobuf`): `HubResult`<[`UserDataBody`](types.md#userdatabody)\>
+▸ **deserializeUserDataBody**(`protobuf`)
 
 #### Parameters
 
@@ -352,15 +280,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`UserDataBody`](protobufs.md#userdatabody) |
 
-#### Returns
-
-`HubResult`<[`UserDataBody`](types.md#userdatabody)\>
-
 ___
 
 ### deserializeVerificationAddEthAddressBody
 
-▸ **deserializeVerificationAddEthAddressBody**(`protobuf`): `HubResult`<[`VerificationAddEthAddressBody`](types.md#verificationaddethaddressbody)\>
+▸ **deserializeVerificationAddEthAddressBody**(`protobuf`)
 
 #### Parameters
 
@@ -368,15 +292,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`VerificationAddEthAddressBody`](protobufs.md#verificationaddethaddressbody) |
 
-#### Returns
-
-`HubResult`<[`VerificationAddEthAddressBody`](types.md#verificationaddethaddressbody)\>
-
 ___
 
 ### deserializeVerificationRemoveBody
 
-▸ **deserializeVerificationRemoveBody**(`protobuf`): `HubResult`<[`VerificationRemoveBody`](types.md#verificationremovebody)\>
+▸ **deserializeVerificationRemoveBody**(`protobuf`)
 
 #### Parameters
 
@@ -384,15 +304,11 @@ ___
 | :------ | :------ |
 | `protobuf` | [`VerificationRemoveBody`](protobufs.md#verificationremovebody) |
 
-#### Returns
-
-`HubResult`<[`VerificationRemoveBody`](types.md#verificationremovebody)\>
-
 ___
 
 ### serializeBlockHash
 
-▸ **serializeBlockHash**(`hash`): `HubResult`<`Uint8Array`\>
+▸ **serializeBlockHash**(`hash`)
 
 Serializes a block hash from a hex string to byte array.
 
@@ -402,15 +318,11 @@ Serializes a block hash from a hex string to byte array.
 | :------ | :------ |
 | `hash` | `string` |
 
-#### Returns
-
-`HubResult`<`Uint8Array`\>
-
 ___
 
 ### serializeCastAddBody
 
-▸ **serializeCastAddBody**(`body`): `HubResult`<[`CastAddBody`](protobufs.md#castaddbody)\>
+▸ **serializeCastAddBody**(`body`)
 
 #### Parameters
 
@@ -418,15 +330,11 @@ ___
 | :------ | :------ |
 | `body` | [`CastAddBody`](types.md#castaddbody) |
 
-#### Returns
-
-`HubResult`<[`CastAddBody`](protobufs.md#castaddbody)\>
-
 ___
 
 ### serializeCastId
 
-▸ **serializeCastId**(`castId`): `HubResult`<[`CastId`](protobufs.md#castid)\>
+▸ **serializeCastId**(`castId`)
 
 #### Parameters
 
@@ -434,15 +342,11 @@ ___
 | :------ | :------ |
 | `castId` | [`CastId`](types.md#castid) |
 
-#### Returns
-
-`HubResult`<[`CastId`](protobufs.md#castid)\>
-
 ___
 
 ### serializeCastRemoveBody
 
-▸ **serializeCastRemoveBody**(`body`): `HubResult`<[`CastRemoveBody`](protobufs.md#castremovebody)\>
+▸ **serializeCastRemoveBody**(`body`)
 
 #### Parameters
 
@@ -450,15 +354,11 @@ ___
 | :------ | :------ |
 | `body` | [`CastRemoveBody`](types.md#castremovebody) |
 
-#### Returns
-
-`HubResult`<[`CastRemoveBody`](protobufs.md#castremovebody)\>
-
 ___
 
 ### serializeEd25519PublicKey
 
-▸ **serializeEd25519PublicKey**(`publicKey`): `HubResult`<`Uint8Array`\>
+▸ **serializeEd25519PublicKey**(`publicKey`)
 
 #### Parameters
 
@@ -466,15 +366,11 @@ ___
 | :------ | :------ |
 | `publicKey` | `string` |
 
-#### Returns
-
-`HubResult`<`Uint8Array`\>
-
 ___
 
 ### serializeEip712Signature
 
-▸ **serializeEip712Signature**(`hash`): `HubResult`<`Uint8Array`\>
+▸ **serializeEip712Signature**(`hash`)
 
 Serializes an EIP-712 from a hex string to byte array.
 
@@ -484,15 +380,11 @@ Serializes an EIP-712 from a hex string to byte array.
 | :------ | :------ |
 | `hash` | `string` |
 
-#### Returns
-
-`HubResult`<`Uint8Array`\>
-
 ___
 
 ### serializeEthAddress
 
-▸ **serializeEthAddress**(`ethAddress`): `HubResult`<`Uint8Array`\>
+▸ **serializeEthAddress**(`ethAddress`)
 
 #### Parameters
 
@@ -500,15 +392,11 @@ ___
 | :------ | :------ |
 | `ethAddress` | `string` |
 
-#### Returns
-
-`HubResult`<`Uint8Array`\>
-
 ___
 
 ### serializeFname
 
-▸ **serializeFname**(`fname`): `HubResult`<`Uint8Array`\>
+▸ **serializeFname**(`fname`)
 
 #### Parameters
 
@@ -516,15 +404,11 @@ ___
 | :------ | :------ |
 | `fname` | `string` |
 
-#### Returns
-
-`HubResult`<`Uint8Array`\>
-
 ___
 
 ### serializeMessageHash
 
-▸ **serializeMessageHash**(`hash`): `HubResult`<`Uint8Array`\>
+▸ **serializeMessageHash**(`hash`)
 
 #### Parameters
 
@@ -532,15 +416,11 @@ ___
 | :------ | :------ |
 | `hash` | `string` |
 
-#### Returns
-
-`HubResult`<`Uint8Array`\>
-
 ___
 
 ### serializeReactionBody
 
-▸ **serializeReactionBody**(`body`): `HubResult`<[`ReactionBody`](protobufs.md#reactionbody)\>
+▸ **serializeReactionBody**(`body`)
 
 #### Parameters
 
@@ -548,15 +428,11 @@ ___
 | :------ | :------ |
 | `body` | [`ReactionBody`](types.md#reactionbody) |
 
-#### Returns
-
-`HubResult`<[`ReactionBody`](protobufs.md#reactionbody)\>
-
 ___
 
 ### serializeSignerBody
 
-▸ **serializeSignerBody**(`body`): `HubResult`<[`SignerBody`](protobufs.md#signerbody)\>
+▸ **serializeSignerBody**(`body`)
 
 #### Parameters
 
@@ -564,15 +440,11 @@ ___
 | :------ | :------ |
 | `body` | [`SignerBody`](types.md#signerbody) |
 
-#### Returns
-
-`HubResult`<[`SignerBody`](protobufs.md#signerbody)\>
-
 ___
 
 ### serializeUserDataBody
 
-▸ **serializeUserDataBody**(`body`): `HubResult`<[`UserDataBody`](protobufs.md#userdatabody)\>
+▸ **serializeUserDataBody**(`body`)
 
 #### Parameters
 
@@ -580,15 +452,11 @@ ___
 | :------ | :------ |
 | `body` | [`UserDataBody`](types.md#userdatabody) |
 
-#### Returns
-
-`HubResult`<[`UserDataBody`](protobufs.md#userdatabody)\>
-
 ___
 
 ### serializeVerificationAddEthAddressBody
 
-▸ **serializeVerificationAddEthAddressBody**(`body`): `HubResult`<[`VerificationAddEthAddressBody`](protobufs.md#verificationaddethaddressbody)\>
+▸ **serializeVerificationAddEthAddressBody**(`body`)
 
 #### Parameters
 
@@ -596,22 +464,14 @@ ___
 | :------ | :------ |
 | `body` | [`VerificationAddEthAddressBody`](types.md#verificationaddethaddressbody) |
 
-#### Returns
-
-`HubResult`<[`VerificationAddEthAddressBody`](protobufs.md#verificationaddethaddressbody)\>
-
 ___
 
 ### serializeVerificationRemoveBody
 
-▸ **serializeVerificationRemoveBody**(`body`): `HubResult`<[`VerificationRemoveBody`](protobufs.md#verificationremovebody)\>
+▸ **serializeVerificationRemoveBody**(`body`)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `body` | [`VerificationRemoveBody`](types.md#verificationremovebody) |
-
-#### Returns
-
-`HubResult`<[`VerificationRemoveBody`](protobufs.md#verificationremovebody)\>

--- a/packages/js/src/builders.ts
+++ b/packages/js/src/builders.ts
@@ -231,12 +231,12 @@ export const makeMessageWithSignature = async (
  *
  * #### Returns
  *
- * | Value                            | Type                                                | Description                                     |
- * | :------------------------------- | :-------------------------------------------------- | :---------------------------------------------- |
+ * | Value | Type | Description |
+ * | :---- | :--- | :---------- |
  * | `HubAsyncResult<CastAddMessage>` | [`CastAddMessage`](modules/types.md#castaddmessage) | A Result that contains the valid CastAddMessage |
  *
  * @param bodyJson - A valid CastAdd body object containing the data to be sent.
- * @param dataOptions - Optional arguments to construct the Cast.
+ * @param dataOptions - Optional arguments to construct the message.
  * @param signer - A valid Ed25519Signer that will sign the message.
  *
  * @example
@@ -280,13 +280,13 @@ export const makeCastAdd = buildMakeMessageMethod(
  *
  * #### Returns
  *
- * | Value                                | Type                                                | Description                                      |
- * | :----------------------------------- | :-------------------------------------------------- | :----------------------------------------------- |
+ * | Value | Type | Description |
+ * | :---- | :--- | :---------- |
  * | `HubAsyncResult<CastRemoveMessage>` | [`CastRemoveMessage`](modules/types.md#castremovemessage) | A `HubAsyncResult` that contains the valid `CastRemoveMessage`. |
  *
  *
  * @param bodyJson - A valid CastRemove body object containing the data to be sent.
- * @param dataOptions - Optional arguments to construct the Cast.
+ * @param dataOptions - Optional arguments to construct the message.
  * @param signer - A valid Ed25519Signer that will sign the message.
  *
  * @example
@@ -348,6 +348,16 @@ export const makeCastRemoveData = buildMakeMessageDataMethod(
 /**
  * Make a message to react a cast (like or recast)
  *
+ * #### Returns
+ *
+ * | Value | Type | Description |
+ * | :---- | :--- | :---------- |
+ * | `HubAsyncResult<ReactionAddMessage>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage) | A `HubAsyncResult` that contains the valid `ReactionAddMessage`. |
+ *
+ * @param bodyJson - A valid ReactionAdd body object containing the data to be sent.
+ * @param dataOptions - Optional arguments to construct the message.
+ * @param signer - A valid Ed25519Signer that will sign the message.
+ *
  * @example
  * ```typescript
  * import {
@@ -395,6 +405,16 @@ export const makeReactionAdd = buildMakeMessageMethod(
 
 /**
  * Make a message to undo a reaction to a cast (unlike or undo recast)
+ *
+ * #### Returns
+ *
+ * | Value | Type | Description |
+ * | :---- | :--- | :---------- |
+ * | `HubAsyncResult<ReactionRemoveMessage>` | [`ReactionRemoveMessage`](modules/types.md#reactionremovemessage) | A `HubAsyncResult` that contains the valid `ReactionRemoveMessage`. |
+ *
+ * @param bodyJson - A valid ReactionRemove body object containing the data to be sent.
+ * @param dataOptions - Optional arguments to construct the message.
+ * @param signer - A valid Ed25519Signer that will sign the message.
  *
  * @example
  * ```typescript
@@ -459,6 +479,16 @@ export const makeReactionRemoveData = buildMakeMessageDataMethod(
 
 /**
  * TODO DOCS
+ *
+ * #### Returns
+ *
+ * | Value | Type | Description |
+ * | :---- | :--- | :---------- |
+ * | `HubAsyncResult<VerificationAddMessage>` | [`VerificationAddMessage`](modules/types.md#verificationaddmessage) | A `HubAsyncResult` that contains the valid `VerificationAddMessage`. |
+ *
+ * @param bodyJson - A valid VerificationAdd body object containing the data to be sent.
+ * @param dataOptions - Optional arguments to construct the message.
+ * @param signer - A valid Ed25519Signer that will sign the message.
  *
  * @example
  * ```typescript
@@ -531,6 +561,16 @@ export const makeVerificationAddEthAddress = buildMakeMessageMethod(
 
 /**
  * TODO DOCS: description
+ *
+ * #### Returns
+ *
+ * | Value | Type | Description |
+ * | :---- | :--- | :---------- |
+ * | `HubAsyncResult<VerificationRemoveMessage>` | [`VerificationRemoveMessage`](modules/types.md#verificationremovemessage) | A `HubAsyncResult` that contains the valid `VerificationRemoveMessage`. |
+ *
+ * @param bodyJson - A valid VerificationRemove body object containing the data to be sent.
+ * @param dataOptions - Optional arguments to construct the message.
+ * @param signer - A valid Ed25519Signer that will sign the message.
  *
  * @example
  * ```typescript
@@ -611,6 +651,16 @@ export const makeVerificationRemoveData = buildMakeMessageDataMethod(
 /**
  * Make a message to add an EdDSA signer
  *
+ * #### Returns
+ *
+ * | Value | Type | Description |
+ * | :---- | :--- | :---------- |
+ * | `HubAsyncResult<VerificationAddEd25519Message>` | [`VerificationAddEd25519Message`](modules/types.md#verificationadded25519message) | A `HubAsyncResult` that contains the valid `VerificationAddEd25519Message`. |
+ *
+ * @param bodyJson - A valid VerificationAddEd25519 body object containing the data to be sent.
+ * @param dataOptions - Optional arguments to construct the message.
+ * @param signer - A valid Eip712Signer that will sign the message.
+ *
  * @example
  * ```typescript
  * import { Client, Ed25519Signer, Eip712Signer, makeSignerAdd, types } from '@farcaster/js';
@@ -655,6 +705,16 @@ export const makeSignerAdd = buildMakeMessageMethod(
 
 /**
  * Make a message to remove an EdDSA signer
+ *
+ * #### Returns
+ *
+ * | Value | Type | Description |
+ * | :---- | :--- | :---------- |
+ * | `HubAsyncResult<SignerRemoveMessage>` | [`SignerRemoveMessage`](modules/types.md#signerremovemessage) | A `HubAsyncResult` that contains the valid `SignerRemoveMessage`. |
+ *
+ * @param bodyJson - A valid SignerRemove body object containing the data to be sent.
+ * @param dataOptions - Optional arguments to construct the message.
+ * @param signer - A valid Eip712Signer that will sign the message.
  *
  * @example
  * ```typescript
@@ -716,6 +776,16 @@ export const makeSignerRemoveData = buildMakeMessageDataMethod(
 
 /**
  * Make a message to set user data (pfp, bio, display name, etc)
+ *
+ * #### Returns
+ *
+ * | Value | Type | Description |
+ * | :---- | :--- | :---------- |
+ * | `HubAsyncResult<UserDataMessage>` | [`UserDataMessage`](modules/types.md#userdatamessage) | A `HubAsyncResult` that contains the valid `UserDataMessage`. |
+ *
+ * @param bodyJson - A valid UserData body object containing the data to be sent.
+ * @param dataOptions - Optional arguments to construct the message.
+ * @param signer - A valid Eip712Signer that will sign the message.
  *
  * @example
  * ```typescript

--- a/packages/js/src/builders.ts
+++ b/packages/js/src/builders.ts
@@ -229,6 +229,16 @@ export const makeMessageWithSignature = async (
 /**
  * Make a message to add a cast
  *
+ * #### Returns
+ *
+ * | Value                            | Type          | Description                                     |
+ * | -------------------------------- | ------------- | ----------------------------------------------- |
+ * | `HubAsyncResult<CastAddMessage>` | `CastAddBody` | A Result that contains the valid CastAddMessage |
+ *
+ * @param bodyJson - The body of the message
+ * @param dataOptions - The data of the message
+ * @param signer - The signer of the message
+ *
  * @example
  * ```typescript
  * import {
@@ -258,9 +268,6 @@ export const makeMessageWithSignature = async (
  * await client.submitMessage(cast._unsafeUnwrap());
  * ```
  *
- * **`signature`**
- *
- * `makeCastAdd(bodyJson, dataOptions, signer): HubAsyncResult<CastAddMessage>`
  */
 export const makeCastAdd = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_CAST_ADD,

--- a/packages/js/src/builders.ts
+++ b/packages/js/src/builders.ts
@@ -318,10 +318,6 @@ export const makeCastAdd = buildMakeMessageMethod(
  * const castRemove = await makeCastRemove(removeBody, dataOptions, ed25519Signer);
  * await client.submitMessage(castRemove._unsafeUnwrap());
  * ```
- *
- * **`signature`**
- *
- * `makeCastRemove(bodyJson, dataOptions, signer): HubAsyncResult<CastRemoveMessage>`
  */
 export const makeCastRemove = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_CAST_REMOVE,
@@ -392,10 +388,6 @@ export const makeCastRemoveData = buildMakeMessageDataMethod(
  * const like = await makeReactionAdd(reactionLikeBody, dataOptions, ed25519Signer);
  * await client.submitMessage(like._unsafeUnwrap());
  * ```
- *
- * **`signature`**
- *
- * `makeReactCast(bodyJson, dataOptions, signer): HubAsyncResult<ReactionAddMessage>`
  */
 export const makeReactionAdd = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_REACTION_ADD,
@@ -450,10 +442,6 @@ export const makeReactionAdd = buildMakeMessageMethod(
  * const unlike = await makeReactionRemove(reactionLikeBody, dataOptions, ed25519Signer);
  * await client.submitMessage(unlike._unsafeUnwrap());
  * ```
- *
- * **`signature`**
- *
- * `makeReactionRemove(bodyJson, dataOptions, signer): HubAsyncResult<ReactionRemoveMessage>`
  */
 export const makeReactionRemove = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_REACTION_REMOVE,
@@ -484,7 +472,7 @@ export const makeReactionRemoveData = buildMakeMessageDataMethod(
  *
  * | Value | Type | Description |
  * | :---- | :--- | :---------- |
- * | `HubAsyncResult<VerificationAddMessage>` | [`VerificationAddMessage`](modules/types.md#verificationaddmessage) | A `HubAsyncResult` that contains the valid `VerificationAddMessage`. |
+ * | `HubAsyncResult<VerificationAddEthAddressMessage>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage) | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage`. |
  *
  * @param bodyJson - A valid VerificationAdd body object containing the data to be sent.
  * @param dataOptions - Optional arguments to construct the message.
@@ -548,10 +536,6 @@ export const makeReactionRemoveData = buildMakeMessageDataMethod(
  * );
  * await client.submitMessage(verificationMessage._unsafeUnwrap());
  * ```
- *
- * **`signature`**
- *
- * `makeVerificationAddEthAddress(bodyJson, dataOptions, signer): HubAsyncResult<VerificationAddEthAddressMessage>`
  */
 export const makeVerificationAddEthAddress = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS,
@@ -621,10 +605,6 @@ export const makeVerificationAddEthAddress = buildMakeMessageMethod(
  *
  * await client.submitMessage(verificationRemoveMessage._unsafeUnwrap());
  * ```
- *
- * **`signature`**
- *
- * `makeVerificationRemove(bodyJson, dataOptions, signer): HubAsyncResult<VerificationRemoveMessage>`
  */
 export const makeVerificationRemove = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_VERIFICATION_REMOVE,
@@ -693,10 +673,6 @@ export const makeVerificationRemoveData = buildMakeMessageDataMethod(
  * const signerAdd = await makeSignerAdd({ signer: ed25519Signer.signerKeyHex }, dataOptions, eip712Signer);
  * await client.submitMessage(signerAdd._unsafeUnwrap());
  * ```
- *
- * **`signature`**
- *
- * `makeSignerAdd(bodyJson, dataOptions, signer): HubAsyncResult<SignerAddMessage>`
  */
 export const makeSignerAdd = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_SIGNER_ADD,
@@ -748,10 +724,6 @@ export const makeSignerAdd = buildMakeMessageMethod(
  * const signerRemove = await makeSignerRemove({ signer: ed25519Signer.signerKeyHex }, dataOptions, eip712Signer);
  * await client.submitMessage(signerRemove._unsafeUnwrap());
  * ```
- *
- * **`signature`**
- *
- * `makeSignerRemove(bodyJson, dataOptions, signer): HubAsyncResult<SignerRemoveMessage>`
  */
 export const makeSignerRemove = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_SIGNER_REMOVE,
@@ -820,10 +792,6 @@ export const makeSignerRemoveData = buildMakeMessageDataMethod(
  * const userDataPfpAdd = await makeUserDataAdd(userDataPfpBody, dataOptions, ed25519Signer);
  * await client.submitMessage(userDataPfpAdd._unsafeUnwrap());
  * ```
- *
- * **`signature`**
- *
- * `makeUserData(bodyJson, dataOptions, signer): HubAsyncResult<UserDataAddMessage>`
  */
 export const makeUserDataAdd = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_USER_DATA_ADD,

--- a/packages/js/src/builders.ts
+++ b/packages/js/src/builders.ts
@@ -257,6 +257,10 @@ export const makeMessageWithSignature = async (
  * const cast = await makeCastAdd({ text: 'hello world' }, dataOptions, ed25519Signer);
  * await client.submitMessage(cast._unsafeUnwrap());
  * ```
+ *
+ * **`signature`**
+ *
+ * `makeCastAdd(bodyJson, dataOptions, signer): HubAsyncResult<CastAddMessage>`
  */
 export const makeCastAdd = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_CAST_ADD,
@@ -296,6 +300,10 @@ export const makeCastAdd = buildMakeMessageMethod(
  * const castRemove = await makeCastRemove(removeBody, dataOptions, ed25519Signer);
  * await client.submitMessage(castRemove._unsafeUnwrap());
  * ```
+ *
+ * **`signature`**
+ *
+ * `makeCastRemove(bodyJson, dataOptions, signer): HubAsyncResult<CastRemoveMessage>`
  */
 export const makeCastRemove = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_CAST_REMOVE,
@@ -356,6 +364,10 @@ export const makeCastRemoveData = buildMakeMessageDataMethod(
  * const like = await makeReactionAdd(reactionLikeBody, dataOptions, ed25519Signer);
  * await client.submitMessage(like._unsafeUnwrap());
  * ```
+ *
+ * **`signature`**
+ *
+ * `makeReactCast(bodyJson, dataOptions, signer): HubAsyncResult<ReactionAddMessage>`
  */
 export const makeReactionAdd = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_REACTION_ADD,
@@ -400,6 +412,10 @@ export const makeReactionAdd = buildMakeMessageMethod(
  * const unlike = await makeReactionRemove(reactionLikeBody, dataOptions, ed25519Signer);
  * await client.submitMessage(unlike._unsafeUnwrap());
  * ```
+ *
+ * **`signature`**
+ *
+ * `makeReactionRemove(bodyJson, dataOptions, signer): HubAsyncResult<ReactionRemoveMessage>`
  */
 export const makeReactionRemove = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_REACTION_REMOVE,
@@ -424,7 +440,7 @@ export const makeReactionRemoveData = buildMakeMessageDataMethod(
 /** Verification Methods */
 
 /**
- * TODO DOCS: description
+ * TODO DOCS
  *
  * @example
  * ```typescript
@@ -484,6 +500,10 @@ export const makeReactionRemoveData = buildMakeMessageDataMethod(
  * );
  * await client.submitMessage(verificationMessage._unsafeUnwrap());
  * ```
+ *
+ * **`signature`**
+ *
+ * `makeVerificationAddEthAddress(bodyJson, dataOptions, signer): HubAsyncResult<VerificationAddEthAddressMessage>`
  */
 export const makeVerificationAddEthAddress = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_VERIFICATION_ADD_ETH_ADDRESS,
@@ -543,6 +563,10 @@ export const makeVerificationAddEthAddress = buildMakeMessageMethod(
  *
  * await client.submitMessage(verificationRemoveMessage._unsafeUnwrap());
  * ```
+ *
+ * **`signature`**
+ *
+ * `makeVerificationRemove(bodyJson, dataOptions, signer): HubAsyncResult<VerificationRemoveMessage>`
  */
 export const makeVerificationRemove = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_VERIFICATION_REMOVE,
@@ -600,6 +624,10 @@ export const makeVerificationRemoveData = buildMakeMessageDataMethod(
  * const signerAdd = await makeSignerAdd({ signer: ed25519Signer.signerKeyHex }, dataOptions, eip712Signer);
  * await client.submitMessage(signerAdd._unsafeUnwrap());
  * ```
+ *
+ * **`signature`**
+ *
+ * `makeSignerAdd(bodyJson, dataOptions, signer): HubAsyncResult<SignerAddMessage>`
  */
 export const makeSignerAdd = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_SIGNER_ADD,
@@ -641,6 +669,10 @@ export const makeSignerAdd = buildMakeMessageMethod(
  * const signerRemove = await makeSignerRemove({ signer: ed25519Signer.signerKeyHex }, dataOptions, eip712Signer);
  * await client.submitMessage(signerRemove._unsafeUnwrap());
  * ```
+ *
+ * **`signature`**
+ *
+ * `makeSignerRemove(bodyJson, dataOptions, signer): HubAsyncResult<SignerRemoveMessage>`
  */
 export const makeSignerRemove = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_SIGNER_REMOVE,
@@ -699,6 +731,10 @@ export const makeSignerRemoveData = buildMakeMessageDataMethod(
  * const userDataPfpAdd = await makeUserDataAdd(userDataPfpBody, dataOptions, ed25519Signer);
  * await client.submitMessage(userDataPfpAdd._unsafeUnwrap());
  * ```
+ *
+ * **`signature`**
+ *
+ * `makeUserData(bodyJson, dataOptions, signer): HubAsyncResult<UserDataAddMessage>`
  */
 export const makeUserDataAdd = buildMakeMessageMethod(
   protobufs.MessageType.MESSAGE_TYPE_USER_DATA_ADD,

--- a/packages/js/src/builders.ts
+++ b/packages/js/src/builders.ts
@@ -231,13 +231,13 @@ export const makeMessageWithSignature = async (
  *
  * #### Returns
  *
- * | Value                            | Type          | Description                                     |
- * | -------------------------------- | ------------- | ----------------------------------------------- |
- * | `HubAsyncResult<CastAddMessage>` | `CastAddBody` | A Result that contains the valid CastAddMessage |
+ * | Value                            | Type                                          | Description                                     |
+ * | -------------------------------- | --------------------------------------------- | ----------------------------------------------- |
+ * | `HubAsyncResult<CastAddMessage>` | [`CastAddMessage`](modules/types.md#castaddmessage) | A Result that contains the valid CastAddMessage |
  *
- * @param bodyJson - The body of the message
- * @param dataOptions - The data of the message
- * @param signer - The signer of the message
+ * @param bodyJson - A valid CastAdd body object containing the data to be sent.
+ * @param dataOptions - Optional arguments to construct the Cast.
+ * @param signer - A valid Ed25519Signer that will sign the message.
  *
  * @example
  * ```typescript

--- a/packages/js/src/builders.ts
+++ b/packages/js/src/builders.ts
@@ -231,8 +231,8 @@ export const makeMessageWithSignature = async (
  *
  * #### Returns
  *
- * | Value                            | Type                                          | Description                                     |
- * | -------------------------------- | --------------------------------------------- | ----------------------------------------------- |
+ * | Value                            | Type                                                | Description                                     |
+ * | :------------------------------- | :-------------------------------------------------- | :---------------------------------------------- |
  * | `HubAsyncResult<CastAddMessage>` | [`CastAddMessage`](modules/types.md#castaddmessage) | A Result that contains the valid CastAddMessage |
  *
  * @param bodyJson - A valid CastAdd body object containing the data to be sent.
@@ -277,6 +277,17 @@ export const makeCastAdd = buildMakeMessageMethod(
 
 /**
  * Make a message to remove a cast
+ *
+ * #### Returns
+ *
+ * | Value                                | Type                                                | Description                                      |
+ * | :----------------------------------- | :-------------------------------------------------- | :----------------------------------------------- |
+ * | `HubAsyncResult<CastRemoveMessage>` | [`CastRemoveMessage`](modules/types.md#castremovemessage) | A `HubAsyncResult` that contains the valid `CastRemoveMessage`. |
+ *
+ *
+ * @param bodyJson - A valid CastRemove body object containing the data to be sent.
+ * @param dataOptions - Optional arguments to construct the Cast.
+ * @param signer - A valid Ed25519Signer that will sign the message.
  *
  * @example
  * ```typescript

--- a/packages/js/src/builders.ts
+++ b/packages/js/src/builders.ts
@@ -655,7 +655,8 @@ export const makeVerificationRemoveData = buildMakeMessageDataMethod(
  *
  * | Value | Type | Description |
  * | :---- | :--- | :---------- |
- * | `HubAsyncResult<VerificationAddEd25519Message>` | [`VerificationAddEd25519Message`](modules/types.md#verificationadded25519message) | A `HubAsyncResult` that contains the valid `VerificationAddEd25519Message`. |
+ * | `HubAsyncResult<VerificationAddEthAddressMessage>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage) | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage`. |
+ *
  *
  * @param bodyJson - A valid VerificationAddEd25519 body object containing the data to be sent.
  * @param dataOptions - Optional arguments to construct the message.
@@ -781,7 +782,7 @@ export const makeSignerRemoveData = buildMakeMessageDataMethod(
  *
  * | Value | Type | Description |
  * | :---- | :--- | :---------- |
- * | `HubAsyncResult<UserDataMessage>` | [`UserDataMessage`](modules/types.md#userdatamessage) | A `HubAsyncResult` that contains the valid `UserDataMessage`. |
+ * | `HubAsyncResult<UserDataAddMessage>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage) | A `HubAsyncResult` that contains the valid `UserDataMessage`. |
  *
  * @param bodyJson - A valid UserData body object containing the data to be sent.
  * @param dataOptions - Optional arguments to construct the message.

--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -391,7 +391,9 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<(VerificationAddEthAddressMessage | VerificationRemoveMessage)[]>` | [`VerificationAddEthAddressMessage`](../modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
+   * | `HubAsyncResult<(VerificationAddEthAddressMessage)[]>` | [`VerificationAddEthAddressMessage`](../modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` or `VerificationRemoveMessageMessage` array. |
+   * | OR | | |
+   * | `HubAsyncResult<(VerificationRemoveMessage)[]>` | [`VerificationRemoveMessage`](../modules/types.md#verificationremovemessage)[] | - |
    *
    * @param {number} fid - The fid to get all verifications for.
    *
@@ -460,9 +462,11 @@ export class Client {
    *
    * #### Returns
    *
-   * | Value | Type | Description |
-   * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<(SignerAddMessage | SignerRemoveMessage)[]>` | [`SignerAddMessage`](../modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
+   * | Value                                          | Type                                     | Description                                                               |
+   * | :--------------------------------------------- | :--------------------------------------- | :------------------------------------------------------------------------ |
+   * | `HubAsyncResult<(SignerAddMessage)>` | [`SignerAddMessage`](../modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` or `SignerRemoveMessage` array. |
+   * | OR                                           |                                         |                                                                          |
+   * | `HubAsyncResult<(SignerRemoveMessage)>` | [`SignerRemoveMessage`](../modules/types.md#signerremovemessage)[] | - |
    *
    * @param {number} fid - The fid to get all signers for.
    *
@@ -530,7 +534,9 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<(UserDataAddMessage | UserDataRemoveMessage)[]>` | [`UserDataAddMessage`](../modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
+   * | `HubAsyncResult<(UserDataAddMessage>` | [`UserDataAddMessage`](../modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` or `UserDataRemoveMessage` array. |
+   * | OR    |                                         |                                                                          |
+   * | `HubAsyncResult<(UserDataRemoveMessage>` | [`UserDataRemoveMessage`](../modules/types.md#userdataremovemessage)[] | - |
    *
    * @param {number} fid - The fid to get all user data for.
    *

--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -93,23 +93,21 @@ export class Client {
   /* -------------------------------------------------------------------------- */
 
   /**
-   * TODO DOCS: description
+   * Get a cast.
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<CastAddMessage>` | [`CastAddMessage`](modules/types.md#castaddmessage) | A `HubAsyncResult` that contains the valid `CastAddMessage`. |
+   *
+   * @param {number} fid - The fid from which the cast originates from.
+   * @param {string} hash - The hash of the cast.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getCast(fid: number, hash: string): HubAsyncResult<types.CastAddMessage> {
     const castId = utils.serializeCastId({ fid, hash });
@@ -121,23 +119,21 @@ export class Client {
   }
 
   /**
-   * TODO DOCS: description
+   * Get casts by fid.
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
+   *
+   * @param {number} fid - The fid from which the cast originates from.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
    *
-   * @param ...
-   *
-   * @returns ...
    */
   async getCastsByFid(fid: number): HubAsyncResult<types.CastAddMessage[]> {
     const fidRequest = protobufs.FidRequest.create({ fid });
@@ -145,23 +141,23 @@ export class Client {
   }
 
   /**
-   * TODO DOCS: description
+   * Get direct children of a cast.
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
+   *
+   * @param {CastId} parent - The parent cast id.
+   * @param {number} parent.fid - The fid from which the cast originates from.
+   * @param {string} parent.hash - The hash of the cast.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
    *
-   * @param ...
-   *
-   * @returns ...
    */
   async getCastsByParent(parent: types.CastId): HubAsyncResult<types.CastAddMessage[]> {
     const serializedCastId = utils.serializeCastId(parent);
@@ -175,21 +171,19 @@ export class Client {
   /**
    * TODO DOCS: description
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
+   *
+   * @param {number} mentionFid - The fid from which the cast originates from.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
    *
-   * @param ...
-   *
-   * @returns ...
    */
   async getCastsByMention(mentionFid: number): HubAsyncResult<types.CastAddMessage[]> {
     const fidRequest = protobufs.FidRequest.create({ fid: mentionFid });
@@ -199,21 +193,18 @@ export class Client {
   /**
    * TODO DOCS: description
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
+   *
+   * @param {number} fid - The fid from which the cast originates from.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getAllCastMessagesByFid(fid: number): HubAsyncResult<(types.CastAddMessage | types.CastRemoveMessage)[]> {
     const request = protobufs.FidRequest.create({ fid });
@@ -225,23 +216,24 @@ export class Client {
   /* -------------------------------------------------------------------------- */
 
   /**
-   * TODO DOCS: description
+   * Get reaction for a specific cast.
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<ReactionAddMessage>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage) | A `HubAsyncResult` that contains the valid `ReactionAddMessage`. |
+   *
+   * @param {number} fid - The fid from which the cast originates from.
+   * @param {ReactionType} type - The type of the reaction (like or recast).
+   * @param {CastId} cast - The cast id.
+   * @param {number} cast.fid - The fid from which the cast originates from.
+   * @param {string} cast.hash - The hash of the cast.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getReaction(
     fid: number,
@@ -262,23 +254,21 @@ export class Client {
   }
 
   /**
-   * TODO DOCS: description
+   * Get reactions from a specific fid.
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
+   *
+   * @param {number} fid - The fid from which the cast originates from.
+   * @param {ReactionType} type - The type of the reaction (like or recast).
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getReactionsByFid(fid: number, type?: types.ReactionType): HubAsyncResult<types.ReactionAddMessage[]> {
     const request = protobufs.ReactionsByFidRequest.create({
@@ -291,21 +281,21 @@ export class Client {
   /**
    * TODO DOCS: description
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
+   *
+   * @param {CastId} cast - The cast id.
+   * @param {number} cast.fid - The fid from which the cast originates from.
+   * @param {string} cast.hash - The hash of the cast.
+   * @param {ReactionType} type - The type of the reaction (like or recast).
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getReactionsByCast(cast: types.CastId, type?: types.ReactionType): HubAsyncResult<types.ReactionAddMessage[]> {
     const serializedCastId = utils.serializeCastId(cast);
@@ -322,21 +312,18 @@ export class Client {
   /**
    * TODO DOCS: description
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
+   *
+   * @param {number} fid - The fid from which the cast originates from.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getAllReactionMessagesByFid(
     fid: number
@@ -350,23 +337,22 @@ export class Client {
   /* -------------------------------------------------------------------------- */
 
   /**
-   * TODO DOCS: description
+   * Get verification for a specific address and fid.
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<VerificationAddEthAddressMessage>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage) | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage`. |
+   *
+   * @param {number} fid - The fid to verify.
+   * @param {string} address - The custody address to verify.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
    *
-   * @param ...
-   *
-   * @returns ...
    */
   async getVerification(fid: number, address: string): HubAsyncResult<types.VerificationAddEthAddressMessage> {
     const serializedAddress = utils.serializeEthAddress(address);
@@ -378,23 +364,20 @@ export class Client {
   }
 
   /**
-   * TODO DOCS: description
+   * Get verifications for a specific fid.
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<VerificationAddEthAddressMessage[]>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
+   *
+   * @param {number} fid - The fid to verify.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getVerificationsByFid(fid: number): HubAsyncResult<types.VerificationAddEthAddressMessage[]> {
     const request = protobufs.FidRequest.create({ fid });
@@ -402,23 +385,20 @@ export class Client {
   }
 
   /**
-   * TODO DOCS: description
+   * Get all verifications for a specific address.
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<(VerificationAddEthAddressMessage | VerificationRemoveMessage)[]>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
+   *
+   * @param {number} fid - The fid to get all verifications for.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getAllVerificationMessagesByFid(
     fid: number
@@ -434,21 +414,16 @@ export class Client {
   /**
    * TODO DOCS: description
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<SignerAddMessage>` | [`SignerAddMessage`](modules/types.md#signeraddmessage) | A `HubAsyncResult` that contains the valid `SignerAddMessage`. |
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getSigner(fid: number, signer: string): HubAsyncResult<types.SignerAddMessage> {
     const serializedSigner = utils.serializeEd25519PublicKey(signer);
@@ -460,23 +435,20 @@ export class Client {
   }
 
   /**
-   * TODO DOCS: description
+   * Get signers of a fid.
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<SignerAddMessage[]>` | [`SignerAddMessage`](modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
+   *
+   * @param {number} fid - The fid to get signers for.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getSignersByFid(fid: number): HubAsyncResult<types.SignerAddMessage[]> {
     const request = protobufs.FidRequest.create({ fid });
@@ -486,21 +458,18 @@ export class Client {
   /**
    * TODO DOCS: description
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<(SignerAddMessage | SignerRemoveMessage)[]>` | [`SignerAddMessage`](modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
+   *
+   * @param {number} fid - The fid to get all signers for.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getAllSignerMessagesByFid(fid: number): HubAsyncResult<(types.SignerAddMessage | types.SignerRemoveMessage)[]> {
     const request = protobufs.FidRequest.create({ fid });
@@ -512,23 +481,21 @@ export class Client {
   /* -------------------------------------------------------------------------- */
 
   /**
-   * TODO DOCS: description
+   * Get user data (pfp, username, fname, etc).
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<UserDataAddMessage>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage) | A `HubAsyncResult` that contains the valid `UserDataAddMessage`. |
+   *
+   * @param {number} fid - The fid to get user data for.
+   * @param {UserDataType} type - The type of user data to get.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getUserData(fid: number, type: types.UserDataType): HubAsyncResult<types.UserDataAddMessage> {
     const request = protobufs.UserDataRequest.create({ fid, userDataType: type });
@@ -536,23 +503,20 @@ export class Client {
   }
 
   /**
-   * TODO DOCS: description
+   * Get user data (pfp, username, fname, etc) by fid.
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<UserDataAddMessage[]>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
+   *
+   * @param {number} fid - The fid to get user data for.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getUserDataByFid(fid: number): HubAsyncResult<types.UserDataAddMessage[]> {
     const request = protobufs.FidRequest.create({ fid });
@@ -562,21 +526,18 @@ export class Client {
   /**
    * TODO DOCS: description
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<(UserDataAddMessage | UserDataRemoveMessage)[]>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
+   *
+   * @param {number} fid - The fid to get all user data for.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getAllUserDataMessagesByFid(fid: number): HubAsyncResult<types.UserDataAddMessage[]> {
     const request = protobufs.FidRequest.create({ fid });
@@ -588,23 +549,20 @@ export class Client {
   /* -------------------------------------------------------------------------- */
 
   /**
-   * TODO DOCS: description
+   * Get fid registry event for a specific fid.
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<IdRegistryEvent>` | [`IdRegistryEvent`](modules/types.md#idregistryevent) | A `HubAsyncResult` that contains the valid `IdRegistryEvent`. |
+   *
+   * @param {number} fid - The fid to get registry event for.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getIdRegistryEvent(fid: number): HubAsyncResult<types.IdRegistryEvent> {
     const request = protobufs.FidRequest.create({ fid });
@@ -612,23 +570,20 @@ export class Client {
   }
 
   /**
-   * TODO DOCS: description
+   * Get fname registry event for a specific fname.
    *
-   * TODO DOCS: usage example, here's the structure:
+   * #### Returns
+   *
+   * | Value | Type | Description |
+   * | :---- | :--- | :---------- |
+   * | `HubAsyncResult<NameRegistryEvent>` | [`NameRegistryEvent`](modules/types.md#nameregistryevent) | A `HubAsyncResult` that contains the valid `NameRegistryEvent`. |
+   *
+   * @param {string} fname - The fname to get registry event for.
+   *
    * @example
    * ```typescript
-   * import { ... } from '@farcaster/js';
-   *
-   * const client = new Client(...)
-   * const result = await client.get...
-   * console.log(result)
-   *
-   * // Output: ...
+   * // TODO DOCS: usage example
    * ```
-   *
-   * @param ...
-   *
-   * @returns ...
    */
   async getNameRegistryEvent(fname: string): HubAsyncResult<types.NameRegistryEvent> {
     const serializedFname = utils.serializeFname(fname);

--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -99,7 +99,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<CastAddMessage>` | [`CastAddMessage`](modules/types.md#castaddmessage) | A `HubAsyncResult` that contains the valid `CastAddMessage`. |
+   * | `HubAsyncResult<CastAddMessage>` | [`CastAddMessage`](../modules/types.md#castaddmessage) | A `HubAsyncResult` that contains the valid `CastAddMessage`. |
    *
    * @param {number} fid - The fid from which the cast originates from.
    * @param {string} hash - The hash of the cast.
@@ -125,7 +125,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
+   * | `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](../modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
    *
    * @param {number} fid - The fid from which the cast originates from.
    *
@@ -147,7 +147,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
+   * | `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](../modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
    *
    * @param {CastId} parent - The parent cast id.
    * @param {number} parent.fid - The fid from which the cast originates from.
@@ -175,7 +175,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
+   * | `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](../modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
    *
    * @param {number} mentionFid - The fid from which the cast originates from.
    *
@@ -197,7 +197,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
+   * | `HubAsyncResult<CastAddMessage[]>` | [`CastAddMessage`](../modules/types.md#castaddmessage)[] | A `HubAsyncResult` that contains the valid `CastAddMessage` array. |
    *
    * @param {number} fid - The fid from which the cast originates from.
    *
@@ -222,7 +222,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<ReactionAddMessage>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage) | A `HubAsyncResult` that contains the valid `ReactionAddMessage`. |
+   * | `HubAsyncResult<ReactionAddMessage>` | [`ReactionAddMessage`](../modules/types.md#reactionaddmessage) | A `HubAsyncResult` that contains the valid `ReactionAddMessage`. |
    *
    * @param {number} fid - The fid from which the cast originates from.
    * @param {ReactionType} type - The type of the reaction (like or recast).
@@ -260,7 +260,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
+   * | `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](../modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
    *
    * @param {number} fid - The fid from which the cast originates from.
    * @param {ReactionType} type - The type of the reaction (like or recast).
@@ -285,7 +285,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
+   * | `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](../modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
    *
    * @param {CastId} cast - The cast id.
    * @param {number} cast.fid - The fid from which the cast originates from.
@@ -316,7 +316,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
+   * | `HubAsyncResult<ReactionAddMessage[]>` | [`ReactionAddMessage`](../modules/types.md#reactionaddmessage)[] | A `HubAsyncResult` that contains the valid `ReactionAddMessage` array. |
    *
    * @param {number} fid - The fid from which the cast originates from.
    *
@@ -343,7 +343,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<VerificationAddEthAddressMessage>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage) | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage`. |
+   * | `HubAsyncResult<VerificationAddEthAddressMessage>` | [`VerificationAddEthAddressMessage`](../modules/types.md#verificationaddethaddressmessage) | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage`. |
    *
    * @param {number} fid - The fid to verify.
    * @param {string} address - The custody address to verify.
@@ -370,7 +370,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<VerificationAddEthAddressMessage[]>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
+   * | `HubAsyncResult<VerificationAddEthAddressMessage[]>` | [`VerificationAddEthAddressMessage`](../modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
    *
    * @param {number} fid - The fid to verify.
    *
@@ -391,7 +391,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<(VerificationAddEthAddressMessage | VerificationRemoveMessage)[]>` | [`VerificationAddEthAddressMessage`](modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
+   * | `HubAsyncResult<(VerificationAddEthAddressMessage | VerificationRemoveMessage)[]>` | [`VerificationAddEthAddressMessage`](../modules/types.md#verificationaddethaddressmessage)[] | A `HubAsyncResult` that contains the valid `VerificationAddEthAddressMessage` array. |
    *
    * @param {number} fid - The fid to get all verifications for.
    *
@@ -418,7 +418,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<SignerAddMessage>` | [`SignerAddMessage`](modules/types.md#signeraddmessage) | A `HubAsyncResult` that contains the valid `SignerAddMessage`. |
+   * | `HubAsyncResult<SignerAddMessage>` | [`SignerAddMessage`](../modules/types.md#signeraddmessage) | A `HubAsyncResult` that contains the valid `SignerAddMessage`. |
    *
    * @example
    * ```typescript
@@ -441,7 +441,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<SignerAddMessage[]>` | [`SignerAddMessage`](modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
+   * | `HubAsyncResult<SignerAddMessage[]>` | [`SignerAddMessage`](../modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
    *
    * @param {number} fid - The fid to get signers for.
    *
@@ -462,7 +462,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<(SignerAddMessage | SignerRemoveMessage)[]>` | [`SignerAddMessage`](modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
+   * | `HubAsyncResult<(SignerAddMessage | SignerRemoveMessage)[]>` | [`SignerAddMessage`](../modules/types.md#signeraddmessage)[] | A `HubAsyncResult` that contains the valid `SignerAddMessage` array. |
    *
    * @param {number} fid - The fid to get all signers for.
    *
@@ -487,7 +487,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<UserDataAddMessage>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage) | A `HubAsyncResult` that contains the valid `UserDataAddMessage`. |
+   * | `HubAsyncResult<UserDataAddMessage>` | [`UserDataAddMessage`](../modules/types.md#userdataaddmessage) | A `HubAsyncResult` that contains the valid `UserDataAddMessage`. |
    *
    * @param {number} fid - The fid to get user data for.
    * @param {UserDataType} type - The type of user data to get.
@@ -509,7 +509,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<UserDataAddMessage[]>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
+   * | `HubAsyncResult<UserDataAddMessage[]>` | [`UserDataAddMessage`](../modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
    *
    * @param {number} fid - The fid to get user data for.
    *
@@ -530,7 +530,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<(UserDataAddMessage | UserDataRemoveMessage)[]>` | [`UserDataAddMessage`](modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
+   * | `HubAsyncResult<(UserDataAddMessage | UserDataRemoveMessage)[]>` | [`UserDataAddMessage`](../modules/types.md#userdataaddmessage)[] | A `HubAsyncResult` that contains the valid `UserDataAddMessage` array. |
    *
    * @param {number} fid - The fid to get all user data for.
    *
@@ -555,7 +555,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<IdRegistryEvent>` | [`IdRegistryEvent`](modules/types.md#idregistryevent) | A `HubAsyncResult` that contains the valid `IdRegistryEvent`. |
+   * | `HubAsyncResult<IdRegistryEvent>` | [`IdRegistryEvent`](../modules/types.md#idregistryevent) | A `HubAsyncResult` that contains the valid `IdRegistryEvent`. |
    *
    * @param {number} fid - The fid to get registry event for.
    *
@@ -576,7 +576,7 @@ export class Client {
    *
    * | Value | Type | Description |
    * | :---- | :--- | :---------- |
-   * | `HubAsyncResult<NameRegistryEvent>` | [`NameRegistryEvent`](modules/types.md#nameregistryevent) | A `HubAsyncResult` that contains the valid `NameRegistryEvent`. |
+   * | `HubAsyncResult<NameRegistryEvent>` | [`NameRegistryEvent`](../modules/types.md#nameregistryevent) | A `HubAsyncResult` that contains the valid `NameRegistryEvent`. |
    *
    * @param {string} fname - The fname to get registry event for.
    *

--- a/packages/js/src/signers.ts
+++ b/packages/js/src/signers.ts
@@ -15,6 +15,15 @@ export class Eip712Signer extends BaseEip712Signer {
   /**
    * Creates an instance of Eip712Signer from a TypedDataSigner and an Ethereum address.
    *
+   * #### Returns
+   *
+   * | Value | Description |
+   * | :---- | :---------- |
+   * | `HubResult<Eip712Signer>` | A HubResult containing an Eip712Signer instance. |
+   *
+   * @param {TypedDataSigner} typedDataSigner - The TypedDataSigner instance to use for signing.
+   * @param {string} address - The Ethereum address associated with the signer.
+   *
    * @example
    * ```typescript
    * import { Eip712Signer } from '@farcaster/js';
@@ -23,12 +32,6 @@ export class Eip712Signer extends BaseEip712Signer {
    * const custodyWallet = ethers.Wallet.fromMnemonic('your mnemonic here apple orange banana');
    * const eip712Signer = Eip712Signer.fromSigner(custodyWallet, custodyWallet.address)._unsafeUnwrap();
    * ```
-   *
-   * @param {TypedDataSigner} typedDataSigner - The TypedDataSigner instance to use for signing.
-   * @param {string} address - The Ethereum address associated with the signer.
-   *
-   * @returns {HubResult<Eip712Signer>} A HubResult that resolves to an Eip712Signer instance on success, or
-   * a failure with an error message on error.
    */
   public static override fromSigner(typedDataSigner: TypedDataSigner, address: string): HubResult<Eip712Signer> {
     const signerKeyHex = address.toLowerCase();
@@ -37,6 +40,14 @@ export class Eip712Signer extends BaseEip712Signer {
 
   /**
    * Generates a 256-bit hex signature from an Ethereum address.
+   *
+   * #### Returns
+   *
+   * | Value | Description |
+   * | :---- | :---------- |
+   * | `HubAsyncResult<string>` | A HubAsyncResult containing the 256-bit signature as a hex string. |
+   *
+   * @param {string} hash - The 256-bit hash of the message to be signed.
    *
    * @example
    * ```typescript
@@ -55,9 +66,6 @@ export class Eip712Signer extends BaseEip712Signer {
    * // Output: "0xa620471a24cd101b99b7f69efcd9fe2437715924b..."
    * ```
    *
-   * @param {string} hash - The 256-bit hash of the message to be signed.
-   *
-   * @returns {Promise<HubAsyncResult<string>>} A HubAsyncResult containing the 256-bit signature as a hex string.
    */
   async signMessageHashHex(hash: string): HubAsyncResult<string> {
     const hashBytes = hexStringToBytes(hash);
@@ -72,6 +80,18 @@ export class Eip712Signer extends BaseEip712Signer {
 
   /**
    * Signs an Ethereum address verification claim, returns hex.
+   *
+   * #### Returns
+   *
+   * | Value | Description |
+   * | :---- | :---------- |
+   * | `HubAsyncResult<string>` | A HubAsyncResult containing the 256-bit signature as a hex string. |
+   *
+   * @param {Object} claim - The body of the claim to be signed as an object
+   * @param {number} claim.fid - The fid of the claim.
+   * @param {string} claim.address - The Ethereum address to be verified.
+   * @param {types.FarcasterNetwork} claim.network - The network to be used for verification.
+   * @param {string} claim.blockHash - The block hash to be used for verification.
    *
    * @example
    * ```typescript
@@ -93,14 +113,6 @@ export class Eip712Signer extends BaseEip712Signer {
    *
    * // Output: "0xa620471a24cd101b99b7f69efcd9fe2437715924b..."
    * ```
-   *
-   * @param {Object} claim - The body of the claim to be signed as an object
-   * @param {number} claim.fid - The fid of the claim.
-   * @param {string} claim.address - The Ethereum address to be verified.
-   * @param {types.FarcasterNetwork} claim.network - The network to be used for verification.
-   * @param {string} claim.blockHash - The block hash to be used for verification.
-   *
-   * @returns {Promise<HubAsyncResult<Uint8Array>>} A HubAsyncResult containing the 256-bit signature as a Uint8Array.
    */
   async signVerificationEthAddressClaimHex(claim: VerificationEthAddressClaim): HubAsyncResult<string> {
     const signatureBytes = await this.signVerificationEthAddressClaim(claim);
@@ -112,6 +124,14 @@ export class Ed25519Signer extends BaseEd25519Signer {
   /**
    * Creates an Ed25519 signer from a private key.
    *
+   * #### Returns
+   *
+   * | Value | Description |
+   * | :---- | :---------- |
+   * | `HubResult<Ed25519Signer>` | A HubResult containing an Ed25519Signer instance |
+   *
+   * @param {Uint8Array} privateKey - The 32-byte private key to use for signing.
+   *
    * @example
    * ```typescript
    * import { Ed25519Signer } from '@farcaster/js';
@@ -120,10 +140,6 @@ export class Ed25519Signer extends BaseEd25519Signer {
    * const privateKeyBytes = ed.utils.randomPrivateKey();
    * const signer = Ed25519Signer.fromPrivateKey(privateKeyBytes)._unsafeUnwrap();
    * ```
-   *
-   * @param {Uint8Array} privateKey - The 32-byte private key to use for signing.
-   *
-   * @returns {HubResult<Ed25519Signer>} A HubResult containing an Ed25519Signer instance on success, or an error message on failure.
    */
   public static override fromPrivateKey(privateKey: Uint8Array): HubResult<Ed25519Signer> {
     const signerKey = ed25519.getPublicKeySync(privateKey);
@@ -134,6 +150,14 @@ export class Ed25519Signer extends BaseEd25519Signer {
 
   /**
    * Generates a 256-bit hex signature from an EdDSA key pair for a given message hash in hex format.
+   *
+   * #### Returns
+   *
+   * | Value | Description |
+   * | :---- | :---------- |
+   * | `HubAsyncResult<string>` | A HubAsyncResult containing the 256-bit signature as a hex string. |
+   *
+   * @param {string} hash - The hash of the message to be signed in hex format.
    *
    * @example
    * ```typescript
@@ -151,10 +175,6 @@ export class Ed25519Signer extends BaseEd25519Signer {
    *
    * console.log(signature._unsafeUnwrap()); // 0x9f1c7e13b9d0b8...
    * ```
-   *
-   * @param {string} hash - The hash of the message to be signed in hex format.
-   *
-   * @returns {Promise<HubAsyncResult<string>>} A HubAsyncResult containing the signature in hex format.
    *
    */
   async signMessageHashHex(hash: string): HubAsyncResult<string> {

--- a/packages/utils/src/signers/ed25519Signer.ts
+++ b/packages/utils/src/signers/ed25519Signer.ts
@@ -32,6 +32,14 @@ export class Ed25519Signer implements Signer {
   /**
    * Generates a 256-bit signature using from EdDSA key pair.
    *
+   * #### Returns
+   *
+   * | Value | Description |
+   * | :---- | :---------- |
+   * | `HubAsyncResult<Uint8Array>` | A HubAsyncResult containing the 256-bit signature as a Uint8Array. |
+   *
+   * @param {Uint8Array} hash - The 256-bit hash of the message to be signed.
+   *
    * @example
    * ```typescript
    * import { Ed25519Signer } from '@farcaster/js';
@@ -48,11 +56,6 @@ export class Ed25519Signer implements Signer {
    *
    * console.log(signature._unsafeUnwrap());
    * ```
-   *
-   * @param {Uint8Array} hash - The 256-bit hash of the message to be signed.
-   *
-   * @returns {Promise<HubAsyncResult<Uint8Array>>} A HubAsyncResult containing the signature as a Uint8Array.
-   *
    */
   public async signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array> {
     return ed25519.signMessageHash(hash, this._privateKey);

--- a/packages/utils/src/signers/eip712Signer.ts
+++ b/packages/utils/src/signers/eip712Signer.ts
@@ -37,6 +37,14 @@ export class Eip712Signer implements Signer {
   /**
    * Generates a 256-bit signature from an Ethereum address.
    *
+   * #### Returns
+   *
+   * | Value | Description |
+   * | :---- | :---------- |
+   * | `HubAsyncResult<Uint8Array>` | A HubAsyncResult containing the 256-bit signature as a Uint8Array. |
+   *
+   * @param {Uint8Array} hash - The 256-bit hash of the message to be signed.
+   *
    * @example
    * ```typescript
    * import { Eip712Signer } from '@farcaster/js';
@@ -55,10 +63,6 @@ export class Eip712Signer implements Signer {
    *
    * // Output: Uint8Array(65) [ 166, 32, 71, 26, 36, 205, ... ]
    * ```
-   *
-   * @param {Uint8Array} hash - The 256-bit hash of the message to be signed.
-   *
-   * @returns {Promise<HubAsyncResult<Uint8Array>>} A HubAsyncResult containing the 256-bit signature as a Uint8Array.
    */
   public signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array> {
     return eip712.signMessageHash(hash, this._typedDataSigner);
@@ -66,6 +70,20 @@ export class Eip712Signer implements Signer {
 
   /**
    * Signs a verification claim for an Ethereum address.
+   *
+   * #### Returns
+   *
+   * | Value | Description |
+   * | :---- | :---------- |
+   * | `HubAsyncResult<Uint8Array>` | A HubAsyncResult containing the 256-bit signature as a Uint8Array. |
+   *
+   *
+   * @param {Object} claim - The body of the claim to be signed.
+   * @param {number} claim.fid - The Farcaster ID.
+   * @param {string} claim.address - The Ethereum address to verify.
+   * @param {types.FarcasterNetwork} claim.network - The Farcaster network to use.
+   * @param {string} claim.blockHash - The hash of the Ethereum block to use for verification.
+   *
    *
    * @example
    * ```typescript
@@ -80,14 +98,6 @@ export class Eip712Signer implements Signer {
    *
    * // Will output: Uint8Array(65) [ 166, 32, 71, 26, 36, 205, ... ]
    * ```
-   *
-   * @param {Object} claim - The body of the claim to be signed.
-   * @param {number} claim.fid - The Farcaster ID.
-   * @param {string} claim.address - The Ethereum address to verify.
-   * @param {types.FarcasterNetwork} claim.network - The Farcaster network to use.
-   * @param {string} claim.blockHash - The hash of the Ethereum block to use for verification.
-   *
-   * @returns {HubAsyncResult<Uint8Array>} A HubAsyncResult containing the 256-bit signature as a Uint8Array.
    */
   public signVerificationEthAddressClaim(claim: VerificationEthAddressClaim): HubAsyncResult<Uint8Array> {
     return eip712.signVerificationEthAddressClaim(claim, this._typedDataSigner);

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,7 +2,7 @@
   "entryPoints": ["./packages/js/src/index.ts"],
   "out": "./packages/js/docs",
   "exclude": ["**/*.test.ts", "**/*.spec.ts", "**/node_modules/**"],
-  "plugin": ["typedoc-plugin-markdown"],
+  "plugin": ["typedoc-plugin-markdown", "./hideSig.js"],
   "skipErrorChecking": true,
   "disableSources": true
 }


### PR DESCRIPTION
## Motivation

#614. Current iteration: https://github.com/vinliao/hubble/blob/md-docs-hide-sig-2/packages/js/docs/modules.md#functions.

## Change Summary

Remove the types in docs by adding a `hideSig.js` TypeDoc plugin and using it.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
