### PR TITLE
feat: Admin server on localhost only

### DIFF
--- a/apps/hubble/.config/hub.config.ts
+++ b/apps/hubble/.config/hub.config.ts
@@ -41,4 +41,6 @@ export const Config = {
   rebuildSyncTrie: false,
   /** Farcaster network */
   network: DEFAULT_NETWORK,
+  /** Start the admin server? */
+  adminServerEnabled: false,
 };

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -50,6 +50,7 @@ app
     '--rpc-auth <username:password>',
     'Enable Auth for RPC submit methods with the username and password. (default: disabled)'
   )
+  .option('--admin-server-enabled', 'Enable the admin server. (default: disabled)')
   .option('--db-name <name>', 'The name of the RocksDB instance')
   .option('--db-reset', 'Clears the database before starting')
   .option('--rebuild-sync-trie', 'Rebuilds the sync trie before starting')
@@ -132,6 +133,7 @@ app
       rocksDBName: cliOptions.dbName ?? hubConfig.dbName,
       resetDB: cliOptions.dbReset ?? hubConfig.dbReset,
       rebuildSyncTrie,
+      adminServerEnabled: cliOptions.adminServerEnabled ?? hubConfig.adminServerEnabled,
     };
 
     const hub = new Hub(options);

--- a/apps/hubble/src/console/console.ts
+++ b/apps/hubble/src/console/console.ts
@@ -2,7 +2,7 @@ import { Empty } from '@farcaster/protobufs';
 import { getAdminRpcClient, getHubRpcClient } from '@farcaster/utils';
 import path from 'path';
 import * as repl from 'repl';
-import { getAdminSocket } from '~/rpc/adminServer';
+import { ADMIN_SERVER_PORT } from '~/rpc/adminServer';
 import { logger } from '~/utils/logger';
 import { AdminCommand } from './adminCommand';
 import { GenCommand } from './genCommand';
@@ -41,7 +41,8 @@ export const startConsole = async (addressString: string) => {
   });
 
   const rpcClient = await getHubRpcClient(addressString);
-  const adminClient = await getAdminRpcClient(getAdminSocket());
+  // Admin server is only available on localhost
+  const adminClient = await getAdminRpcClient(`127.0.0.1:${ADMIN_SERVER_PORT}`);
 
   const commands: ConsoleCommandInterface[] = [
     new RpcClientCommand(rpcClient),

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -115,6 +115,9 @@ export interface HubOptions {
   /** Rebuild the sync trie from messages in the DB on startup */
   rebuildSyncTrie?: boolean;
 
+  /** Enables the Admin Server */
+  adminServerEnabled?: boolean;
+
   /**
    * Only allows the Hub to connect to and advertise local IP addresses
    *
@@ -251,7 +254,9 @@ export class Hub implements HubInterface {
 
     // Start the RPC server
     await this.rpcServer.start(this.options.rpcPort ? this.options.rpcPort : 0);
-    await this.adminServer.start();
+    if (this.options.adminServerEnabled) {
+      await this.adminServer.start();
+    }
     this.registerEventHandlers();
 
     // Start cron tasks


### PR DESCRIPTION
## Motivation

Run the Admin server on localhost only, gated by flag. 

## Change Summary

- Move admin server to localhost port
- --admin-server-enabled flag has to be passed in to turn it on (off by default)
