### PR TITLE
fix: Read the processFile every 15s instead of watch

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -55,6 +55,8 @@ export type HubSubmitSource = 'gossip' | 'rpc' | 'eth-provider';
 export const APP_VERSION = process.env['npm_package_version'] ?? '1.0.0';
 export const APP_NICKNAME = 'Farcaster Hub';
 
+export const HUB_LOCK_POLL_INTERVAL_MS = 15 * 1000;
+
 export interface HubInterface {
   engine: Engine;
   submitMessage(message: protobufs.Message, source?: HubSubmitSource): HubAsyncResult<number>;
@@ -240,7 +242,7 @@ export class Hub implements HubInterface {
         );
 
         // Sleep for 15s
-        await sleep(15 * 1000);
+        await sleep(HUB_LOCK_POLL_INTERVAL_MS);
       } else {
         break;
       }


### PR DESCRIPTION
## Motivation

Since ionotify doesn't work on EFS, fs.watch won't work to watch for processNum changes to check if there is more than one hub running. 

Switch to reading the processNum file every 15s

## Change Summary

- Remove fs.watch and switch to reading every 15s

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
