### PR TITLE
chore: upgrade typescript to v5 from v5beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ts-node": "^10.9.1",
     "tsup": "^6.5.0",
     "turbo": "1.7.3",
-    "typescript": "^5.0.0-beta"
+    "typescript": "^5.0.2"
   },
   "lint-staged": {
     "*.ts": "eslint --cache --fix"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7529,10 +7529,10 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@^5.0.0-beta:
-  version "5.0.0-dev.20230206"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.0.0-dev.20230206.tgz#04bb2d393eadfa32a9131270b26c2dd024643d91"
-  integrity sha512-pEoZbri8HyvEk/DV1ivC2V5z/Fv5Pd/riw6llt3yfx+/JMMTmbDQraCCq2JQgxgvtGYQrU2861MnrPNjI3815A==
+typescript@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz#891e1a90c5189d8506af64b9ef929fca99ba1ee5"
+  integrity sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==
 
 uint8-varint@^1.0.1, uint8-varint@^1.0.2:
   version "1.0.4"


### PR DESCRIPTION
## Motivation

Upgrade typescript to the final stable release before hub launch.

## Change Summary

- Upgrade TS to v5.0.2

## Merge Checklist

- [x] The title of this PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] The PR has been tagged with the appropriate change type label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] Changes to the protocol specification have been merged
