### PR TITLE
feat: make name and fromId optional

### DIFF
--- a/.changeset/long-moles-buy.md
+++ b/.changeset/long-moles-buy.md
@@ -1,0 +1,6 @@
+---
+'@farcaster/protobufs': patch
+'@farcaster/utils': patch
+---
+
+make SignerAddBody.name and SubscribeRequest.fromId optional

--- a/packages/protobufs/src/generated/message.ts
+++ b/packages/protobufs/src/generated/message.ts
@@ -349,7 +349,7 @@ export interface SignerAddBody {
   /** Public key of the Ed25519 key pair */
   signer: Uint8Array;
   /** Name of the key pair */
-  name: string;
+  name?: string | undefined;
 }
 
 /** Removes an Ed25519 key pair that signs messages for a user */
@@ -729,7 +729,7 @@ export const MessageData = {
 };
 
 function createBaseSignerAddBody(): SignerAddBody {
-  return { signer: new Uint8Array(), name: "" };
+  return { signer: new Uint8Array(), name: undefined };
 }
 
 export const SignerAddBody = {
@@ -737,7 +737,7 @@ export const SignerAddBody = {
     if (message.signer.length !== 0) {
       writer.uint32(10).bytes(message.signer);
     }
-    if (message.name !== "") {
+    if (message.name !== undefined) {
       writer.uint32(18).string(message.name);
     }
     return writer;
@@ -767,7 +767,7 @@ export const SignerAddBody = {
   fromJSON(object: any): SignerAddBody {
     return {
       signer: isSet(object.signer) ? bytesFromBase64(object.signer) : new Uint8Array(),
-      name: isSet(object.name) ? String(object.name) : "",
+      name: isSet(object.name) ? String(object.name) : undefined,
     };
   },
 
@@ -786,7 +786,7 @@ export const SignerAddBody = {
   fromPartial<I extends Exact<DeepPartial<SignerAddBody>, I>>(object: I): SignerAddBody {
     const message = createBaseSignerAddBody();
     message.signer = object.signer ?? new Uint8Array();
-    message.name = object.name ?? "";
+    message.name = object.name ?? undefined;
     return message;
   },
 };

--- a/packages/protobufs/src/generated/rpc.ts
+++ b/packages/protobufs/src/generated/rpc.ts
@@ -34,7 +34,7 @@ export interface Empty {
 
 export interface SubscribeRequest {
   eventTypes: HubEventType[];
-  fromId: number;
+  fromId?: number | undefined;
 }
 
 export interface EventRequest {
@@ -181,7 +181,7 @@ export const Empty = {
 };
 
 function createBaseSubscribeRequest(): SubscribeRequest {
-  return { eventTypes: [], fromId: 0 };
+  return { eventTypes: [], fromId: undefined };
 }
 
 export const SubscribeRequest = {
@@ -191,7 +191,7 @@ export const SubscribeRequest = {
       writer.int32(v);
     }
     writer.ldelim();
-    if (message.fromId !== 0) {
+    if (message.fromId !== undefined) {
       writer.uint32(16).uint64(message.fromId);
     }
     return writer;
@@ -228,7 +228,7 @@ export const SubscribeRequest = {
   fromJSON(object: any): SubscribeRequest {
     return {
       eventTypes: Array.isArray(object?.eventTypes) ? object.eventTypes.map((e: any) => hubEventTypeFromJSON(e)) : [],
-      fromId: isSet(object.fromId) ? Number(object.fromId) : 0,
+      fromId: isSet(object.fromId) ? Number(object.fromId) : undefined,
     };
   },
 
@@ -250,7 +250,7 @@ export const SubscribeRequest = {
   fromPartial<I extends Exact<DeepPartial<SubscribeRequest>, I>>(object: I): SubscribeRequest {
     const message = createBaseSubscribeRequest();
     message.eventTypes = object.eventTypes?.map((e) => e) || [];
-    message.fromId = object.fromId ?? 0;
+    message.fromId = object.fromId ?? undefined;
     return message;
   },
 };

--- a/packages/protobufs/src/schemas/message.proto
+++ b/packages/protobufs/src/schemas/message.proto
@@ -72,7 +72,7 @@ enum FarcasterNetwork {
 /** Adds an Ed25519 key pair that signs messages for a user */
 message SignerAddBody {
   bytes signer = 1; // Public key of the Ed25519 key pair
-  string name = 2; // Name of the key pair
+  optional string name = 2; // Name of the key pair
 }
 
 /** Removes an Ed25519 key pair that signs messages for a user */

--- a/packages/protobufs/src/schemas/rpc.proto
+++ b/packages/protobufs/src/schemas/rpc.proto
@@ -9,7 +9,7 @@ message Empty {}
 
 message SubscribeRequest {
   repeated HubEventType event_types = 1;
-  uint64 from_id = 2;
+  optional uint64 from_id = 2;
 }
 
 message EventRequest {

--- a/packages/utils/src/builders.test.ts
+++ b/packages/utils/src/builders.test.ts
@@ -195,7 +195,7 @@ describe('makeVerificationRemove', () => {
 
 describe('makeSignerAddData', () => {
   test('succeeds', async () => {
-    const data = await builders.makeSignerAddData({ signer: ed25519Signer.signerKey, name: '' }, { fid, network });
+    const data = await builders.makeSignerAddData({ signer: ed25519Signer.signerKey }, { fid, network });
     const isValid = await validations.validateMessageData(data._unsafeUnwrap());
     expect(isValid.isOk()).toBeTruthy();
   });
@@ -212,10 +212,16 @@ describe('makeSignerRemoveData', () => {
 describe('makeSignerAdd', () => {
   test('succeeds', async () => {
     const message = await builders.makeSignerAdd(
-      { signer: ed25519Signer.signerKey, name: '' },
+      { signer: ed25519Signer.signerKey, name: 'test signer' },
       { fid, network },
       eip712Signer
     );
+    const isValid = await validations.validateMessage(message._unsafeUnwrap());
+    expect(isValid.isOk()).toBeTruthy();
+  });
+
+  test('succeeds without name', async () => {
+    const message = await builders.makeSignerAdd({ signer: ed25519Signer.signerKey }, { fid, network }, eip712Signer);
     const isValid = await validations.validateMessage(message._unsafeUnwrap());
     expect(isValid.isOk()).toBeTruthy();
   });
@@ -294,7 +300,7 @@ describe('makeMessageWithSignature', () => {
     const signature = hexStringToBytes(
       '0xf8dc77d52468483806addab7d397836e802551bfb692604e2d7df4bc4820556c63524399a63d319ae4b027090ce296ade08286878dc1f414b62412f89e8bc4e01b'
     )._unsafeUnwrap();
-    const data = builders.makeSignerAddData({ signer: ed25519Signer.signerKey, name: '' }, { fid, network });
+    const data = builders.makeSignerAddData({ signer: ed25519Signer.signerKey }, { fid, network });
     expect(data.isOk()).toBeTruthy();
     const message = await builders.makeMessageWithSignature(data._unsafeUnwrap(), {
       signer: eip712Signer.signerKey,

--- a/packages/utils/src/validations.test.ts
+++ b/packages/utils/src/validations.test.ts
@@ -548,6 +548,11 @@ describe('validateSignerAddBody', () => {
       hubErrorMessage = 'publicKey must be 32 bytes';
     });
 
+    test('with name as empty string', () => {
+      body = Factories.SignerAddBody.build({ name: '' });
+      hubErrorMessage = 'name cannot be empty string';
+    });
+
     test('with name > 32 chars', () => {
       body = Factories.SignerAddBody.build({ name: faker.random.alphaNumeric(33) });
       hubErrorMessage = 'name > 32 bytes';

--- a/packages/utils/src/validations.ts
+++ b/packages/utils/src/validations.ts
@@ -391,13 +391,19 @@ export const validateVerificationRemoveBody = (
 };
 
 export const validateSignerAddBody = (body: protobufs.SignerAddBody): HubResult<protobufs.SignerAddBody> => {
-  const textUtf8BytesResult = utf8StringToBytes(body.name);
-  if (textUtf8BytesResult.isErr()) {
-    return err(new HubError('bad_request.invalid_param', 'name cannot be encoded as utf8'));
-  }
+  if (body.name !== undefined) {
+    const textUtf8BytesResult = utf8StringToBytes(body.name);
+    if (textUtf8BytesResult.isErr()) {
+      return err(new HubError('bad_request.invalid_param', 'name cannot be encoded as utf8'));
+    }
 
-  if (textUtf8BytesResult.value.length > 32) {
-    return err(new HubError('bad_request.validation_failure', 'name > 32 bytes'));
+    if (textUtf8BytesResult.value.length === 0) {
+      return err(new HubError('bad_request.validation_failure', 'name cannot be empty string'));
+    }
+
+    if (textUtf8BytesResult.value.length > 32) {
+      return err(new HubError('bad_request.validation_failure', 'name > 32 bytes'));
+    }
   }
 
   return validateEd25519PublicKey(body.signer).map(() => body);


### PR DESCRIPTION
## Motivation

Closes https://github.com/farcasterxyz/hubble/issues/644

## Change Summary

* Make `name` optional to avoid writing empty strings to protobufs
* Validate SignerAddBody `name` is either undefined or a string (1-32 bytes)
* Make `fromId` optional in SubscribeRequest

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] Changes to the protocol specification have been merged

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
