### PR TITLE
refactor: update ethers to v6.1 from v5.7

### DIFF
--- a/.changeset/forty-zoos-tan.md
+++ b/.changeset/forty-zoos-tan.md
@@ -1,0 +1,7 @@
+---
+'@farcaster/hub-nodejs': minor
+'@farcaster/utils': minor
+'@farcaster/hubble': patch
+---
+
+upgrade ethers from v5 to v6

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -59,7 +59,7 @@
     "@multiformats/multiaddr": "^11.0.0",
     "async-lock": "^1.4.0",
     "commander": "~10.0.0",
-    "ethers": "~5.7.2",
+    "ethers": "~6.1.0",
     "libp2p": "0.42.2",
     "neverthrow": "~6.0.0",
     "node-cron": "~3.0.2",

--- a/apps/hubble/src/eth/utils.test.ts
+++ b/apps/hubble/src/eth/utils.test.ts
@@ -1,20 +1,16 @@
-import { BigNumber } from 'ethers';
 import { bytes32ToBytes, bytesToBytes32 } from '~/eth/utils';
 
-const passingCases: [BigNumber, Uint8Array][] = [
+const passingCases: [bigint, Uint8Array][] = [
   [
-    BigNumber.from('50839975223553296918063695500986414185067076564032165621192833738513116561408'),
+    BigInt('50839975223553296918063695500986414185067076564032165621192833738513116561408'),
     new Uint8Array([112, 102, 104]),
   ],
-  [
-    BigNumber.from('0x7066680000000000000000000000000000000000000000000000000000000000'),
-    new Uint8Array([112, 102, 104]),
-  ],
+  [BigInt('0x7066680000000000000000000000000000000000000000000000000000000000'), new Uint8Array([112, 102, 104])],
 ];
 
 describe('bytes32ToBytes', () => {
   for (const [input, output] of passingCases) {
-    test(`converts BigNumber bytes32 to unpadded byte array: ${input.toString()}`, () => {
+    test(`converts BigInt bytes32 to unpadded byte array: ${input.toString()}`, () => {
       expect(bytes32ToBytes(input)._unsafeUnwrap()).toEqual(output);
     });
   }
@@ -22,7 +18,7 @@ describe('bytes32ToBytes', () => {
 
 describe('bytesToBytes32', () => {
   for (const [output, input] of passingCases) {
-    test(`converts byte array to BigNumber bytes32: ${input.toString()}`, () => {
+    test(`converts byte array to BigInt bytes32: ${input.toString()}`, () => {
       expect(bytesToBytes32(input)._unsafeUnwrap()).toEqual(output);
     });
   }

--- a/apps/hubble/src/eth/utils.ts
+++ b/apps/hubble/src/eth/utils.ts
@@ -1,9 +1,8 @@
-import { bytesToBigNumber, hexStringToBytes, HubResult } from '@farcaster/utils';
-import { BigNumber } from 'ethers';
+import { bytesToBigInt, hexStringToBytes, HubResult } from '@farcaster/utils';
 
-export const bytes32ToBytes = (value: BigNumber): HubResult<Uint8Array> => {
+export const bytes32ToBytes = (value: bigint): HubResult<Uint8Array> => {
   // Remove right padding
-  let hex = value.toHexString();
+  let hex = value.toString(16);
   while (hex.substring(hex.length - 2) === '00') {
     hex = hex.substring(0, hex.length - 2);
   }
@@ -11,8 +10,8 @@ export const bytes32ToBytes = (value: BigNumber): HubResult<Uint8Array> => {
   return hexStringToBytes(hex);
 };
 
-export const bytesToBytes32 = (value: Uint8Array): HubResult<BigNumber> => {
+export const bytesToBytes32 = (value: Uint8Array): HubResult<bigint> => {
   const bytes = new Uint8Array(32);
   bytes.set(value, 0);
-  return bytesToBigNumber(bytes);
+  return bytesToBigInt(bytes);
 };

--- a/packages/hub-nodejs/docs/Builders.md
+++ b/packages/hub-nodejs/docs/Builders.md
@@ -29,10 +29,10 @@ An Eip712Signer is an ECDSA key pair which is necessary signing for some message
 
 ```typescript
 import { Eip712Signer } from '@farcaster/hub-nodejs';
-import { ethers } from 'ethers';
+import { wallet } from 'ethers';
 
 const mnemonic = 'ordinary long coach bounce thank quit become youth belt pretty diet caught attract melt bargain';
-const wallet = ethers.Wallet.fromMnemonic(mnemonic);
+const wallet = Wallet.fromPhrase(mnemonic);
 
 const eip712Signer = (await Eip712Signer.fromSigner(wallet))._unsafeUnwrap();
 ```

--- a/packages/hub-nodejs/docs/Messages.md
+++ b/packages/hub-nodejs/docs/Messages.md
@@ -200,5 +200,5 @@ An object that is hashed, signed and included in `VerificationAddEthAddressBody`
 | :---------- | :-------------------------------------- | ------------------------------------------------------------- |
 | `address`   | `string`                                | Ethereum address being verified                               |
 | `blockHash` | `string`                                | Hash of the latest Ethereum block when the claim was produced |
-| `fid`       | `BigNumber`                             | Fid of the user who claims to own the Ethereum address        |
+| `fid`       | `BigInt`                                | Fid of the user who claims to own the Ethereum address        |
 | `network`   | [`FarcasterNetwork`](#farcasternetwork) | Farcaster Network on which the claim will be broadcast        |

--- a/packages/hub-nodejs/docs/Utils.md
+++ b/packages/hub-nodejs/docs/Utils.md
@@ -189,12 +189,12 @@ import {
   hexStringToBytes,
   makeVerificationEthAddressClaim,
 } from '@farcaster/hub-nodejs';
-import { ethers } from 'ethers';
+import { Wallet } from 'ethers';
 
 // Create a valid Eip712Signer from the Etherum Address making the claim
 const mnemonic = 'ordinary long coach bounce thank quit become youth belt pretty diet caught attract melt bargain';
-const wallet = ethers.Wallet.fromMnemonic(mnemonic);
-const eip712Signer = (await Eip712Signer.fromSigner(wallet))._unsafeUnwrap();
+const wallet = Wallet.fromPhrase(mnemonic);
+const eip712Signer = Eip712Signer.fromSigner(wallet)._unsafeUnwrap();
 
 // Construct the claim object with the block number of a recent block
 const blockHashHex = '0x1d3b0456c920eb503450c7efdcf9b5cf1f5184bf04e5d8ecbcead188a0d02018';

--- a/packages/hub-nodejs/docs/signers/Eip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/Eip712Signer.md
@@ -18,26 +18,34 @@ An Eip712Signer is initialized with an Ethereum wallet and can be used with [Bui
 
 Prefer building with `Eip712Signer.fromSigner`.
 
+```typescript
+import { Eip712Signer } from '@farcaster/hub-nodejs';
+import { Wallet } from 'ethers';
+
+const custodyWallet = Wallet.fromPhrase('your mnemonic here apple orange banana');
+const eip712Signer = Eip712Signer.fromSigner(custodyWallet, custodyWallet.address)._unsafeUnwrap();
+```
+
 #### Parameters
 
-| Name              | Type              | Description              |
-| :---------------- | :---------------- | ------------------------ |
-| `typedDataSigner` | `TypedDataSigner` | A wallet instance        |
-| `signerKey`       | `Uint8Array`      | 20-byte Ethereum Address |
+| Name        | Type         | Description              |
+| :---------- | :----------- | ------------------------ |
+| `signer`    | `Signer`     | A wallet instance        |
+| `signerKey` | `Uint8Array` | 20-byte Ethereum Address |
 
 ---
 
 ### `static` fromSigner
 
-Creates an instance of Eip712Signer from an ethers TypedDataSigner (Wallet) and an Ethereum address.
+Creates an instance of Eip712Signer from an ethers Signer (Wallet) and an Ethereum address.
 
 #### Usage
 
 ```typescript
 import { Eip712Signer } from '@farcaster/hub-nodejs';
-import { ethers } from 'ethers';
+import { Wallet } from 'ethers';
 
-const custodyWallet = ethers.Wallet.fromMnemonic('your mnemonic here apple orange banana');
+const custodyWallet = Wallet.fromPhrase('your mnemonic here apple orange banana');
 const eip712Signer = (await Eip712Signer.fromSigner(custodyWallet)._unsafeUnwrap();
 ```
 
@@ -49,9 +57,9 @@ const eip712Signer = (await Eip712Signer.fromSigner(custodyWallet)._unsafeUnwrap
 
 #### Parameters
 
-| Name              | Type              | Description                                      |
-| :---------------- | :---------------- | :----------------------------------------------- |
-| `typedDataSigner` | `TypedDataSigner` | The TypedDataSigner instance to use for signing. |
+| Name     | Type     | Description                                    |
+| :------- | :------- | :--------------------------------------------- |
+| `signer` | `Signer` | The Ethers Signer instance to use for signing. |
 
 ## Instance Methods
 
@@ -62,7 +70,7 @@ Generates a 256-bit signature for a string input and returns the bytes.
 #### Usage
 
 ```typescript
-import { randomBytes } from 'ethers/lib/utils';
+import { randomBytes } from 'ethers';
 import { blake3 } from '@noble/hashes/blake3';
 
 const bytes = randomBytes(32);

--- a/packages/hub-nodejs/examples/write-signer.md
+++ b/packages/hub-nodejs/examples/write-signer.md
@@ -24,16 +24,14 @@ import {
   types,
 } from '@farcaster/hub-nodejs';
 import * as ed from '@noble/ed25519';
-import { ethers } from 'ethers';
-import * as ed from '@noble/ed25519';
-import { ethers } from 'ethers';
+import { Wallet } from 'ethers';
 
 // Safety: we use unsafeUnwrap() and crash on failure in a few places, since it can't be handled
 //  any other way
 
 // Create an EIP712 Signer with the wallet that holds the custody address of the user
 const mnemonic = 'your mnemonic apple orange banana ...'; // mnemonic for the custody address' wallet
-const wallet = ethers.Wallet.fromMnemonic(mnemonic);
+const wallet = Wallet.fromPhrase(mnemonic);
 const eip712Signer = (await Eip712Signer.fromSigner(wallet))._unsafeUnwrap();
 
 // Generate a new Ed25519 key pair which will become the Signer and store the private key securely
@@ -49,7 +47,7 @@ const signerAddResult = await makeSignerAdd({ signer: signerPrivateKeyHex }, dat
 const signerAdd = signerAddResult._unsafeUnwrap();
 
 // Submit the SignerAdd message to the Hub
-const client = new Client('127 .0.0.1:8080');
+const client = new Client('127.0.0.1:8080');
 const result = await client.submitMessage(signerAdd);
 result.isOk() ? console.log('SignerAdd was published successfully!') : console.log(result.error);
 ```

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -19,7 +19,7 @@
     "@farcaster/protobufs": "0.1.8",
     "@farcaster/utils": "0.2.12",
     "@noble/hashes": "^1.3.0",
-    "ethers": "^5.7.2",
+    "ethers": "~6.1.0",
     "neverthrow": "^6.0.0"
   },
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,7 +20,7 @@
     "@farcaster/protobufs": "0.1.8",
     "@noble/ed25519": "^1.7.3",
     "@noble/hashes": "^1.3.0",
-    "ethers": "^5.7.2",
+    "ethers": "~6.1.0",
     "neverthrow": "^6.0.0"
   },
   "scripts": {

--- a/packages/utils/src/builders.test.ts
+++ b/packages/utils/src/builders.test.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker';
 import * as protobufs from '@farcaster/protobufs';
-import { ethers } from 'ethers';
+import { Wallet } from 'ethers';
 import { err, ok } from 'neverthrow';
 import * as builders from './builders';
 import { hexStringToBytes } from './bytes';
@@ -14,7 +14,7 @@ const fid = Factories.Fid.build();
 const network = protobufs.FarcasterNetwork.TESTNET;
 
 const ed25519Signer = Ed25519Signer.fromPrivateKey(Factories.Ed25519PrivateKey.build())._unsafeUnwrap();
-const wallet = new ethers.Wallet(ethers.utils.randomBytes(32));
+const wallet = Wallet.createRandom();
 
 let eip712Signer: Eip712Signer;
 let address: Uint8Array;

--- a/packages/utils/src/bytes.test.ts
+++ b/packages/utils/src/bytes.test.ts
@@ -1,7 +1,6 @@
-import { BigNumber } from 'ethers';
 import { err, ok } from 'neverthrow';
 import {
-  bigNumberToBytes,
+  bigIntToBytes,
   bytesCompare,
   bytesDecrement,
   bytesIncrement,
@@ -179,15 +178,15 @@ describe('utf8StringToBytes', () => {
   }
 });
 
-describe('bigNumberToBytes', () => {
-  const passingCases: [BigNumber, Uint8Array][] = [
-    [BigNumber.from(1000), new Uint8Array([3, 232])],
-    [BigNumber.from(`${Number.MAX_SAFE_INTEGER}`).add(BigNumber.from(1)), new Uint8Array([32, 0, 0, 0, 0, 0, 0])],
+describe('bigIntToBytes', () => {
+  const passingCases: [bigint, Uint8Array][] = [
+    [BigInt(1000), new Uint8Array([3, 232])],
+    [BigInt(`${Number.MAX_SAFE_INTEGER}`) + BigInt(1), new Uint8Array([32, 0, 0, 0, 0, 0, 0])],
   ];
 
   for (const [input, output] of passingCases) {
-    test(`converts BigNumber to byte array: ${input?.toString()}`, () => {
-      expect(bigNumberToBytes(input)).toEqual(ok(output));
+    test(`converts bigint to byte array: ${input?.toString()}`, () => {
+      expect(bigIntToBytes(input)).toEqual(ok(output));
     });
   }
 });

--- a/packages/utils/src/bytes.ts
+++ b/packages/utils/src/bytes.ts
@@ -1,6 +1,5 @@
 /* eslint-disable security/detect-object-injection */
 import { utils } from '@noble/ed25519';
-import { BigNumber } from 'ethers';
 import { err, ok, Result } from 'neverthrow';
 import { HubError, HubResult } from './errors';
 
@@ -89,10 +88,15 @@ export const utf8StringToBytes = (utf8: string): HubResult<Uint8Array> => {
   return ok(encoder.encode(utf8));
 };
 
-export const bigNumberToBytes = (value: BigNumber): HubResult<Uint8Array> => {
-  return hexStringToBytes(value._hex);
+export const bigIntToBytes = (value: bigint): HubResult<Uint8Array> => {
+  let hexValue = value.toString(16);
+
+  // Prefix odd-length hex values with a 0 since hexStringToBytes requires even-length hex values
+  hexValue = hexValue.length % 2 == 0 ? hexValue : '0' + hexValue;
+
+  return hexStringToBytes(hexValue);
 };
 
-export const bytesToBigNumber = (bytes: Uint8Array): HubResult<BigNumber> => {
-  return bytesToHexString(bytes).map((hexString) => BigNumber.from(hexString));
+export const bytesToBigInt = (bytes: Uint8Array): HubResult<bigint> => {
+  return bytesToHexString(bytes).map((hexString) => BigInt(hexString));
 };

--- a/packages/utils/src/crypto/ed25519.test.ts
+++ b/packages/utils/src/crypto/ed25519.test.ts
@@ -1,7 +1,7 @@
 import * as protobufs from '@farcaster/protobufs';
 import * as ed from '@noble/ed25519';
 import { blake3 } from '@noble/hashes/blake3';
-import { randomBytes } from 'ethers/lib/utils';
+import { randomBytes } from 'ethers';
 import { HubError } from '../errors';
 import { Factories } from '../factories';
 import * as ed25519 from './ed25519';

--- a/packages/utils/src/crypto/eip712.test.ts
+++ b/packages/utils/src/crypto/eip712.test.ts
@@ -1,13 +1,13 @@
 import * as protobufs from '@farcaster/protobufs';
 import { blake3 } from '@noble/hashes/blake3';
-import { utils, Wallet } from 'ethers';
+import { getAddress, Wallet } from 'ethers';
 import { ok } from 'neverthrow';
 import { bytesToHexString, hexStringToBytes } from '../bytes';
 import { Factories } from '../factories';
 import { VerificationEthAddressClaim } from '../verifications';
 import * as eip712 from './eip712';
 
-const wallet = new Wallet(utils.randomBytes(32));
+const wallet = Wallet.createRandom();
 const fid = Factories.Fid.build();
 
 describe('signVerificationEthAddressClaim', () => {
@@ -40,7 +40,7 @@ describe('signVerificationEthAddressClaim', () => {
   });
 
   test('succeeds with checksummed address', async () => {
-    const claim2: VerificationEthAddressClaim = { ...claim, address: utils.getAddress(claim.address) };
+    const claim2: VerificationEthAddressClaim = { ...claim, address: getAddress(claim.address) };
     const signature2 = await eip712.signVerificationEthAddressClaim(claim2, wallet);
     expect(signature2).toEqual(ok(signature));
   });

--- a/packages/utils/src/crypto/eip712.ts
+++ b/packages/utils/src/crypto/eip712.ts
@@ -1,7 +1,6 @@
-import { TypedDataSigner } from '@ethersproject/abstract-signer';
-import { utils } from 'ethers';
-import { Result, ResultAsync } from 'neverthrow';
-import { hexStringToBytes } from '../bytes';
+import { recoverAddress, Signer, TypedDataEncoder } from 'ethers';
+import { err, Result, ResultAsync } from 'neverthrow';
+import { bytesToHexString, hexStringToBytes } from '../bytes';
 import { HubAsyncResult, HubError, HubResult } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
 
@@ -40,14 +39,10 @@ export const EIP_712_FARCASTER_MESSAGE_DATA = [
 
 export const signVerificationEthAddressClaim = async (
   claim: VerificationEthAddressClaim,
-  ethersTypedDataSigner: TypedDataSigner
+  signer: Signer
 ): HubAsyncResult<Uint8Array> => {
   const hexSignature = await ResultAsync.fromPromise(
-    ethersTypedDataSigner._signTypedData(
-      EIP_712_FARCASTER_DOMAIN,
-      { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM },
-      claim
-    ),
+    signer.signTypedData(EIP_712_FARCASTER_DOMAIN, { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM }, claim),
     (e) => new HubError('bad_request.invalid_param', e as Error)
   );
 
@@ -59,14 +54,23 @@ export const verifyVerificationEthAddressClaimSignature = (
   claim: VerificationEthAddressClaim,
   signature: Uint8Array
 ): HubResult<Uint8Array> => {
+  const signatureHexResult = bytesToHexString(signature);
+
+  if (signatureHexResult.isErr()) {
+    return err(signatureHexResult.error);
+  }
+
   // Recover address from signature
   const recoveredHexAddress = Result.fromThrowable(
     () =>
-      utils.verifyTypedData(
-        EIP_712_FARCASTER_DOMAIN,
-        { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM },
-        claim,
-        signature
+      recoverAddress(
+        TypedDataEncoder.hash(
+          EIP_712_FARCASTER_DOMAIN,
+          { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM },
+          claim
+        ),
+
+        signatureHexResult.value
       ),
     (e) => new HubError('bad_request.invalid_param', e as Error)
   )();
@@ -75,16 +79,9 @@ export const verifyVerificationEthAddressClaimSignature = (
   return recoveredHexAddress.andThen((hex) => hexStringToBytes(hex));
 };
 
-export const signMessageHash = async (
-  hash: Uint8Array,
-  ethersTypedDataSigner: TypedDataSigner
-): HubAsyncResult<Uint8Array> => {
+export const signMessageHash = async (hash: Uint8Array, signer: Signer): HubAsyncResult<Uint8Array> => {
   const hexSignature = await ResultAsync.fromPromise(
-    ethersTypedDataSigner._signTypedData(
-      EIP_712_FARCASTER_DOMAIN,
-      { MessageData: EIP_712_FARCASTER_MESSAGE_DATA },
-      { hash }
-    ),
+    signer.signTypedData(EIP_712_FARCASTER_DOMAIN, { MessageData: EIP_712_FARCASTER_MESSAGE_DATA }, { hash }),
     (e) => new HubError('bad_request.invalid_param', e as Error)
   );
 
@@ -93,14 +90,18 @@ export const signMessageHash = async (
 };
 
 export const verifyMessageHashSignature = (hash: Uint8Array, signature: Uint8Array): HubResult<Uint8Array> => {
+  const signatureHexResult = bytesToHexString(signature);
+
+  if (signatureHexResult.isErr()) {
+    return err(signatureHexResult.error);
+  }
+
   // Recover address from signature
   const recoveredHexAddress = Result.fromThrowable(
     () =>
-      utils.verifyTypedData(
-        EIP_712_FARCASTER_DOMAIN,
-        { MessageData: EIP_712_FARCASTER_MESSAGE_DATA },
-        { hash },
-        signature
+      recoverAddress(
+        TypedDataEncoder.hash(EIP_712_FARCASTER_DOMAIN, { MessageData: EIP_712_FARCASTER_MESSAGE_DATA }, { hash }),
+        signatureHexResult.value
       ),
     (e) => new HubError('bad_request.invalid_param', e as Error)
   )();

--- a/packages/utils/src/factories.ts
+++ b/packages/utils/src/factories.ts
@@ -3,7 +3,7 @@ import { Factory } from '@farcaster/fishery';
 import * as protobufs from '@farcaster/protobufs';
 import { utils } from '@noble/ed25519';
 import { blake3 } from '@noble/hashes/blake3';
-import { BigNumber, ethers, Wallet } from 'ethers';
+import { Wallet } from 'ethers';
 import { bytesToHexString } from './bytes';
 import { Ed25519Signer, Eip712Signer, Signer } from './signers';
 import { getFarcasterTime } from './time';
@@ -86,7 +86,7 @@ const Ed25519SignatureFactory = Factory.define<Uint8Array>(() => {
 
 const Eip712SignerFactory = Factory.define<void, { wallet: Wallet }, Eip712Signer>(({ onCreate, transientParams }) => {
   onCreate(async () => {
-    const wallet = transientParams.wallet ?? new ethers.Wallet(utils.randomBytes(32));
+    const wallet = transientParams.wallet ?? Wallet.createRandom();
     const signer = await Eip712Signer.fromSigner(wallet);
     return signer._unsafeUnwrap();
   });
@@ -355,7 +355,7 @@ const VerificationEthAddressClaimFactory = Factory.define<VerificationEthAddress
   const blockHash = bytesToHexString(BlockHashFactory.build())._unsafeUnwrap();
 
   return {
-    fid: BigNumber.from(FidFactory.build()),
+    fid: BigInt(FidFactory.build()),
     address,
     network: FarcasterNetworkFactory.build(),
     blockHash,
@@ -377,7 +377,7 @@ const VerificationAddEthAddressBodyFactory = Factory.define<
       const network = transientParams.network ?? FarcasterNetworkFactory.build();
       const blockHash = bytesToHexString(body.blockHash);
       const claim = VerificationEthAddressClaimFactory.build({
-        fid: BigNumber.from(fid),
+        fid: BigInt(fid),
         network,
         blockHash: blockHash.isOk() ? blockHash.value : '0x',
         address: bytesToHexString(body.address)._unsafeUnwrap(),

--- a/packages/utils/src/signers/ed25519Signer.test.ts
+++ b/packages/utils/src/signers/ed25519Signer.test.ts
@@ -1,5 +1,5 @@
 import { blake3 } from '@noble/hashes/blake3';
-import { randomBytes } from 'ethers/lib/utils';
+import { randomBytes } from 'ethers';
 import { ed25519 } from '../crypto';
 import { Factories } from '../factories';
 import { Ed25519Signer } from './ed25519Signer';

--- a/packages/utils/src/signers/eip712Signer.test.ts
+++ b/packages/utils/src/signers/eip712Signer.test.ts
@@ -1,22 +1,21 @@
 import { FarcasterNetwork } from '@farcaster/protobufs';
 import { blake3 } from '@noble/hashes/blake3';
-import { ethers } from 'ethers';
-import { randomBytes } from 'ethers/lib/utils';
+import { Signer as EthersSigner, Wallet, randomBytes } from 'ethers';
 import { bytesToHexString, hexStringToBytes } from '../bytes';
 import { eip712 } from '../crypto';
 import { Factories } from '../factories';
 import { VerificationEthAddressClaim, makeVerificationEthAddressClaim } from '../verifications';
-import { Eip712Signer, TypedDataSigner } from './eip712Signer';
+import { Eip712Signer } from './eip712Signer';
 
 describe('Eip712Signer', () => {
   let signer: Eip712Signer;
-  let typedDataSigner: TypedDataSigner;
+  let ethersSigner: EthersSigner;
   let ethAddress: string;
 
   beforeAll(async () => {
-    typedDataSigner = new ethers.Wallet(ethers.utils.randomBytes(32));
-    ethAddress = await typedDataSigner.getAddress();
-    signer = (await Eip712Signer.fromSigner(typedDataSigner))._unsafeUnwrap();
+    ethersSigner = Wallet.createRandom();
+    ethAddress = await ethersSigner.getAddress();
+    signer = (await Eip712Signer.fromSigner(ethersSigner))._unsafeUnwrap();
   });
 
   describe('static methods', () => {

--- a/packages/utils/src/signers/eip712Signer.ts
+++ b/packages/utils/src/signers/eip712Signer.ts
@@ -1,16 +1,11 @@
-import {
-  Signer as EthersAbstractSigner,
-  TypedDataSigner as EthersTypedDataSigner,
-} from '@ethersproject/abstract-signer';
 import { SignatureScheme } from '@farcaster/protobufs';
+import { Signer as EthersSigner } from 'ethers';
 import { ResultAsync } from 'neverthrow';
 import { hexStringToBytes } from '../bytes';
 import { eip712 } from '../crypto';
 import { HubAsyncResult, HubError } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
 import { Signer } from './signer';
-
-export type TypedDataSigner = EthersAbstractSigner & EthersTypedDataSigner;
 
 export class Eip712Signer implements Signer {
   /** Signature scheme as defined in protobufs */
@@ -19,27 +14,26 @@ export class Eip712Signer implements Signer {
   /** 20-byte wallet address */
   public readonly signerKey: Uint8Array;
 
-  private readonly _typedDataSigner: TypedDataSigner;
+  private readonly _ethersSigner: EthersSigner;
 
-  public static async fromSigner(typedDataSigner: TypedDataSigner): HubAsyncResult<Eip712Signer> {
-    return ResultAsync.fromPromise(
-      typedDataSigner.getAddress(),
-      (error) => new HubError('unknown', error as Error)
-    ).andThen((address) => {
-      return hexStringToBytes(address).map((signerKey) => new this(typedDataSigner, signerKey));
-    });
+  public static async fromSigner(signer: EthersSigner): HubAsyncResult<Eip712Signer> {
+    return ResultAsync.fromPromise(signer.getAddress(), (error) => new HubError('unknown', error as Error)).andThen(
+      (address) => {
+        return hexStringToBytes(address).map((signerKey) => new this(signer, signerKey));
+      }
+    );
   }
 
-  constructor(typedDataSigner: TypedDataSigner, signerKey: Uint8Array) {
-    this._typedDataSigner = typedDataSigner;
+  constructor(signer: EthersSigner, signerKey: Uint8Array) {
+    this._ethersSigner = signer;
     this.signerKey = signerKey;
   }
 
   public signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array> {
-    return eip712.signMessageHash(hash, this._typedDataSigner);
+    return eip712.signMessageHash(hash, this._ethersSigner);
   }
 
   public signVerificationEthAddressClaim(claim: VerificationEthAddressClaim): HubAsyncResult<Uint8Array> {
-    return eip712.signVerificationEthAddressClaim(claim, this._typedDataSigner);
+    return eip712.signVerificationEthAddressClaim(claim, this._ethersSigner);
   }
 }

--- a/packages/utils/src/verifications.ts
+++ b/packages/utils/src/verifications.ts
@@ -1,12 +1,11 @@
 import { FarcasterNetwork } from '@farcaster/protobufs';
-import { BigNumber } from 'ethers';
 import { err, ok } from 'neverthrow';
 import { bytesToHexString } from './bytes';
 import { HubResult } from './errors';
 import { validateEthAddress, validateEthBlockHash } from './validations';
 
 export type VerificationEthAddressClaim = {
-  fid: BigNumber;
+  fid: bigint;
   address: string; // Hex string
   network: FarcasterNetwork;
   blockHash: string; // Hex string
@@ -33,7 +32,7 @@ export const makeVerificationEthAddressClaim = (
   }
 
   return ok({
-    fid: BigNumber.from(fid),
+    fid: BigInt(fid),
     address: ethAddressHex.value,
     network: network,
     blockHash: blockHashHex.value,

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,6 +35,11 @@
     uuid "^8.3.2"
     xml2js "^0.4.23"
 
+"@adraffy/ens-normalize@1.8.9":
+  version "1.8.9"
+  resolved "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.8.9.tgz#67b3acadebbb551669c9a1da15fac951db795b85"
+  integrity sha512-93OmGCV0vO8+JQ3FHG+gZk/MPHzzMPDRiCiFcCQNTCnHaaxsacO3ScTPGlu2wX2dOtgfalbchPcw1cOYYjHCYQ==
+
 "@ampproject/remapping@^2.2.0":
   version "2.2.0"
   resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -781,348 +786,6 @@
   version "8.36.0"
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz#9837f768c03a1e4a30bd304a64fb8844f0e72efe"
   integrity sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==
-
-"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
-  integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
-  dependencies:
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/hash" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/strings" "^5.7.0"
-
-"@ethersproject/abstract-provider@5.7.0", "@ethersproject/abstract-provider@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
-  integrity sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==
-  dependencies:
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/networks" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/transactions" "^5.7.0"
-    "@ethersproject/web" "^5.7.0"
-
-"@ethersproject/abstract-signer@5.7.0", "@ethersproject/abstract-signer@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
-  integrity sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==
-  dependencies:
-    "@ethersproject/abstract-provider" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-
-"@ethersproject/address@5.7.0", "@ethersproject/address@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
-  integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
-  dependencies:
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/rlp" "^5.7.0"
-
-"@ethersproject/base64@5.7.0", "@ethersproject/base64@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
-  integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
-  dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-
-"@ethersproject/basex@5.7.0", "@ethersproject/basex@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz#97034dc7e8938a8ca943ab20f8a5e492ece4020b"
-  integrity sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==
-  dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-
-"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
-  integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
-  dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    bn.js "^5.2.1"
-
-"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
-  integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
-  dependencies:
-    "@ethersproject/logger" "^5.7.0"
-
-"@ethersproject/constants@5.7.0", "@ethersproject/constants@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
-  integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
-  dependencies:
-    "@ethersproject/bignumber" "^5.7.0"
-
-"@ethersproject/contracts@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
-  integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
-  dependencies:
-    "@ethersproject/abi" "^5.7.0"
-    "@ethersproject/abstract-provider" "^5.7.0"
-    "@ethersproject/abstract-signer" "^5.7.0"
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/transactions" "^5.7.0"
-
-"@ethersproject/hash@5.7.0", "@ethersproject/hash@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
-  integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==
-  dependencies:
-    "@ethersproject/abstract-signer" "^5.7.0"
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/base64" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/strings" "^5.7.0"
-
-"@ethersproject/hdnode@5.7.0", "@ethersproject/hdnode@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz#e627ddc6b466bc77aebf1a6b9e47405ca5aef9cf"
-  integrity sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==
-  dependencies:
-    "@ethersproject/abstract-signer" "^5.7.0"
-    "@ethersproject/basex" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/pbkdf2" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/sha2" "^5.7.0"
-    "@ethersproject/signing-key" "^5.7.0"
-    "@ethersproject/strings" "^5.7.0"
-    "@ethersproject/transactions" "^5.7.0"
-    "@ethersproject/wordlists" "^5.7.0"
-
-"@ethersproject/json-wallets@5.7.0", "@ethersproject/json-wallets@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz#5e3355287b548c32b368d91014919ebebddd5360"
-  integrity sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==
-  dependencies:
-    "@ethersproject/abstract-signer" "^5.7.0"
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/hdnode" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/pbkdf2" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/random" "^5.7.0"
-    "@ethersproject/strings" "^5.7.0"
-    "@ethersproject/transactions" "^5.7.0"
-    aes-js "3.0.0"
-    scrypt-js "3.0.1"
-
-"@ethersproject/keccak256@5.7.0", "@ethersproject/keccak256@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
-  integrity sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==
-  dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    js-sha3 "0.8.0"
-
-"@ethersproject/logger@5.7.0", "@ethersproject/logger@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
-  integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
-
-"@ethersproject/networks@5.7.1", "@ethersproject/networks@^5.7.0":
-  version "5.7.1"
-  resolved "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz#118e1a981d757d45ccea6bb58d9fd3d9db14ead6"
-  integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
-  dependencies:
-    "@ethersproject/logger" "^5.7.0"
-
-"@ethersproject/pbkdf2@5.7.0", "@ethersproject/pbkdf2@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz#d2267d0a1f6e123f3771007338c47cccd83d3102"
-  integrity sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==
-  dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/sha2" "^5.7.0"
-
-"@ethersproject/properties@5.7.0", "@ethersproject/properties@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
-  integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
-  dependencies:
-    "@ethersproject/logger" "^5.7.0"
-
-"@ethersproject/providers@5.7.2":
-  version "5.7.2"
-  resolved "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
-  integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
-  dependencies:
-    "@ethersproject/abstract-provider" "^5.7.0"
-    "@ethersproject/abstract-signer" "^5.7.0"
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/base64" "^5.7.0"
-    "@ethersproject/basex" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/hash" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/networks" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/random" "^5.7.0"
-    "@ethersproject/rlp" "^5.7.0"
-    "@ethersproject/sha2" "^5.7.0"
-    "@ethersproject/strings" "^5.7.0"
-    "@ethersproject/transactions" "^5.7.0"
-    "@ethersproject/web" "^5.7.0"
-    bech32 "1.1.4"
-    ws "7.4.6"
-
-"@ethersproject/random@5.7.0", "@ethersproject/random@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
-  integrity sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==
-  dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-
-"@ethersproject/rlp@5.7.0", "@ethersproject/rlp@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz#de39e4d5918b9d74d46de93af80b7685a9c21304"
-  integrity sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==
-  dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-
-"@ethersproject/sha2@5.7.0", "@ethersproject/sha2@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
-  integrity sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==
-  dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    hash.js "1.1.7"
-
-"@ethersproject/signing-key@5.7.0", "@ethersproject/signing-key@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"
-  integrity sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==
-  dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    bn.js "^5.2.1"
-    elliptic "6.5.4"
-    hash.js "1.1.7"
-
-"@ethersproject/solidity@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz#5e9c911d8a2acce2a5ebb48a5e2e0af20b631cb8"
-  integrity sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==
-  dependencies:
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/sha2" "^5.7.0"
-    "@ethersproject/strings" "^5.7.0"
-
-"@ethersproject/strings@5.7.0", "@ethersproject/strings@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
-  integrity sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==
-  dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-
-"@ethersproject/transactions@5.7.0", "@ethersproject/transactions@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
-  integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
-  dependencies:
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/rlp" "^5.7.0"
-    "@ethersproject/signing-key" "^5.7.0"
-
-"@ethersproject/units@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz#637b563d7e14f42deeee39245275d477aae1d8b1"
-  integrity sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==
-  dependencies:
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-
-"@ethersproject/wallet@5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz#4e5d0790d96fe21d61d38fb40324e6c7ef350b2d"
-  integrity sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==
-  dependencies:
-    "@ethersproject/abstract-provider" "^5.7.0"
-    "@ethersproject/abstract-signer" "^5.7.0"
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/hash" "^5.7.0"
-    "@ethersproject/hdnode" "^5.7.0"
-    "@ethersproject/json-wallets" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/random" "^5.7.0"
-    "@ethersproject/signing-key" "^5.7.0"
-    "@ethersproject/transactions" "^5.7.0"
-    "@ethersproject/wordlists" "^5.7.0"
-
-"@ethersproject/web@5.7.1", "@ethersproject/web@^5.7.0":
-  version "5.7.1"
-  resolved "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
-  integrity sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==
-  dependencies:
-    "@ethersproject/base64" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/strings" "^5.7.0"
-
-"@ethersproject/wordlists@5.7.0", "@ethersproject/wordlists@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz#8fb2c07185d68c3e09eb3bfd6e779ba2774627f5"
-  integrity sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==
-  dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/hash" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/strings" "^5.7.0"
 
 "@faker-js/faker@^7.6.0", "@faker-js/faker@~7.6.0":
   version "7.6.0"
@@ -1980,12 +1643,17 @@
   resolved "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz#57e1677bf6885354b466c38e2b620c62f45a7123"
   integrity sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==
 
+"@noble/hashes@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
+  integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
+
 "@noble/hashes@^1.3.0":
   version "1.3.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
   integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
 
-"@noble/secp256k1@^1.5.4":
+"@noble/secp256k1@1.7.1", "@noble/secp256k1@^1.5.4":
   version "1.7.1"
   resolved "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
   integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
@@ -2662,10 +2330,10 @@ acorn@^8.4.1, acorn@^8.8.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
-aes-js@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
-  integrity sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==
+aes-js@4.0.0-beta.3:
+  version "4.0.0-beta.3"
+  resolved "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.3.tgz#da2253f0ff03a0b3a9e445c8cbdf78e7fda7d48c"
+  integrity sha512-/xJX0/VTPcbc5xQE2VUP91y1xN8q/rDfhEzLm+vLc3hYvb5+qHCnpJRuFcrKn63zumK/sCwYYzhG8HP78JYSTA==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -2881,11 +2549,6 @@ base64-js@^1.3.1:
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-bech32@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
-  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
-
 benchmark@^2.1.4:
   version "2.1.4"
   resolved "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
@@ -2931,16 +2594,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-bn.js@^4.11.9:
-  version "4.12.0"
-  resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
-  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
-
-bn.js@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
-  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -2969,11 +2622,6 @@ breakword@^1.0.5:
   integrity sha512-ex5W9DoOQ/LUEU3PMdLs9ua/CYZl1678NUkKOdUSi8Aw5F1idieaiRURCBFJCwVcrD1J8Iy3vfWSloaMwO2qFg==
   dependencies:
     wcwidth "^1.0.1"
-
-brorand@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
-  integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
 
 browserslist@^4.21.3:
   version "4.21.5"
@@ -3527,19 +3175,6 @@ electron-to-chromium@^1.4.284:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.332.tgz#b981fcf61587abe03c24b301b2cfbdcc2b70e8a5"
   integrity sha512-c1Vbv5tuUlBFp0mb3mCIjw+REEsgthRgNE8BlbEDKmvzb8rxjcVki6OkQP83vLN34s0XCxpSkq7AZNep1a6xhw==
 
-elliptic@6.5.4:
-  version "6.5.4"
-  resolved "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
-  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
-  dependencies:
-    bn.js "^4.11.9"
-    brorand "^1.1.0"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.1"
-    inherits "^2.0.4"
-    minimalistic-assert "^1.0.1"
-    minimalistic-crypto-utils "^1.0.1"
-
 emittery@^0.13.1:
   version "0.13.1"
   resolved "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
@@ -3972,41 +3607,17 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-ethers@^5.7.2, ethers@~5.7.2:
-  version "5.7.2"
-  resolved "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
-  integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
+ethers@~6.1.0:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/ethers/-/ethers-6.1.0.tgz#de9c3acbb865fda6c080e80ec88ae0aada046947"
+  integrity sha512-aC45YGbvgXt7Nses5WsdQwc1cUIrrQt32zeFShNW7ZT3RQCIHBnd4nmbE5sJmrp70uTdwkRHkr4cZr1D/YwFPg==
   dependencies:
-    "@ethersproject/abi" "5.7.0"
-    "@ethersproject/abstract-provider" "5.7.0"
-    "@ethersproject/abstract-signer" "5.7.0"
-    "@ethersproject/address" "5.7.0"
-    "@ethersproject/base64" "5.7.0"
-    "@ethersproject/basex" "5.7.0"
-    "@ethersproject/bignumber" "5.7.0"
-    "@ethersproject/bytes" "5.7.0"
-    "@ethersproject/constants" "5.7.0"
-    "@ethersproject/contracts" "5.7.0"
-    "@ethersproject/hash" "5.7.0"
-    "@ethersproject/hdnode" "5.7.0"
-    "@ethersproject/json-wallets" "5.7.0"
-    "@ethersproject/keccak256" "5.7.0"
-    "@ethersproject/logger" "5.7.0"
-    "@ethersproject/networks" "5.7.1"
-    "@ethersproject/pbkdf2" "5.7.0"
-    "@ethersproject/properties" "5.7.0"
-    "@ethersproject/providers" "5.7.2"
-    "@ethersproject/random" "5.7.0"
-    "@ethersproject/rlp" "5.7.0"
-    "@ethersproject/sha2" "5.7.0"
-    "@ethersproject/signing-key" "5.7.0"
-    "@ethersproject/solidity" "5.7.0"
-    "@ethersproject/strings" "5.7.0"
-    "@ethersproject/transactions" "5.7.0"
-    "@ethersproject/units" "5.7.0"
-    "@ethersproject/wallet" "5.7.0"
-    "@ethersproject/web" "5.7.1"
-    "@ethersproject/wordlists" "5.7.0"
+    "@adraffy/ens-normalize" "1.8.9"
+    "@noble/hashes" "1.1.2"
+    "@noble/secp256k1" "1.7.1"
+    aes-js "4.0.0-beta.3"
+    tslib "2.4.0"
+    ws "8.5.0"
 
 event-iterator@^2.0.0:
   version "2.0.0"
@@ -4580,14 +4191,6 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.7"
-  resolved "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
-  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
-  dependencies:
-    inherits "^2.0.3"
-    minimalistic-assert "^1.0.1"
-
 hashlru@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz#5dc15928b3f6961a2056416bb3a4910216fdfb51"
@@ -4600,15 +4203,6 @@ help-me@^4.0.1:
   dependencies:
     glob "^8.0.0"
     readable-stream "^3.6.0"
-
-hmac-drbg@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
-  integrity sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==
-  dependencies:
-    hash.js "^1.0.3"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.1"
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -4704,7 +4298,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -5505,11 +5099,6 @@ js-sdsl@^4.1.4:
   resolved "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz#aeefe32a451f7af88425b11fdb5f58c90ae1d711"
   integrity sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==
 
-js-sha3@0.8.0:
-  version "0.8.0"
-  resolved "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
-  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -5960,16 +5549,6 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
-
-minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
-  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
-
-minimalistic-crypto-utils@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
-  integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
@@ -6985,11 +6564,6 @@ sax@>=0.6.0:
   resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scrypt-js@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
-  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
-
 secure-json-parse@^2.4.0:
   version "2.7.0"
   resolved "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
@@ -7586,6 +7160,11 @@ ts-proto@^1.142.1:
     ts-poet "^6.4.1"
     ts-proto-descriptors "1.7.1"
 
+tslib@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -7964,10 +7543,10 @@ write-file-atomic@^4.0.2:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
 
-ws@7.4.6:
-  version "7.4.6"
-  resolved "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
-  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
+ws@8.5.0:
+  version "8.5.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
+  integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
 
 xml2js@^0.4.23:
   version "0.4.23"


### PR DESCRIPTION
## Motivation

- Ethers v6 uses noble crypto instead of elliptic, which avoids issues [like this one](https://github.com/indutny/elliptic/issues/301) (cc @CassOnMars) 
- Ethers v6 will introduce breaking changes to our library so best to get it out before launch vs after. 

The downside is that we may be introducing some last minute bugs here which can go undetected, so I'd like to get some second opinions from folks working in the codebase. 

## Change Summary

The most significant changes being made are: 

**JS BigInt instead of Ethers.BigNum**
BigInt seems like a drop in replacement except for the fact that serialization returns odd-length hex values like 0x3e8 instead of 0x03e8. In some cases this needs to be sanitized because parts of our codebase expect even length values. 

**Providers are very different under the hood**
The internals of Providers have been refactored significantly. Providers now inherit from an AbstractProvider class and polling logic is handled explicitly by a Subscription. Since we used to reach into providers and modify polling behavior manually, this needs to be refactored carefully. 

**TypedDataSigner and verifyTypedData no longer exist**
TypedDataSigner is superseded by the new Signer class and verifyTypedData no longer seems to exist for EIP712 verifications, which means we must perform signature recovery using more manual steps. 

There are also some minor changes: 

- Utilities and most exports [now happen at the top level](https://docs.ethers.org/v6/migrating/#migrate-utils)
- Types returned by Contracts and their listeners have changed slightly 
- Using `Wallet.createRandom()` instead of `new Wallet(utils.randomBytes(32))` which has existed since v5, not sure if there's a reason we were doing this or just an omission.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
