### PR TITLE
fix: getCastsByFid should return items in reverse chronological order

### DIFF
--- a/.changeset/gorgeous-flowers-jog.md
+++ b/.changeset/gorgeous-flowers-jog.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Return casts from getCastsByFid in reverse chronological order

--- a/apps/hubble/src/rpc/server/test/castService.test.ts
+++ b/apps/hubble/src/rpc/server/test/castService.test.ts
@@ -91,7 +91,7 @@ describe('getCast', () => {
       );
     });
 
-    test('returns casts in reverse chronological order', async () => {
+    test('returns casts in chronological order', async () => {
       const castsAsJson = [];
       let latestCast;
       for (let i = 0; i < 4; i++) {
@@ -111,7 +111,7 @@ describe('getCast', () => {
       expect(castsAsJson.length).toEqual(4);
       expect(clientRetrievedCastsAsJson.length).toEqual(4);
 
-      expect(clientRetrievedCastsAsJson).toEqual(castsAsJson.reverse());
+      expect(clientRetrievedCastsAsJson).toEqual(castsAsJson);
     });
 
     test('returns empty array without casts', async () => {

--- a/apps/hubble/src/rpc/server/test/castService.test.ts
+++ b/apps/hubble/src/rpc/server/test/castService.test.ts
@@ -91,6 +91,29 @@ describe('getCast', () => {
       );
     });
 
+    test('returns casts in reverse chronological order', async () => {
+      const castsAsJson = [];
+      let latestCast;
+      for (let i = 0; i < 4; i++) {
+        latestCast = await Factories.CastAddMessage.create(
+          {
+            data: { fid, network, timestamp: i },
+          },
+          { transient: { signer } }
+        );
+        await engine.mergeMessage(latestCast);
+        castsAsJson.push(protobufs.Message.toJSON(latestCast));
+      }
+
+      const clientRetrievedCasts = await client.getCastsByFid(protobufs.FidRequest.create({ fid }));
+      const clientRetrievedCastsAsJson = clientRetrievedCasts._unsafeUnwrap().messages.map(protobufs.Message.toJSON);
+
+      expect(castsAsJson.length).toEqual(4);
+      expect(clientRetrievedCastsAsJson.length).toEqual(4);
+
+      expect(clientRetrievedCastsAsJson).toEqual(castsAsJson.reverse());
+    });
+
     test('returns empty array without casts', async () => {
       const casts = await client.getCastsByFid(protobufs.FidRequest.create({ fid }));
       expect(casts._unsafeUnwrap().messages).toEqual([]);

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -4,6 +4,7 @@ import AsyncLock from 'async-lock';
 import { err, ok, ResultAsync } from 'neverthrow';
 import {
   deleteMessageTransaction,
+  getAllMessagesByFid,
   getAllMessagesBySigner,
   getManyMessages,
   getManyMessagesByFid,
@@ -143,12 +144,9 @@ class CastStore {
 
   /** Gets all CastAdd messages for an fid */
   async getCastAddsByFid(fid: number): Promise<protobufs.CastAddMessage[]> {
-    const castAddsPrefix = makeCastAddsKey(fid);
-    const messageKeys: Buffer[] = [];
-    for await (const [, value] of this._db.iteratorByPrefix(castAddsPrefix, { keys: false, valueAsBuffer: true })) {
-      messageKeys.push(value);
-    }
-    return getManyMessagesByFid(this._db, fid, UserPostfix.CastMessage, messageKeys);
+    return (await getAllMessagesByFid(this._db, fid))
+      .filter((message) => message.data?.type === protobufs.MessageType.CAST_ADD)
+      .reverse() as protobufs.CastAddMessage[];
   }
 
   /** Gets all CastRemove messages for an fid */


### PR DESCRIPTION
## Motivation
Fixes https://github.com/farcasterxyz/hubble/issues/611

## Change Summary
Modifies CastStore#getCastAddsByFid to fetch all messages for a given FID rather than only CastAdds from the DB.
Fetching all messages utilizes thash so casts are retrieved in chronological order.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] Changes to the protocol specification have been merged

## Additional Context
Not sure that I fully understood approach described in https://github.com/farcasterxyz/hubble/issues/611
If I understand correctly, it seems like this is a bandaid, and long term it might make sense to have a parallel index RocksDB table stored with thash keys?