### PR TITLE
fix: Fix memory leak in prune messages job

### DIFF
--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -35,7 +35,7 @@ describe('MerkleTrie', () => {
     let count = 0;
     for await (const [key, value] of db.iteratorByPrefix(Buffer.from([RootPrefix.SyncMerkleTrieNode]))) {
       if (callback) {
-        await callback(count, key, value);
+        await callback(count, key as Buffer, value as Buffer);
       }
       count++;
     }

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -188,11 +188,7 @@ export const getMessagesPageByPrefix = async <T extends protobufs.Message>(
   });
 
   const getNextIteratorRecord = async (iterator: Iterator): Promise<[Buffer, protobufs.Message]> => {
-    const record = await iterator.next();
-    if (record === undefined) {
-      throw new HubError('not_found', 'record not found');
-    }
-    const [key, value] = record;
+    const [key, value] = await iterator.next();
     return [key as Buffer, protobufs.Message.decode(new Uint8Array(value as Buffer))];
   };
 
@@ -262,11 +258,7 @@ export const getMessagesPruneIterator = (db: RocksDB, fid: number, setPostfix: U
 };
 
 export const getNextMessageFromIterator = async (iterator: Iterator): Promise<protobufs.Message> => {
-  const record = await iterator.next();
-  if (record === undefined) {
-    throw new HubError('not_found', 'record not found');
-  }
-  const [, value] = record;
+  const [, value] = await iterator.next();
   return protobufs.Message.decode(new Uint8Array(value as Buffer));
 };
 

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -209,7 +209,7 @@ export const getMessagesPageByPrefix = async <T extends protobufs.Message>(
   } while (messages.length < limit);
 
   if (!iteratorFinished) {
-    await iterator.end(); // Clear iterator if it has not finished
+    await iterator.end(); // clear iterator if it has not finished
     return { messages, nextPageToken: lastPageToken };
   } else {
     return { messages, nextPageToken: undefined };

--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -209,6 +209,7 @@ export const getMessagesPageByPrefix = async <T extends protobufs.Message>(
   } while (messages.length < limit);
 
   if (!iteratorFinished) {
+    await iterator.end(); // Clear iterator if it has not finished
     return { messages, nextPageToken: lastPageToken };
   } else {
     return { messages, nextPageToken: undefined };

--- a/apps/hubble/src/storage/db/nameRegistryEvent.test.ts
+++ b/apps/hubble/src/storage/db/nameRegistryEvent.test.ts
@@ -61,6 +61,8 @@ describe('putNameRegistryEvent', () => {
     const byExpiryIterator = getNameRegistryEventsByExpiryIterator(db);
     const eventByExpiry = await getNextNameRegistryEventByExpiry(byExpiryIterator);
     expect(eventByExpiry).toEqual(nameRegistryEvent);
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    byExpiryIterator.end(() => {});
   });
 });
 
@@ -74,6 +76,8 @@ describe('deleteNameRegistryEvent', () => {
 
     const byExpiryIterator = getNameRegistryEventsByExpiryIterator(db);
     await expect(getNextNameRegistryEventByExpiry(byExpiryIterator)).rejects.toEqual(undefined);
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    byExpiryIterator.end(() => {});
   });
 });
 

--- a/apps/hubble/src/storage/db/nameRegistryEvent.test.ts
+++ b/apps/hubble/src/storage/db/nameRegistryEvent.test.ts
@@ -4,7 +4,7 @@ import {
   deleteNameRegistryEvent,
   getNameRegistryEvent,
   getNameRegistryEventsByExpiryIterator,
-  getNextNameRegistryEventByExpiry,
+  getNextNameRegistryEventFromIterator,
   makeNameRegistryEventByExpiryKey,
   makeNameRegistryEventPrimaryKey,
   putNameRegistryEvent,
@@ -24,8 +24,8 @@ describe('makeNameRegistryEventPrimaryKey', () => {
       await db.put(key, Buffer.from(bytes));
     }
     const orderedValues = [];
-    for await (const [, value] of db.iterator({ keys: false, valueAsBuffer: true })) {
-      orderedValues.push(bytesToUtf8String(Uint8Array.from(value))._unsafeUnwrap());
+    for await (const [, value] of db.iterator({ keys: false })) {
+      orderedValues.push(bytesToUtf8String(Uint8Array.from(value as Buffer))._unsafeUnwrap());
     }
     expect(orderedValues).toEqual(names);
   });
@@ -46,8 +46,8 @@ describe('makeNameRegistryEventByExpiryKey', () => {
       await db.put(key, Buffer.from(bytes));
     }
     const orderedValues = [];
-    for await (const [, value] of db.iterator({ keys: false, valueAsBuffer: true })) {
-      orderedValues.push(bytesToUtf8String(Uint8Array.from(value))._unsafeUnwrap());
+    for await (const [, value] of db.iterator({ keys: false })) {
+      orderedValues.push(bytesToUtf8String(Uint8Array.from(value as Buffer))._unsafeUnwrap());
     }
     expect(orderedValues).toEqual(['b', 'a', 'c', 'd', 'e']);
   });
@@ -59,10 +59,9 @@ describe('putNameRegistryEvent', () => {
     await expect(getNameRegistryEvent(db, nameRegistryEvent.fname)).resolves.toEqual(nameRegistryEvent);
 
     const byExpiryIterator = getNameRegistryEventsByExpiryIterator(db);
-    const eventByExpiry = await getNextNameRegistryEventByExpiry(byExpiryIterator);
+    const eventByExpiry = await getNextNameRegistryEventFromIterator(byExpiryIterator);
     expect(eventByExpiry).toEqual(nameRegistryEvent);
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    byExpiryIterator.end(() => {});
+    await byExpiryIterator.end();
   });
 });
 
@@ -75,9 +74,8 @@ describe('deleteNameRegistryEvent', () => {
     await expect(getNameRegistryEvent(db, nameRegistryEvent.fname)).rejects.toThrow();
 
     const byExpiryIterator = getNameRegistryEventsByExpiryIterator(db);
-    await expect(getNextNameRegistryEventByExpiry(byExpiryIterator)).rejects.toEqual(undefined);
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    byExpiryIterator.end(() => {});
+    await expect(getNextNameRegistryEventFromIterator(byExpiryIterator)).rejects.toThrow();
+    await byExpiryIterator.end();
   });
 });
 

--- a/apps/hubble/src/storage/db/nameRegistryEvent.ts
+++ b/apps/hubble/src/storage/db/nameRegistryEvent.ts
@@ -1,5 +1,4 @@
 import { NameRegistryEvent } from '@farcaster/protobufs';
-import { HubError } from '~/../../../packages/utils/dist';
 import RocksDB, { Iterator, Transaction } from '~/storage/db/rocksdb';
 import { RootPrefix } from '~/storage/db/types';
 
@@ -31,11 +30,7 @@ export const getNameRegistryEventsByExpiryIterator = (db: RocksDB): Iterator => 
 };
 
 export const getNextNameRegistryEventFromIterator = async (iterator: Iterator): Promise<NameRegistryEvent> => {
-  const record = await iterator.next();
-  if (!record) {
-    throw new HubError('not_found', 'record not found');
-  }
-  const [, value] = record;
+  const [, value] = await iterator.next();
   return NameRegistryEvent.decode(Uint8Array.from(value as Buffer));
 };
 

--- a/apps/hubble/src/storage/db/nameRegistryEvent.ts
+++ b/apps/hubble/src/storage/db/nameRegistryEvent.ts
@@ -1,6 +1,6 @@
 import { NameRegistryEvent } from '@farcaster/protobufs';
-import AbstractRocksDB from 'rocksdb';
-import RocksDB, { Transaction } from '~/storage/db/rocksdb';
+import { HubError } from '~/../../../packages/utils/dist';
+import RocksDB, { Iterator, Transaction } from '~/storage/db/rocksdb';
 import { RootPrefix } from '~/storage/db/types';
 
 const EXPIRY_BYTES = 4;
@@ -25,21 +25,18 @@ export const getNameRegistryEvent = async (db: RocksDB, fname: Uint8Array): Prom
   return NameRegistryEvent.decode(new Uint8Array(buffer));
 };
 
-export const getNameRegistryEventsByExpiryIterator = (db: RocksDB): AbstractRocksDB.Iterator => {
+export const getNameRegistryEventsByExpiryIterator = (db: RocksDB): Iterator => {
   const prefix = Buffer.from([RootPrefix.NameRegistryEventsByExpiry]);
-  return db.iteratorByPrefix(prefix, { keys: false, valueAsBuffer: true });
+  return db.iteratorByPrefix(prefix, { keys: false });
 };
 
-export const getNextNameRegistryEventByExpiry = (iterator: AbstractRocksDB.Iterator): Promise<NameRegistryEvent> => {
-  return new Promise((resolve, reject) => {
-    iterator.next((err: Error | undefined, _: AbstractRocksDB.Bytes, value: AbstractRocksDB.Bytes) => {
-      if (err || !value) {
-        reject(err);
-      } else {
-        resolve(NameRegistryEvent.decode(new Uint8Array(value as Buffer)));
-      }
-    });
-  });
+export const getNextNameRegistryEventFromIterator = async (iterator: Iterator): Promise<NameRegistryEvent> => {
+  const record = await iterator.next();
+  if (!record) {
+    throw new HubError('not_found', 'record not found');
+  }
+  const [, value] = record;
+  return NameRegistryEvent.decode(Uint8Array.from(value as Buffer));
 };
 
 export const putNameRegistryEvent = (db: RocksDB, event: NameRegistryEvent): Promise<void> => {

--- a/apps/hubble/src/storage/db/rocksdb.test.ts
+++ b/apps/hubble/src/storage/db/rocksdb.test.ts
@@ -175,10 +175,7 @@ describe('with db', () => {
       await db.put(Buffer.from('bobprefix!a'), Buffer.from('bar'));
       await db.put(Buffer.from('prefix!a'), Buffer.from('bar'));
       const output = [];
-      for await (const [key, value] of db.iteratorByPrefix(Buffer.from('aliceprefix!'), {
-        keyAsBuffer: true,
-        valueAsBuffer: true,
-      })) {
+      for await (const [key, value] of db.iteratorByPrefix(Buffer.from('aliceprefix!'))) {
         output.push([key, value]);
       }
       expect(output).toEqual([
@@ -199,10 +196,10 @@ describe('with db', () => {
       await db.commit(tsx);
 
       const values = [];
-      for await (const [, value] of db.iteratorByPrefix(Buffer.from([1, 255]), { keys: false, valueAsBuffer: false })) {
+      for await (const [, value] of db.iteratorByPrefix(Buffer.from([1, 255]), { keys: false })) {
         values.push(value);
       }
-      expect(values).toEqual(['a', 'b']);
+      expect(values).toEqual([Buffer.from('a'), Buffer.from('b')]);
     });
 
     test('succeeds with single byte prefix', async () => {
@@ -217,10 +214,10 @@ describe('with db', () => {
       await db.commit(tsx);
 
       const values = [];
-      for await (const [, value] of db.iteratorByPrefix(Buffer.from([255]), { keys: false, valueAsBuffer: false })) {
+      for await (const [, value] of db.iteratorByPrefix(Buffer.from([255]), { keys: false })) {
         values.push(value);
       }
-      expect(values).toEqual(['a', 'b']);
+      expect(values).toEqual([Buffer.from('a'), Buffer.from('b')]);
     });
   });
 });

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
@@ -4,7 +4,7 @@ import cron from 'node-cron';
 import Engine from '~/storage/engine';
 import { logger } from '~/utils/logger';
 
-export const DEFAULT_PRUNE_MESSAGES_JOB_CRON = '* * * * *'; // Every hour at :00
+export const DEFAULT_PRUNE_MESSAGES_JOB_CRON = '0 * * * *'; // Every hour at :00
 
 const log = logger.child({
   component: 'PruneMessagesJob',

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
@@ -4,7 +4,7 @@ import cron from 'node-cron';
 import Engine from '~/storage/engine';
 import { logger } from '~/utils/logger';
 
-export const DEFAULT_PRUNE_MESSAGES_JOB_CRON = '0 * * * *'; // Every hour at :00
+export const DEFAULT_PRUNE_MESSAGES_JOB_CRON = '* * * * *'; // Every hour at :00
 
 const log = logger.child({
   component: 'PruneMessagesJob',

--- a/apps/hubble/src/storage/jobs/updateNameRegistryEventExpiryJob.ts
+++ b/apps/hubble/src/storage/jobs/updateNameRegistryEventExpiryJob.ts
@@ -11,10 +11,9 @@ import {
 } from '@farcaster/utils';
 import { blake3 } from '@noble/hashes/blake3';
 import { err, ok, Result, ResultAsync } from 'neverthrow';
-import AbstractRocksDB from 'rocksdb';
 import { TypedEmitter } from 'tiny-typed-emitter';
 import { EthEventsProvider } from '~/eth/ethEventsProvider';
-import RocksDB from '~/storage/db/rocksdb';
+import RocksDB, { Iterator } from '~/storage/db/rocksdb';
 import { logger, nameRegistryEventToLog } from '~/utils/logger';
 import { getNameRegistryEvent, putNameRegistryEvent } from '../db/nameRegistryEvent';
 import { RootPrefix } from '../db/types';
@@ -151,7 +150,7 @@ export class UpdateNameRegistryEventExpiryJobQueue extends TypedEmitter<JobQueue
   }
 
   /** Return rocksdb iterator for revoke signer jobs. If doBefore timestamp is missing, iterate over all jobs  */
-  iterator(doBefore?: number): HubResult<AbstractRocksDB.Iterator> {
+  iterator(doBefore?: number): HubResult<Iterator> {
     const gte = UpdateNameRegistryEventExpiryJobQueue.jobKeyPrefix();
     let lt: Buffer;
     if (doBefore) {
@@ -208,27 +207,29 @@ export class UpdateNameRegistryEventExpiryJobQueue extends TypedEmitter<JobQueue
     if (iterator.isErr()) {
       return err(iterator.error);
     }
-    return new Promise((resolve) => {
-      iterator.value.next(async (e: Error | undefined, key: AbstractRocksDB.Bytes, value: AbstractRocksDB.Bytes) => {
-        if (e) {
-          resolve(err(new HubError('unknown', e as Error)));
-        } else if (!key && !value) {
-          resolve(err(new HubError('not_found', 'record not found')));
-        } else {
-          const payload = Result.fromThrowable(
-            () => protobufs.UpdateNameRegistryEventExpiryJobPayload.decode(Uint8Array.from(value as Buffer)),
-            (err) =>
-              new HubError('bad_request.parse_failure', {
-                cause: err as Error,
-                message: `Failed to parse UpdateNameRegistryEventExpiryJobPayload`,
-              })
-          )();
-          // Delete job from rocksdb to prevent it from being done multiple times
-          await this._db.del(key as Buffer);
-          resolve(payload);
-        }
-      });
-    });
+
+    const result = await ResultAsync.fromPromise(iterator.value.next(), (e) => e as HubError);
+    if (result.isErr()) {
+      return err(result.error);
+    }
+
+    const [key, value] = result.value;
+
+    const payload = Result.fromThrowable(
+      () => protobufs.UpdateNameRegistryEventExpiryJobPayload.decode(Uint8Array.from(value as Buffer)),
+      (err) =>
+        new HubError('bad_request.parse_failure', {
+          cause: err as Error,
+          message: `Failed to parse UpdateNameRegistryEventExpiryJobPayload`,
+        })
+    )();
+
+    // clear rocksdb iterator
+    await iterator.value.end();
+    // Delete job from rocksdb to prevent it from being done multiple times
+    await this._db.del(key as Buffer);
+
+    return payload;
   }
 
   async getAllJobs(doBefore?: number): HubAsyncResult<[number, protobufs.UpdateNameRegistryEventExpiryJobPayload][]> {
@@ -239,7 +240,7 @@ export class UpdateNameRegistryEventExpiryJobQueue extends TypedEmitter<JobQueue
     }
     for await (const [key, value] of iterator.value) {
       const timestamp = UpdateNameRegistryEventExpiryJobQueue.jobKeyToTimestamp(key as Buffer);
-      const payload = protobufs.UpdateNameRegistryEventExpiryJobPayload.decode(Uint8Array.from(value));
+      const payload = protobufs.UpdateNameRegistryEventExpiryJobPayload.decode(Uint8Array.from(value as Buffer));
       if (timestamp.isOk()) {
         jobs.push([timestamp.value, payload]);
       }

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -229,6 +229,7 @@ class CastStore {
     const messages = await getManyMessages<protobufs.CastAddMessage>(this._db, messageKeys);
 
     if (!iteratorFinished) {
+      await iterator.end(); // clear iterator if it has not finished
       return { messages, nextPageToken: lastPageToken };
     } else {
       return { messages, nextPageToken: undefined };
@@ -289,6 +290,7 @@ class CastStore {
     const messages = await getManyMessages<protobufs.CastAddMessage>(this._db, messageKeys);
 
     if (!iteratorFinished) {
+      await iterator.end(); // clear iterator if it has not finished
       return { messages, nextPageToken: lastPageToken };
     } else {
       return { messages, nextPageToken: undefined };

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -453,6 +453,10 @@ class CastStore {
       nextMessage = await getNextResult();
     }
 
+    // Close the iterator
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    pruneIterator.end(() => {});
+
     if (events.length > 0) {
       // Commit the transaction to rocksdb
       await this._db.commit(pruneTxn);

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -2,7 +2,6 @@ import * as protobufs from '@farcaster/protobufs';
 import { bytesCompare, bytesIncrement, getFarcasterTime, HubAsyncResult, HubError, isHubError } from '@farcaster/utils';
 import AsyncLock from 'async-lock';
 import { err, ok, ResultAsync } from 'neverthrow';
-import AbstractRocksDB from 'rocksdb';
 import {
   deleteMessageTransaction,
   getAllMessagesBySigner,
@@ -10,7 +9,7 @@ import {
   getMessage,
   getMessagesPageByPrefix,
   getMessagesPruneIterator,
-  getNextMessageToPrune,
+  getNextMessageFromIterator,
   makeCastIdKey,
   makeFidKey,
   makeMessagePrimaryKey,
@@ -18,7 +17,7 @@ import {
   makeUserKey,
   putMessageTransaction,
 } from '~/storage/db/message';
-import RocksDB, { Transaction } from '~/storage/db/rocksdb';
+import RocksDB, { Iterator, Transaction } from '~/storage/db/rocksdb';
 import { FID_BYTES, RootPrefix, TRUE_VALUE, UserPostfix } from '~/storage/db/types';
 import StoreEventHandler, { putEventTransaction } from '~/storage/stores/storeEventHandler';
 import {
@@ -205,19 +204,16 @@ class CastStore {
     });
 
     // Custom method to retrieve message key from key
-    const getNextIteratorRecord = (iterator: AbstractRocksDB.Iterator): Promise<[Buffer, Buffer]> => {
-      return new Promise((resolve, reject) => {
-        iterator.next((err: Error | undefined, key: AbstractRocksDB.Bytes, value: AbstractRocksDB.Bytes) => {
-          if (err || !value) {
-            reject(err);
-          } else {
-            const fid = Number((key as Buffer).readUint32BE(prefix.length));
-            const tsHash = Uint8Array.from(key as Buffer).subarray(prefix.length + FID_BYTES);
-            const messagePrimaryKey = makeMessagePrimaryKey(fid, UserPostfix.CastMessage, tsHash);
-            resolve([key as Buffer, messagePrimaryKey]);
-          }
-        });
-      });
+    const getNextIteratorRecord = async (iterator: Iterator): Promise<[Buffer, Buffer]> => {
+      const record = await iterator.next();
+      if (record === undefined) {
+        throw new HubError('not_found', 'record not found');
+      }
+      const [key] = record;
+      const fid = Number((key as Buffer).readUint32BE(prefix.length));
+      const tsHash = Uint8Array.from(key as Buffer).subarray(prefix.length + FID_BYTES);
+      const messagePrimaryKey = makeMessagePrimaryKey(fid, UserPostfix.CastMessage, tsHash);
+      return [key as Buffer, messagePrimaryKey];
     };
 
     let iteratorFinished = false;
@@ -272,19 +268,17 @@ class CastStore {
     });
 
     // Custom method to retrieve message key from key
-    const getNextIteratorRecord = (iterator: AbstractRocksDB.Iterator): Promise<[Buffer, Buffer]> => {
-      return new Promise((resolve, reject) => {
-        iterator.next((err: Error | undefined, key: AbstractRocksDB.Bytes, value: AbstractRocksDB.Bytes) => {
-          if (err || !value) {
-            reject(err);
-          } else {
-            const fid = Number((key as Buffer).readUint32BE(prefix.length));
-            const tsHash = Uint8Array.from(key as Buffer).subarray(prefix.length + FID_BYTES);
-            const messagePrimaryKey = makeMessagePrimaryKey(fid, UserPostfix.CastMessage, tsHash);
-            resolve([key as Buffer, messagePrimaryKey]);
-          }
-        });
-      });
+    const getNextIteratorRecord = async (iterator: Iterator): Promise<[Buffer, Buffer]> => {
+      const record = await iterator.next();
+      if (record === undefined) {
+        throw new HubError('not_found', 'record not found');
+      }
+
+      const [key] = record;
+      const fid = Number((key as Buffer).readUint32BE(prefix.length));
+      const tsHash = Uint8Array.from(key as Buffer).subarray(prefix.length + FID_BYTES);
+      const messagePrimaryKey = makeMessagePrimaryKey(fid, UserPostfix.CastMessage, tsHash);
+      return [key as Buffer, messagePrimaryKey];
     };
 
     let iteratorFinished = false;
@@ -420,7 +414,7 @@ class CastStore {
     // Create a rocksdb iterator for all messages with the given prefix
     const pruneIterator = getMessagesPruneIterator(this._db, fid, UserPostfix.CastMessage);
 
-    const getNextResult = () => ResultAsync.fromPromise(getNextMessageToPrune(pruneIterator), () => undefined);
+    const getNextResult = () => ResultAsync.fromPromise(getNextMessageFromIterator(pruneIterator), () => undefined);
 
     // For each message in order, prune it if the store is over the size limit or the message was signed
     // before the timestamp cut-off
@@ -454,8 +448,7 @@ class CastStore {
     }
 
     // Close the iterator
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    pruneIterator.end(() => {});
+    await pruneIterator.end();
 
     if (events.length > 0) {
       // Commit the transaction to rocksdb

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -205,11 +205,7 @@ class CastStore {
 
     // Custom method to retrieve message key from key
     const getNextIteratorRecord = async (iterator: Iterator): Promise<[Buffer, Buffer]> => {
-      const record = await iterator.next();
-      if (record === undefined) {
-        throw new HubError('not_found', 'record not found');
-      }
-      const [key] = record;
+      const [key] = await iterator.next();
       const fid = Number((key as Buffer).readUint32BE(prefix.length));
       const tsHash = Uint8Array.from(key as Buffer).subarray(prefix.length + FID_BYTES);
       const messagePrimaryKey = makeMessagePrimaryKey(fid, UserPostfix.CastMessage, tsHash);
@@ -269,12 +265,7 @@ class CastStore {
 
     // Custom method to retrieve message key from key
     const getNextIteratorRecord = async (iterator: Iterator): Promise<[Buffer, Buffer]> => {
-      const record = await iterator.next();
-      if (record === undefined) {
-        throw new HubError('not_found', 'record not found');
-      }
-
-      const [key] = record;
+      const [key] = await iterator.next();
       const fid = Number((key as Buffer).readUint32BE(prefix.length));
       const tsHash = Uint8Array.from(key as Buffer).subarray(prefix.length + FID_BYTES);
       const messagePrimaryKey = makeMessagePrimaryKey(fid, UserPostfix.CastMessage, tsHash);

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -258,11 +258,8 @@ class ReactionStore {
 
     // Custom method to retrieve message key from key
     const getNextIteratorRecord = async (iterator: Iterator): Promise<[Buffer, Buffer]> => {
-      const record = await iterator.next();
-      if (record === undefined) {
-        throw new HubError('not_found', 'record not found');
-      }
-      const [key] = record;
+      const [key] = await iterator.next();
+
       // Calculates the positions in the key where the fid and tsHash begin
       const fidOffset = prefix.length + (type ? 0 : 1); // compensate for fact that prefix is 1 byte longer if type was provided
       const tsHashOffset = fidOffset + FID_BYTES;

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -288,6 +288,7 @@ class ReactionStore {
     const messages = await getManyMessages<protobufs.ReactionAddMessage>(this._db, messageKeys);
 
     if (!iteratorFinished) {
+      await iterator.end(); // clear iterator if it has not finished
       return { messages, nextPageToken: lastPageToken };
     } else {
       return { messages, nextPageToken: undefined };

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -445,6 +445,10 @@ class ReactionStore {
       nextMessage = await getNextResult();
     }
 
+    // Close the iterator
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    pruneIterator.end(() => {});
+
     if (events.length > 0) {
       // Commit the transaction to rocksdb
       await this._db.commit(pruneTxn);

--- a/apps/hubble/src/storage/stores/signerStore.ts
+++ b/apps/hubble/src/storage/stores/signerStore.ts
@@ -2,7 +2,6 @@ import * as protobufs from '@farcaster/protobufs';
 import { bytesCompare, bytesIncrement, HubAsyncResult, HubError, isHubError } from '@farcaster/utils';
 import AsyncLock from 'async-lock';
 import { err, ok, ResultAsync } from 'neverthrow';
-import AbstractRocksDB from 'rocksdb';
 import { getIdRegistryEvent, putIdRegistryEventTransaction } from '~/storage/db/idRegistryEvent';
 import {
   deleteMessageTransaction,
@@ -10,13 +9,13 @@ import {
   getMessage,
   getMessagesPageByPrefix,
   getMessagesPruneIterator,
-  getNextMessageToPrune,
+  getNextMessageFromIterator,
   makeMessagePrimaryKey,
   makeTsHash,
   makeUserKey,
   putMessageTransaction,
 } from '~/storage/db/message';
-import RocksDB, { Transaction } from '~/storage/db/rocksdb';
+import RocksDB, { Iterator, Transaction } from '~/storage/db/rocksdb';
 import { RootPrefix, UserPostfix } from '~/storage/db/types';
 import StoreEventHandler, { putEventTransaction } from '~/storage/stores/storeEventHandler';
 import {
@@ -200,16 +199,15 @@ class SignerStore {
     });
 
     /** Custom to retrieve fid from key */
-    const getNextIteratorRecord = (iterator: AbstractRocksDB.Iterator): Promise<[Buffer, number]> => {
-      return new Promise((resolve, reject) => {
-        iterator.next((err: Error | undefined, key: AbstractRocksDB.Bytes, value: AbstractRocksDB.Bytes) => {
-          if (err || !value) {
-            reject(err);
-          } else {
-            resolve([key as Buffer, Number((key as Buffer).readUint32BE(1))]);
-          }
-        });
-      });
+    const getNextIteratorRecord = async (iterator: Iterator): Promise<[Buffer, number]> => {
+      const record = await iterator.next();
+
+      if (record === undefined) {
+        throw new HubError('not_found', 'record not found');
+      }
+
+      const [key] = record;
+      return [key as Buffer, Number((key as Buffer).readUint32BE(1))];
     };
 
     let iteratorFinished = false;
@@ -368,7 +366,7 @@ class SignerStore {
     // Create a rocksdb iterator for all messages with the given prefix
     const pruneIterator = getMessagesPruneIterator(this._db, fid, UserPostfix.SignerMessage);
 
-    const getNextResult = () => ResultAsync.fromPromise(getNextMessageToPrune(pruneIterator), () => undefined);
+    const getNextResult = () => ResultAsync.fromPromise(getNextMessageFromIterator(pruneIterator), () => undefined);
 
     // For each message in order, prune it if the store is over the size limit
     let nextMessage = await getNextResult();
@@ -398,8 +396,7 @@ class SignerStore {
     }
 
     // Close the iterator
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    pruneIterator.end(() => {});
+    await pruneIterator.end();
 
     if (events.length > 0) {
       // Commit the transaction to rocksdb

--- a/apps/hubble/src/storage/stores/signerStore.ts
+++ b/apps/hubble/src/storage/stores/signerStore.ts
@@ -219,6 +219,7 @@ class SignerStore {
     } while (fids.length < limit);
 
     if (!iteratorFinished) {
+      await iterator.end(); // clear iterator if it has not finished
       return { fids, nextPageToken: lastPageToken };
     } else {
       return { fids, nextPageToken: undefined };

--- a/apps/hubble/src/storage/stores/signerStore.ts
+++ b/apps/hubble/src/storage/stores/signerStore.ts
@@ -397,6 +397,10 @@ class SignerStore {
       nextMessage = await getNextResult();
     }
 
+    // Close the iterator
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    pruneIterator.end(() => {});
+
     if (events.length > 0) {
       // Commit the transaction to rocksdb
       await this._db.commit(pruneTxn);

--- a/apps/hubble/src/storage/stores/signerStore.ts
+++ b/apps/hubble/src/storage/stores/signerStore.ts
@@ -200,13 +200,7 @@ class SignerStore {
 
     /** Custom to retrieve fid from key */
     const getNextIteratorRecord = async (iterator: Iterator): Promise<[Buffer, number]> => {
-      const record = await iterator.next();
-
-      if (record === undefined) {
-        throw new HubError('not_found', 'record not found');
-      }
-
-      const [key] = record;
+      const [key] = await iterator.next();
       return [key as Buffer, Number((key as Buffer).readUint32BE(1))];
     };
 

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -17,9 +17,8 @@ import {
 } from '@farcaster/protobufs';
 import { bytesIncrement, FARCASTER_EPOCH, HubAsyncResult, HubError, HubResult } from '@farcaster/utils';
 import { err, ok, ResultAsync } from 'neverthrow';
-import AbstractRocksDB from 'rocksdb';
 import { TypedEmitter } from 'tiny-typed-emitter';
-import RocksDB, { Transaction } from '~/storage/db/rocksdb';
+import RocksDB, { Iterator, Transaction } from '~/storage/db/rocksdb';
 import { RootPrefix } from '~/storage/db/types';
 
 export type StoreEvents = {
@@ -132,7 +131,7 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
     return result.map((buffer) => HubEvent.decode(new Uint8Array(buffer as Buffer)));
   }
 
-  getEventsIterator(fromId?: number): HubResult<AbstractRocksDB.Iterator> {
+  getEventsIterator(fromId?: number): HubResult<Iterator> {
     const minKey = makeEventKey(fromId);
     const maxKey = bytesIncrement(Uint8Array.from(makeEventKey()));
     if (maxKey.isErr()) {

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -9,7 +9,7 @@ import {
   getMessage,
   getMessagesPageByPrefix,
   getMessagesPruneIterator,
-  getNextMessageToPrune,
+  getNextMessageFromIterator,
   makeMessagePrimaryKey,
   makeTsHash,
   makeUserKey,
@@ -233,7 +233,7 @@ class UserDataStore {
     // Create a rocksdb iterator for all messages with the given prefix
     const pruneIterator = getMessagesPruneIterator(this._db, fid, UserPostfix.UserDataMessage);
 
-    const getNextResult = () => ResultAsync.fromPromise(getNextMessageToPrune(pruneIterator), () => undefined);
+    const getNextResult = () => ResultAsync.fromPromise(getNextMessageFromIterator(pruneIterator), () => undefined);
 
     // For each message in order, prune it if the store is over the size limit
     let nextMessage = await getNextResult();
@@ -261,8 +261,7 @@ class UserDataStore {
     }
 
     // Close the iterator
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    pruneIterator.end(() => {});
+    await pruneIterator.end();
 
     if (events.length > 0) {
       // Commit the transaction to rocksdb

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -260,6 +260,10 @@ class UserDataStore {
       nextMessage = await getNextResult();
     }
 
+    // Close the iterator
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    pruneIterator.end(() => {});
+
     if (events.length > 0) {
       // Commit the transaction to rocksdb
       await this._db.commit(pruneTxn);

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -8,7 +8,7 @@ import {
   getMessage,
   getMessagesPageByPrefix,
   getMessagesPruneIterator,
-  getNextMessageToPrune,
+  getNextMessageFromIterator,
   makeMessagePrimaryKey,
   makeTsHash,
   makeUserKey,
@@ -264,7 +264,7 @@ class VerificationStore {
     // Create a rocksdb iterator for all messages with the given prefix
     const pruneIterator = getMessagesPruneIterator(this._db, fid, UserPostfix.VerificationMessage);
 
-    const getNextResult = () => ResultAsync.fromPromise(getNextMessageToPrune(pruneIterator), () => undefined);
+    const getNextResult = () => ResultAsync.fromPromise(getNextMessageFromIterator(pruneIterator), () => undefined);
 
     // For each message in order, prune it if the store is over the size limit
     let nextMessage = await getNextResult();
@@ -294,8 +294,7 @@ class VerificationStore {
     }
 
     // Close the iterator
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    pruneIterator.end(() => {});
+    await pruneIterator.end();
 
     if (events.length > 0) {
       // Commit the transaction to rocksdb

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -293,6 +293,10 @@ class VerificationStore {
       nextMessage = await getNextResult();
     }
 
+    // Close the iterator
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    pruneIterator.end(() => {});
+
     if (events.length > 0) {
       // Commit the transaction to rocksdb
       await this._db.commit(pruneTxn);


### PR DESCRIPTION
## Motivation

The RocksDB iterator doesn't seem to be release the natively-allocated memory unless end() is called explicitly. 

## Change Summary

- Call iterator.end() explicitly 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

