### PR TITLE
fix: Increase Q limits now that we have more memory.

### DIFF
--- a/.changeset/breezy-glasses-search.md
+++ b/.changeset/breezy-glasses-search.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Increase sync trie Q limit

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -19,7 +19,7 @@ import { addressInfoFromParts, checkNodeAddrs, ipMultiAddrStrFromAddressInfo } f
 const MultiaddrLocalHost = '/ip4/127.0.0.1';
 
 /** The maximum number of pending merge messages before we drop new incoming gossip or sync messages  */
-export const MAX_MESSAGE_QUEUE_SIZE = 1000;
+export const MAX_MESSAGE_QUEUE_SIZE = 10_000;
 
 const log = logger.child({ component: 'Node' });
 

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -6,7 +6,7 @@ import RocksDB from '~/storage/db/rocksdb';
 import Engine from '~/storage/engine';
 import { logger } from '~/utils/logger';
 
-const TRIE_UNLOAD_THRESHOLD = 10_000;
+const TRIE_UNLOAD_THRESHOLD = 25_000;
 
 /**
  * Represents a node in the trie, and it's immediate children


### PR DESCRIPTION
## Motivation

Increase sync trie Q size

## Change Summary

- Sync Q size 1000 -> 10_000
- Trie node cache 10_000 -> 25_000 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
