### PR TITLE
fix: validate length limits in terms of utf8 bytes and allow up to 10 mentions

### DIFF
--- a/.changeset/ten-shrimps-know.md
+++ b/.changeset/ten-shrimps-know.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/utils': patch
+---
+
+Validate using UTF8 byte count instead of character length

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -84,8 +84,8 @@ export const bytesToUtf8String = (bytes: Uint8Array): HubResult<string> => {
   return ok(decoder.decode(bytes));
 };
 
+const encoder = new TextEncoder();
 export const utf8StringToBytes = (utf8: string): HubResult<Uint8Array> => {
-  const encoder = new TextEncoder();
   return ok(encoder.encode(utf8));
 };
 


### PR DESCRIPTION
## Motivation

We want to know exactly how many bytes we're storing.

Furthermore, we want to guarantee that regardless of future iterations to the Unicode specification that we have an unambiguous way to take text and mention positions and reconstruct cast text from that by inserting dynamic content at those positions (e.g. username, which can change).

## Change Summary

Check using utf8 byte length instead of character length.

While here, based on a team discussion and existing cast data we also increased the maximum number of mentions from 5 to 10.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
