### PR TITLE
docs: fix broken signer doc links in builders

### DIFF
--- a/packages/hub-nodejs/docs/Builders.md
+++ b/packages/hub-nodejs/docs/Builders.md
@@ -163,11 +163,11 @@ const cast = await makeCastAdd(
 
 #### Parameters
 
-| Name          | Type                                          | Description                                                 |
-| :------------ | :-------------------------------------------- | :---------------------------------------------------------- |
-| `body`        | [`CastAddBody`](./Messages.md#castaddbody)    | A valid CastAdd body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions`                          | Optional metadata to construct the message.                 |
-| `signer`      | [`Ed25519Signer`](./signers/Ed25519Signer.md) | A currently valid Signer for the fid.                       |
+| Name          | Type                                               | Description                                                 |
+| :------------ | :------------------------------------------------- | :---------------------------------------------------------- |
+| `body`        | [`CastAddBody`](./Messages.md#castaddbody)         | A valid CastAdd body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions`                               | Optional metadata to construct the message.                 |
+| `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md) | A currently valid Signer for the fid.                       |
 
 ---
 
@@ -200,11 +200,11 @@ const castRemove = await makeCastRemove(
 
 #### Parameters
 
-| Name          | Type                                             | Description                                                    |
-| :------------ | :----------------------------------------------- | :------------------------------------------------------------- |
-| `body`        | [`CastRemoveBody`](./Messages.md#castremovebody) | A valid CastRemove body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions`                             | Optional metadata to construct the message.                    |
-| `signer`      | [`Ed25519Signer`](./signers/Ed25519Signer.md)    | A currently valid Signer for the fid.                          |
+| Name          | Type                                               | Description                                                    |
+| :------------ | :------------------------------------------------- | :------------------------------------------------------------- |
+| `body`        | [`CastRemoveBody`](./Messages.md#castremovebody)   | A valid CastRemove body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions`                               | Optional metadata to construct the message.                    |
+| `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md) | A currently valid Signer for the fid.                          |
 
 ---
 
@@ -239,11 +239,11 @@ const like = await makeReactionAdd(reactionLikeBody, dataOptions, ed25519Signer)
 
 #### Parameters
 
-| Name          | Type                                          | Description                                                     |
-| :------------ | :-------------------------------------------- | :-------------------------------------------------------------- |
-| `body`        | [`ReactionBody`](./Messages.md#reactionbody)  | A valid ReactionAdd body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions`                          | Optional metadata to construct the message.                     |
-| `signer`      | [`Ed25519Signer`](./signers/Ed25519Signer.md) | A currently valid Signer for the fid.                           |
+| Name          | Type                                               | Description                                                     |
+| :------------ | :------------------------------------------------- | :-------------------------------------------------------------- |
+| `body`        | [`ReactionBody`](./Messages.md#reactionbody)       | A valid ReactionAdd body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions`                               | Optional metadata to construct the message.                     |
+| `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md) | A currently valid Signer for the fid.                           |
 
 ---
 
@@ -278,11 +278,11 @@ const like = await makeReactionRemove(reactionLikeBody, dataOptions, ed25519Sign
 
 #### Parameters
 
-| Name          | Type                                          | Description                                                        |
-| :------------ | :-------------------------------------------- | :----------------------------------------------------------------- |
-| `body`        | [`ReactionBody`](./Messages.md#reactionbody)  | A valid ReactionRemove body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions`                          | Optional metadata to construct the message.                        |
-| `signer`      | [`Ed25519Signer`](./signers/Ed25519Signer.md) | A currently valid Signer for the fid.                              |
+| Name          | Type                                               | Description                                                        |
+| :------------ | :------------------------------------------------- | :----------------------------------------------------------------- |
+| `body`        | [`ReactionBody`](./Messages.md#reactionbody)       | A valid ReactionRemove body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions`                               | Optional metadata to construct the message.                        |
+| `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md) | A currently valid Signer for the fid.                              |
 
 ---
 
@@ -312,11 +312,11 @@ console.log(userDataPfpAdd);
 
 #### Parameters
 
-| Name          | Type                                          | Description                                                  |
-| :------------ | :-------------------------------------------- | :----------------------------------------------------------- |
-| `body`        | [`UserDataBody`](./Messages.md#userdatabody)  | A valid UserData body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions`                          | Optional metadata to construct the message.                  |
-| `signer`      | [`Ed25519Signer`](./signers/Ed25519Signer.md) | A currently valid Signer for the fid.                        |
+| Name          | Type                                               | Description                                                  |
+| :------------ | :------------------------------------------------- | :----------------------------------------------------------- |
+| `body`        | [`UserDataBody`](./Messages.md#userdatabody)       | A valid UserData body object containing the data to be sent. |
+| `dataOptions` | `MessageDataOptions`                               | Optional metadata to construct the message.                  |
+| `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md) | A currently valid Signer for the fid.                        |
 
 ---
 
@@ -367,11 +367,11 @@ if (claimResult.isOk()) {
 
 #### Parameters
 
-| Name          | Type                                          | Description                                                                            |
-| :------------ | :-------------------------------------------- | :------------------------------------------------------------------------------------- |
-| `body`        | [`VerificationAddEthAddressBody`](#)          | An object which contains an Eip712 Signature from the Ethereum Address being verified. |
-| `dataOptions` | `MessageDataOptions`                          | Optional metadata to construct the message.                                            |
-| `signer`      | [`Ed25519Signer`](./signers/Ed25519Signer.md) | A currently valid Signer for the fid.                                                  |
+| Name          | Type                                               | Description                                                                            |
+| :------------ | :------------------------------------------------- | :------------------------------------------------------------------------------------- |
+| `body`        | [`VerificationAddEthAddressBody`](#)               | An object which contains an Eip712 Signature from the Ethereum Address being verified. |
+| `dataOptions` | `MessageDataOptions`                               | Optional metadata to construct the message.                                            |
+| `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md) | A currently valid Signer for the fid.                                                  |
 
 ---
 
@@ -404,4 +404,4 @@ console.log(verificationRemoveMessage);
 | :------------ | :--------------------------------------------------------------- | :------------------------------------------------------------------- |
 | `body`        | [`VerificationRemoveBody`](./Messages.md#verificationremovebody) | An object which contains data about the Verification being removed . |
 | `dataOptions` | `MessageDataOptions`                                             | Optional metadata to construct the message.                          |
-| `signer`      | [`Ed25519Signer`](./signers/Ed25519Signer.md)                    | A currently valid Signer for the fid.                                |
+| `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md)               | A currently valid Signer for the fid.                                |


### PR DESCRIPTION
## Motivation

The signer is now at [NobleEd25519Signer.md](https://github.com/farcasterxyz/hubble/blob/main/packages/hub-nodejs/docs/signers/NobleEd25519Signer.md) and no longer at [Ed25519Signer.md](https://github.com/farcasterxyz/hubble/blob/main/packages/hub-nodejs/docs/signers/Ed25519Signer.md)

## Change Summary

Fixes broken links in the docs

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [ ] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

-