### PR TITLE
fix: Validate embed URLs using utf8 byte length

### DIFF
--- a/.changeset/old-dancers-promise.md
+++ b/.changeset/old-dancers-promise.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/utils': patch
+---
+
+Validate embed URLs using utf8 byte length

--- a/packages/utils/src/validations.test.ts
+++ b/packages/utils/src/validations.test.ts
@@ -237,6 +237,27 @@ describe('validateCastAddBody', () => {
       hubErrorMessage = 'embeds > 2';
     });
 
+    test('with an empty embed string', () => {
+      body = Factories.CastAddBody.build({
+        embeds: [''],
+      });
+      hubErrorMessage = 'embed < 1 byte';
+    });
+
+    test('with an embed string over 256 ASCII characters', () => {
+      body = Factories.CastAddBody.build({
+        embeds: [faker.random.alphaNumeric(257)],
+      });
+      hubErrorMessage = 'embed > 256 bytes';
+    });
+
+    test('with an embed string over 256 bytes', () => {
+      body = Factories.CastAddBody.build({
+        embeds: [faker.random.alphaNumeric(254) + '🤓'],
+      });
+      hubErrorMessage = 'embed > 256 bytes';
+    });
+
     test('when parent fid is missing', () => {
       body = Factories.CastAddBody.build({
         parentCastId: Factories.CastId.build({ fid: undefined }),


### PR DESCRIPTION
## Motivation

We want to ensure these URLs remain under 256 bytes when encoded as utf8.

## Change Summary

Check that each embed URL has at least one byte and at most 256 bytes when encoded as utf8.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
