### PR TITLE
fix: Switch to time-based check for process shutdown file

### DIFF
--- a/.changeset/funny-ears-compare.md
+++ b/.changeset/funny-ears-compare.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Switch to time-based check for process shutdown file


### PR DESCRIPTION
## Motivation

Using `fs.watch` uses `inotify`, which doesn't work with network file systems like EFS where other kernels could be responsible for changes to the file system.

## Change Summary

Instead, check every 10 seconds to see if there is a change.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
