### PR TITLE
fix: Correctly get SSL / Insecure client

### DIFF
--- a/packages/protobufs/src/index.ts
+++ b/packages/protobufs/src/index.ts
@@ -25,18 +25,18 @@ export const getClient = async (address: string): Promise<HubServiceClient> => {
   return new Promise((resolve) => {
     try {
       const sslClientResult = getSSLClient(address);
-      if (sslClientResult) {
-        sslClientResult.waitForReady(Date.now() + 1000, (err) => {
-          if (!err) {
-            resolve(sslClientResult);
-          }
-        });
-      }
+
+      sslClientResult.waitForReady(Date.now() + 2000, (err) => {
+        if (!err) {
+          resolve(sslClientResult);
+        } else {
+          resolve(getInsecureClient(address));
+        }
+      });
     } catch (e) {
       // Fall back to insecure client
+      resolve(getInsecureClient(address));
     }
-
-    resolve(getInsecureClient(address));
   });
 };
 


### PR DESCRIPTION
## Motivation

Correctly fallback if SSL client fails

## Change Summary

- Try to get SSL client
- Timeout after 2 seconds
- Fall back to Insecure client.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
