### PR TITLE
feat: Add RPC Auth and SSL support

### DIFF
--- a/apps/hubble/.config/hub.config.ts
+++ b/apps/hubble/.config/hub.config.ts
@@ -31,6 +31,8 @@ export const Config = {
   gossipPort: DEFAULT_GOSSIP_PORT,
   /** The RPC port to use. */
   rpcPort: DEFAULT_RPC_PORT,
+  /** RPC Auth, disabled by default */
+  // rpcAuth: 'admin:password',
   /** The name of the RocksDB instance */
   dbName: 'rocks.hub._default',
   /** Clear the RocksDB instance before starting */

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -39,6 +39,10 @@ app
   )
   .option('-g, --gossip-port <port>', 'The tcp port libp2p should gossip over. (default: 13111)')
   .option('-r, --rpc-port <port>', 'The tcp port that the rpc server should listen on.  (default: 13112)')
+  .option(
+    '--rpc-auth <username:password>',
+    'Enable Auth for RPC submit methods with the username and password. (default: disabled)'
+  )
   .option('--db-name <name>', 'The name of the RocksDB instance')
   .option('--db-reset', 'Clears the database before starting')
   .option('--rebuild-sync-trie', 'Rebuilds the sync trie before starting')
@@ -114,6 +118,7 @@ app
       bootstrapAddrs,
       allowedPeers: cliOptions.allowedPeers ?? hubConfig.allowedPeers,
       rpcPort: cliOptions.rpcPort ?? hubConfig.rpcPort,
+      rpcAuth: cliOptions.rpcAuth ?? hubConfig.rpcAuth,
       rocksDBName: cliOptions.dbName ?? hubConfig.dbName,
       resetDB: cliOptions.dbReset ?? hubConfig.dbReset,
       rebuildSyncTrie,

--- a/apps/hubble/src/console/console.ts
+++ b/apps/hubble/src/console/console.ts
@@ -41,7 +41,7 @@ export const startConsole = async (addressString: string) => {
     }
   });
 
-  const rpcClient = getHubRpcClient(addressString);
+  const rpcClient = await getHubRpcClient(addressString);
   const adminClient = protobufs.getAdminClient(getAdminSocket());
 
   const commands: ConsoleCommandInterface[] = [

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -88,6 +88,9 @@ export interface HubOptions {
   /** Port for the RPC Client */
   rpcPort?: number;
 
+  /** Username and Password to use for RPC submit methods */
+  rpcAuth?: string;
+
   /** Network URL of the IdRegistry Contract */
   ethRpcUrl?: string;
 
@@ -152,7 +155,7 @@ export class Hub implements HubInterface {
     this.engine = new Engine(this.rocksDB, options.network);
     this.syncEngine = new SyncEngine(this.engine, this.rocksDB);
 
-    this.rpcServer = new Server(this, this.engine, this.syncEngine, this.gossipNode);
+    this.rpcServer = new Server(this, this.engine, this.syncEngine, this.gossipNode, options.rpcAuth);
     this.adminServer = new AdminServer(this, this.rocksDB, this.engine, this.syncEngine);
 
     // Create the ETH registry provider, which will fetch ETH events and push them into the engine.
@@ -431,7 +434,7 @@ export class Hub implements HubInterface {
     }
 
     if (isIP(rpcAddressInfo.value.address)) {
-      return getHubRpcClient(`${rpcAddressInfo.value.address}:${rpcAddressInfo.value.port}`);
+      return await getHubRpcClient(`${rpcAddressInfo.value.address}:${rpcAddressInfo.value.port}`);
     }
 
     log.info({ peerId }, 'falling back to addressbook lookup for peer');
@@ -458,7 +461,7 @@ export class Hub implements HubInterface {
       port: rpcAddressInfo.value.port,
     };
 
-    return getHubRpcClient(addressInfoToString(ai));
+    return await getHubRpcClient(addressInfoToString(ai));
   }
 
   private registerEventHandlers() {

--- a/apps/hubble/src/network/p2p/gossipNode.test.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.test.ts
@@ -1,5 +1,5 @@
 import * as protobufs from '@farcaster/protobufs';
-import { Factories, getHubRpcClient, HubRpcClient } from '@farcaster/utils';
+import { Factories, getInsecureHubRpcClient, HubRpcClient } from '@farcaster/utils';
 import { multiaddr } from '@multiformats/multiaddr/';
 import { GossipNode } from '~/network/p2p/gossipNode';
 import Server from '~/rpc/server';
@@ -124,7 +124,7 @@ describe('GossipNode', () => {
       const syncEngine = new SyncEngine(engine, db);
       server = new Server(hub, engine, syncEngine, mockGossipNode);
       const port = await server.start();
-      client = getHubRpcClient(`127.0.0.1:${port}`);
+      client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 
       await client.submitIdRegistryEvent(custodyEvent);
 

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -1,5 +1,5 @@
 import * as protobufs from '@farcaster/protobufs';
-import { Ed25519Signer, Factories, getHubRpcClient, HubRpcClient } from '@farcaster/utils';
+import { Ed25519Signer, Factories, getInsecureHubRpcClient, HubRpcClient } from '@farcaster/utils';
 import { APP_NICKNAME, APP_VERSION } from '~/hubble';
 import SyncEngine from '~/network/sync/syncEngine';
 import { SyncId } from '~/network/sync/syncId';
@@ -88,7 +88,7 @@ describe('Multi peer sync engine', () => {
     syncEngine1.initialize();
     server1 = new Server(hub1, engine1, syncEngine1);
     port1 = await server1.start();
-    clientForServer1 = getHubRpcClient(`127.0.0.1:${port1}`);
+    clientForServer1 = getInsecureHubRpcClient(`127.0.0.1:${port1}`);
   });
 
   afterEach(async () => {
@@ -238,7 +238,7 @@ describe('Multi peer sync engine', () => {
     {
       const server2 = new Server(new MockHub(testDb2, engine2), engine2, syncEngine2);
       const port2 = await server2.start();
-      const clientForServer2 = getHubRpcClient(`127.0.0.1:${port2}`);
+      const clientForServer2 = getInsecureHubRpcClient(`127.0.0.1:${port2}`);
       const engine1RootHashBefore = await syncEngine1.trie.rootHash();
 
       await syncEngine1.performSync((await syncEngine2.getSnapshot())._unsafeUnwrap(), clientForServer2);

--- a/apps/hubble/src/rpc/server/test/bulkService.test.ts
+++ b/apps/hubble/src/rpc/server/test/bulkService.test.ts
@@ -1,5 +1,5 @@
 import * as protobufs from '@farcaster/protobufs';
-import { Factories, getHubRpcClient, HubResult, HubRpcClient } from '@farcaster/utils';
+import { Factories, getInsecureHubRpcClient, HubResult, HubRpcClient } from '@farcaster/utils';
 import SyncEngine from '~/network/sync/syncEngine';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -17,7 +17,7 @@ let client: HubRpcClient;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
-  client = getHubRpcClient(`127.0.0.1:${port}`);
+  client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/apps/hubble/src/rpc/server/test/castService.test.ts
+++ b/apps/hubble/src/rpc/server/test/castService.test.ts
@@ -1,5 +1,5 @@
 import * as protobufs from '@farcaster/protobufs';
-import { Factories, getHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
+import { Factories, getInsecureHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
 import SyncEngine from '~/network/sync/syncEngine';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -17,7 +17,7 @@ let client: HubRpcClient;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
-  client = getHubRpcClient(`127.0.0.1:${port}`);
+  client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/apps/hubble/src/rpc/server/test/concurrency.test.ts
+++ b/apps/hubble/src/rpc/server/test/concurrency.test.ts
@@ -1,5 +1,5 @@
 import * as protobufs from '@farcaster/protobufs';
-import { Factories, getHubRpcClient, HubResult, HubRpcClient } from '@farcaster/utils';
+import { Factories, getInsecureHubRpcClient, HubResult, HubRpcClient } from '@farcaster/utils';
 import SyncEngine from '~/network/sync/syncEngine';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -20,9 +20,9 @@ let client3: HubRpcClient;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
-  client1 = getHubRpcClient(`127.0.0.1:${port}`);
-  client2 = getHubRpcClient(`127.0.0.1:${port}`);
-  client3 = getHubRpcClient(`127.0.0.1:${port}`);
+  client1 = getInsecureHubRpcClient(`127.0.0.1:${port}`);
+  client2 = getInsecureHubRpcClient(`127.0.0.1:${port}`);
+  client3 = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/apps/hubble/src/rpc/server/test/eventService.test.ts
+++ b/apps/hubble/src/rpc/server/test/eventService.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import * as protobufs from '@farcaster/protobufs';
-import { Factories, getHubRpcClient, HubRpcClient } from '@farcaster/utils';
+import { Factories, getInsecureHubRpcClient, HubRpcClient } from '@farcaster/utils';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import Engine from '~/storage/engine';
@@ -17,7 +17,7 @@ let client: HubRpcClient;
 beforeAll(async () => {
   server = new Server(hub, engine);
   const port = await server.start();
-  client = getHubRpcClient(`127.0.0.1:${port}`);
+  client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/apps/hubble/src/rpc/server/test/reactionService.test.ts
+++ b/apps/hubble/src/rpc/server/test/reactionService.test.ts
@@ -1,5 +1,5 @@
 import * as protobufs from '@farcaster/protobufs';
-import { Factories, getHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
+import { Factories, getInsecureHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
 import SyncEngine from '~/network/sync/syncEngine';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -17,7 +17,7 @@ let client: HubRpcClient;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
-  client = getHubRpcClient(`127.0.0.1:${port}`);
+  client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/apps/hubble/src/rpc/server/test/rpcAuth.test.ts
+++ b/apps/hubble/src/rpc/server/test/rpcAuth.test.ts
@@ -1,0 +1,99 @@
+import * as protobufs from '@farcaster/protobufs';
+import { Factories, getInsecureHubRpcClient, HubError } from '@farcaster/utils';
+import SyncEngine from '~/network/sync/syncEngine';
+
+import Server from '~/rpc/server';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import Engine from '~/storage/engine';
+import { MockHub } from '~/test/mocks';
+
+const db = jestRocksDB('protobufs.rpc.submitService.test');
+const network = protobufs.FarcasterNetwork.FARCASTER_NETWORK_TESTNET;
+const engine = new Engine(db, network);
+const hub = new MockHub(db, engine);
+
+const fid = Factories.Fid.build();
+const custodySigner = Factories.Eip712Signer.build();
+const signer = Factories.Ed25519Signer.build();
+
+let custodyEvent: protobufs.IdRegistryEvent;
+let signerAdd: protobufs.Message;
+
+beforeAll(async () => {
+  custodyEvent = Factories.IdRegistryEvent.build({ fid, to: custodySigner.signerKey });
+
+  signerAdd = await Factories.SignerAddMessage.create(
+    { data: { fid, network, signerBody: { signer: signer.signerKey } } },
+    { transient: { signer: custodySigner } }
+  );
+});
+
+describe('auth tests', () => {
+  test('fails with invalid password', async () => {
+    const authServer = new Server(hub, engine, new SyncEngine(engine, db), undefined, 'admin:password');
+    const port = await authServer.start();
+    const authClient = getInsecureHubRpcClient(`127.0.0.1:${port}`);
+
+    const nameRegistryEvent = Factories.NameRegistryEvent.build({ to: signer.signerKey });
+
+    // No password
+    const result = await authClient.submitNameRegistryEvent(nameRegistryEvent);
+    expect(result._unsafeUnwrapErr()).toEqual(new HubError('unauthorized', 'User is not authenticated'));
+
+    // Wrong password
+    const metadata = new protobufs.Metadata();
+    metadata.set('authorization', `Basic ${Buffer.from(`admin:wrongpassword`).toString('base64')}`);
+    const result2 = await authClient.submitNameRegistryEvent(nameRegistryEvent, metadata);
+    expect(result2._unsafeUnwrapErr()).toEqual(new HubError('unauthorized', 'User is not authenticated'));
+
+    // Wrong username
+    const metadata2 = new protobufs.Metadata();
+    metadata2.set('authorization', `Basic ${Buffer.from(`wronguser:password`).toString('base64')}`);
+    const result3 = await authClient.submitNameRegistryEvent(nameRegistryEvent, metadata2);
+    expect(result3._unsafeUnwrapErr()).toEqual(new HubError('unauthorized', 'User is not authenticated'));
+
+    // Right password
+    const metadata3 = new protobufs.Metadata();
+    metadata3.set('authorization', `Basic ${Buffer.from(`admin:password`).toString('base64')}`);
+    const result4 = await authClient.submitNameRegistryEvent(nameRegistryEvent, metadata3);
+    expect(result4.isOk()).toBeTruthy();
+
+    // Non submit methods work without auth
+    const result5 = await authClient.getInfo(protobufs.Empty.create());
+    expect(result5.isOk()).toBeTruthy();
+
+    await authServer.stop();
+    authClient.$.close();
+  });
+
+  test('all submit methods require auth', async () => {
+    const authServer = new Server(hub, engine, new SyncEngine(engine, db), undefined, 'admin:password');
+    const port = await authServer.start();
+    const authClient = getInsecureHubRpcClient(`127.0.0.1:${port}`);
+
+    // Without auth fails
+    const result = await authClient.submitIdRegistryEvent(custodyEvent);
+    expect(result._unsafeUnwrapErr()).toEqual(new HubError('unauthorized', 'User is not authenticated'));
+
+    const result2 = await authClient.submitMessage(signerAdd);
+    expect(result2._unsafeUnwrapErr()).toEqual(new HubError('unauthorized', 'User is not authenticated'));
+
+    const result3 = await authClient.submitNameRegistryEvent(Factories.NameRegistryEvent.build());
+    expect(result3._unsafeUnwrapErr()).toEqual(new HubError('unauthorized', 'User is not authenticated'));
+
+    // Works with auth
+    const metadata = new protobufs.Metadata();
+    metadata.set('authorization', `Basic ${Buffer.from(`admin:password`).toString('base64')}`);
+    const result4 = await authClient.submitIdRegistryEvent(custodyEvent, metadata);
+    expect(result4.isOk()).toBeTruthy();
+
+    const result5 = await authClient.submitMessage(signerAdd, metadata);
+    expect(result5.isOk()).toBeTruthy();
+
+    const result6 = await authClient.submitNameRegistryEvent(Factories.NameRegistryEvent.build(), metadata);
+    expect(result6.isOk()).toBeTruthy();
+
+    await authServer.stop();
+    authClient.$.close();
+  });
+});

--- a/apps/hubble/src/rpc/server/test/signerService.test.ts
+++ b/apps/hubble/src/rpc/server/test/signerService.test.ts
@@ -1,5 +1,5 @@
 import * as protobufs from '@farcaster/protobufs';
-import { Factories, getHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
+import { Factories, getInsecureHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
 import SyncEngine from '~/network/sync/syncEngine';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -17,7 +17,7 @@ let client: HubRpcClient;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
-  client = getHubRpcClient(`127.0.0.1:${port}`);
+  client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/apps/hubble/src/rpc/server/test/submitService.test.ts
+++ b/apps/hubble/src/rpc/server/test/submitService.test.ts
@@ -1,5 +1,5 @@
 import * as protobufs from '@farcaster/protobufs';
-import { Factories, getHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
+import { Factories, getInsecureHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
 import { err } from 'neverthrow';
 import SyncEngine from '~/network/sync/syncEngine';
 
@@ -19,7 +19,7 @@ let client: HubRpcClient;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
-  client = getHubRpcClient(`127.0.0.1:${port}`);
+  client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/apps/hubble/src/rpc/server/test/userDataService.test.ts
+++ b/apps/hubble/src/rpc/server/test/userDataService.test.ts
@@ -1,5 +1,5 @@
 import * as protobufs from '@farcaster/protobufs';
-import { bytesToUtf8String, Factories, getHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
+import { bytesToUtf8String, Factories, getInsecureHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
 import { Ok } from 'neverthrow';
 import SyncEngine from '~/network/sync/syncEngine';
 import Server from '~/rpc/server';
@@ -18,7 +18,7 @@ let client: HubRpcClient;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
-  client = getHubRpcClient(`127.0.0.1:${port}`);
+  client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/apps/hubble/src/rpc/server/test/verificationService.test.ts
+++ b/apps/hubble/src/rpc/server/test/verificationService.test.ts
@@ -1,5 +1,5 @@
 import * as protobufs from '@farcaster/protobufs';
-import { Factories, getHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
+import { Factories, getInsecureHubRpcClient, HubError, HubRpcClient } from '@farcaster/utils';
 import SyncEngine from '~/network/sync/syncEngine';
 import Server from '~/rpc/server';
 import { jestRocksDB } from '~/storage/db/jestUtils';
@@ -17,7 +17,7 @@ let client: HubRpcClient;
 beforeAll(async () => {
   server = new Server(hub, engine, new SyncEngine(engine, db));
   const port = await server.start();
-  client = getHubRpcClient(`127.0.0.1:${port}`);
+  client = getInsecureHubRpcClient(`127.0.0.1:${port}`);
 });
 
 afterAll(async () => {

--- a/packages/protobufs/src/index.ts
+++ b/packages/protobufs/src/index.ts
@@ -21,7 +21,30 @@ export const getServer = (): grpc.Server => {
   return server;
 };
 
-export const getClient = (address: string): HubServiceClient => {
+export const getClient = async (address: string): Promise<HubServiceClient> => {
+  return new Promise((resolve) => {
+    try {
+      const sslClientResult = getSSLClient(address);
+      if (sslClientResult) {
+        sslClientResult.waitForReady(Date.now() + 1000, (err) => {
+          if (!err) {
+            resolve(sslClientResult);
+          }
+        });
+      }
+    } catch (e) {
+      // Fall back to insecure client
+    }
+
+    resolve(getInsecureClient(address));
+  });
+};
+
+export const getSSLClient = (address: string): HubServiceClient => {
+  return new HubServiceClient(address, grpc.credentials.createSsl());
+};
+
+export const getInsecureClient = (address: string): HubServiceClient => {
   return new HubServiceClient(address, grpc.credentials.createInsecure());
 };
 

--- a/packages/utils/src/client.ts
+++ b/packages/utils/src/client.ts
@@ -4,6 +4,8 @@ import {
   ClientReadableStream,
   ClientUnaryCall,
   getClient,
+  getInsecureClient,
+  getSSLClient,
   HubServiceClient,
   Metadata,
   ServiceError,
@@ -98,6 +100,14 @@ const promisifyClient = <C extends Client>(client: C) => {
 
 export type HubRpcClient = PromisifiedClient<HubServiceClient>;
 
-export const getHubRpcClient = (address: string): HubRpcClient => {
-  return promisifyClient(getClient(address));
+export const getHubRpcClient = async (address: string): Promise<HubRpcClient> => {
+  return promisifyClient(await getClient(address));
+};
+
+export const getSSLHubRpcClient = (address: string): HubRpcClient => {
+  return promisifyClient(getSSLClient(address));
+};
+
+export const getInsecureHubRpcClient = (address: string): HubRpcClient => {
+  return promisifyClient(getInsecureClient(address));
 };


### PR DESCRIPTION
## Motivation

Add SSL and basic auth to submit methods so only authorized users can submit to the Hub

## Change Summary

-Add SSL support for clients
- Add optional basic auth for submit methods

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
