### PR TITLE
feat: add ability to change contract configuration via cli

### DIFF
--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -29,7 +29,13 @@ app
   .description('Start a Hub')
   .option('-e, --eth-rpc-url <url>', 'RPC URL of a Goerli Ethereum Node')
   .option('-c, --config <filepath>', 'Path to a config file with options', DEFAULT_CONFIG_FILE)
-  .option('-f, --fir-address <address>', 'The address of the FIR contract')
+  .option('--fir-address <address>', 'The address of the Farcaster ID Registry contract')
+  .option('--fnr-address <address>', 'The address of the Farcaster Name Registry contract')
+  .option('--first-block <number>', 'The block number to begin syncing events from Farcaster contracts')
+  .option(
+    '--chunk-size <number>',
+    'The number of blocks to batch when syncing historical events from Farcaster contracts'
+  )
   .option('-b, --bootstrap <peer-multiaddrs...>', 'A list of peer multiaddrs to bootstrap libp2p')
   .option('-a, --allowed-peers <peerIds...>', 'An allow-list of peer ids permitted to connect to the hub')
   .option('--ip <ip-address>', 'The IP address libp2p should listen on. (default: "127.0.0.1")')
@@ -110,7 +116,10 @@ app
       gossipPort: hubAddressInfo.value.port,
       network: cliOptions.network ?? hubConfig.network,
       ethRpcUrl: cliOptions.ethRpcUrl ?? hubConfig.ethRpcUrl,
-      IdRegistryAddress: cliOptions.firAddress ?? hubConfig.firAddress,
+      idRegistryAddress: cliOptions.firAddress ?? hubConfig.firAddress,
+      nameRegistryAddress: cliOptions.fnrAddress ?? hubConfig.fnrAddress,
+      firstBlock: cliOptions.firstBlock ?? hubConfig.firstBlock,
+      chunkSize: cliOptions.chunkSize ?? hubConfig.chunkSize,
       bootstrapAddrs,
       allowedPeers: cliOptions.allowedPeers ?? hubConfig.allowedPeers,
       rpcPort: cliOptions.rpcPort ?? hubConfig.rpcPort,

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -20,7 +20,7 @@ const PEER_ID_FILENAME = 'id.protobuf';
 const DEFAULT_PEER_ID_DIR = './.hub';
 const DEFAULT_PEER_ID_FILENAME = `default_${PEER_ID_FILENAME}`;
 const DEFAULT_PEER_ID_LOCATION = `${DEFAULT_PEER_ID_DIR}/${DEFAULT_PEER_ID_FILENAME}`;
-const DEFAULT_CHUNK_SIZE = '10000';
+const DEFAULT_CHUNK_SIZE = 10000;
 
 const app = new Command();
 app.name('hub').description('Farcaster Hub').version(APP_VERSION);
@@ -35,8 +35,7 @@ app
   .option('--first-block <number>', 'The block number to begin syncing events from Farcaster contracts')
   .option(
     '--chunk-size <number>',
-    'The number of blocks to batch when syncing historical events from Farcaster contracts. (default: 10000)',
-    DEFAULT_CHUNK_SIZE
+    'The number of blocks to batch when syncing historical events from Farcaster contracts. (default: 10000)'
   )
   .option('-b, --bootstrap <peer-multiaddrs...>', 'A list of peer multiaddrs to bootstrap libp2p')
   .option('-a, --allowed-peers <peerIds...>', 'An allow-list of peer ids permitted to connect to the hub')

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -20,6 +20,7 @@ const PEER_ID_FILENAME = 'id.protobuf';
 const DEFAULT_PEER_ID_DIR = './.hub';
 const DEFAULT_PEER_ID_FILENAME = `default_${PEER_ID_FILENAME}`;
 const DEFAULT_PEER_ID_LOCATION = `${DEFAULT_PEER_ID_DIR}/${DEFAULT_PEER_ID_FILENAME}`;
+const DEFAULT_CHUNK_SIZE = '10000';
 
 const app = new Command();
 app.name('hub').description('Farcaster Hub').version(APP_VERSION);
@@ -34,7 +35,8 @@ app
   .option('--first-block <number>', 'The block number to begin syncing events from Farcaster contracts')
   .option(
     '--chunk-size <number>',
-    'The number of blocks to batch when syncing historical events from Farcaster contracts'
+    'The number of blocks to batch when syncing historical events from Farcaster contracts. (default: 10000)',
+    DEFAULT_CHUNK_SIZE
   )
   .option('-b, --bootstrap <peer-multiaddrs...>', 'A list of peer multiaddrs to bootstrap libp2p')
   .option('-a, --allowed-peers <peerIds...>', 'An allow-list of peer ids permitted to connect to the hub')
@@ -119,7 +121,7 @@ app
       idRegistryAddress: cliOptions.firAddress ?? hubConfig.firAddress,
       nameRegistryAddress: cliOptions.fnrAddress ?? hubConfig.fnrAddress,
       firstBlock: cliOptions.firstBlock ?? hubConfig.firstBlock,
-      chunkSize: cliOptions.chunkSize ?? hubConfig.chunkSize,
+      chunkSize: cliOptions.chunkSize ?? hubConfig.chunkSize ?? DEFAULT_CHUNK_SIZE,
       bootstrapAddrs,
       allowedPeers: cliOptions.allowedPeers ?? hubConfig.allowedPeers,
       rpcPort: cliOptions.rpcPort ?? hubConfig.rpcPort,

--- a/apps/hubble/src/eth/ethEventsProvider.test.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.test.ts
@@ -80,7 +80,7 @@ beforeAll(async () => {
 
 describe('process events', () => {
   beforeEach(async () => {
-    ethEventsProvider = new EthEventsProvider(hub, mockRPCProvider, mockIdRegistry, mockNameRegistry);
+    ethEventsProvider = new EthEventsProvider(hub, mockRPCProvider, mockIdRegistry, mockNameRegistry, 1, 10000);
     mockRPCProvider.polling = true;
     await ethEventsProvider.start();
   });

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -92,7 +92,16 @@ export interface HubOptions {
   ethRpcUrl?: string;
 
   /** Address of the IdRegistry contract  */
-  IdRegistryAddress?: string;
+  idRegistryAddress?: string;
+
+  /** Address of the NameRegistryAddress contract  */
+  nameRegistryAddress?: string;
+
+  /** Block number to begin syncing events from  */
+  firstBlock?: number;
+
+  /** Number of blocks to batch when syncing historical events  */
+  chunkSize?: number;
 
   /** Name of the RocksDB instance */
   rocksDBName?: string;
@@ -156,11 +165,14 @@ export class Hub implements HubInterface {
     this.adminServer = new AdminServer(this, this.rocksDB, this.engine, this.syncEngine);
 
     // Create the ETH registry provider, which will fetch ETH events and push them into the engine.
-    this.ethRegistryProvider = EthEventsProvider.makeWithGoerli(
+    // Defaults to Goerli testnet, which is currently used for Production Farcaster Hubs.
+    this.ethRegistryProvider = EthEventsProvider.build(
       this,
       options.ethRpcUrl ?? '',
-      GoerliEthConstants.IdRegistryAddress,
-      GoerliEthConstants.NameRegistryAddress
+      options.idRegistryAddress ?? GoerliEthConstants.IdRegistryAddress,
+      options.nameRegistryAddress ?? GoerliEthConstants.NameRegistryAddress,
+      options.firstBlock ?? GoerliEthConstants.FirstBlock,
+      options.chunkSize ?? GoerliEthConstants.ChunkSize
     );
 
     // Setup job queues


### PR DESCRIPTION
## Motivation

Exposing this will allow developers to create fully isolated testing environments if they wish to run a hub against a local/private Ethereum node (resolves #622). 

## Change Summary

Expose all of `GoerliEthConstants` as CLI options.
https://github.com/farcasterxyz/hubble/blob/a237a6554a12d8822e74271d943169a355efdb8f/apps/hubble/src/eth/ethEventsProvider.ts#L14-L19

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] (N/A) Changes to the protocol specification have been merged

## Additional Context

In the future, I think it will be worth adding an abi override option for testing changes to `farcasterxyz/contracts`. This feels less important in the current state as I imagine the vast majority of cases using this feature will be to reproduce production.
