### PR TITLE
chore: Allow specifying hub name via environment variable

### DIFF
--- a/.changeset/clever-seals-greet.md
+++ b/.changeset/clever-seals-greet.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Allow specifying hub nickname via environment variable

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -53,7 +53,7 @@ import { sleep } from './utils/crypto';
 export type HubSubmitSource = 'gossip' | 'rpc' | 'eth-provider';
 
 export const APP_VERSION = process.env['npm_package_version'] ?? '1.0.0';
-export const APP_NICKNAME = 'Farcaster Hub';
+export const APP_NICKNAME = process.env['HUBBLE_NAME'] ?? 'Farcaster Hub';
 
 export interface HubInterface {
   engine: Engine;


### PR DESCRIPTION
## Motivation

This makes it easier to set the name when deploying multiple hubs.

## Change Summary

Add support for reading name from the `HUBBLE_NAME` environment variable.

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
