### PR TITLE
fix: Fix issue with ethers v6

### DIFF
--- a/apps/hubble/.config/hub.config.ts
+++ b/apps/hubble/.config/hub.config.ts
@@ -43,4 +43,6 @@ export const Config = {
   network: DEFAULT_NETWORK,
   /** Start the admin server? */
   adminServerEnabled: false,
+  /** The admin server bind host */
+  adminServerHost: '127.0.0.1',
 };

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -57,6 +57,7 @@ app
     'Enable Auth for RPC submit methods with the username and password. (default: disabled)'
   )
   .option('--admin-server-enabled', 'Enable the admin server. (default: disabled)')
+  .option('--admin-server-host <host>', "The host the admin server should listen on. (default: '127.0.0.1')")
   .option('--db-name <name>', 'The name of the RocksDB instance')
   .option('--db-reset', 'Clears the database before starting')
   .option('--rebuild-sync-trie', 'Rebuilds the sync trie before starting')
@@ -202,6 +203,7 @@ app
       resetDB: cliOptions.dbReset ?? hubConfig.dbReset,
       rebuildSyncTrie,
       adminServerEnabled: cliOptions.adminServerEnabled ?? hubConfig.adminServerEnabled,
+      adminServerHost: cliOptions.adminServerHost ?? hubConfig.adminServerHost,
     };
 
     const hub = new Hub(options);

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -191,6 +191,8 @@ export class Hub implements HubInterface {
         options.firstBlock ?? GoerliEthConstants.FirstBlock,
         options.chunkSize ?? GoerliEthConstants.ChunkSize
       );
+    } else {
+      log.warn('No ETH RPC URL provided, not syncing with ETH contract events');
     }
 
     // Setup job queues

--- a/apps/hubble/src/rpc/adminServer.ts
+++ b/apps/hubble/src/rpc/adminServer.ts
@@ -36,7 +36,7 @@ export default class AdminServer {
     this.grpcServer.addService(AdminServiceService, this.getImpl());
   }
 
-  async start(): HubAsyncResult<undefined> {
+  async start(host = '127.0.0.1'): HubAsyncResult<undefined> {
     // Create a unix socket server
     net.createServer(() => {
       log.info('Admin server socket connected');
@@ -44,13 +44,13 @@ export default class AdminServer {
 
     return new Promise((resolve) => {
       // The Admin server is only available on localhost
-      this.grpcServer.bindAsync(`127.0.0.1:${ADMIN_SERVER_PORT}`, ServerCredentials.createInsecure(), (e, port) => {
+      this.grpcServer.bindAsync(`${host}:${ADMIN_SERVER_PORT}`, ServerCredentials.createInsecure(), (e, port) => {
         if (e) {
           log.error(`Failed to bind admin server to socket: ${e}`);
           resolve(err(new HubError('unavailable.network_failure', `Failed to bind admin server to socket: ${e}`)));
         } else {
           this.grpcServer.start();
-          log.info({ port }, 'Starting Admin server');
+          log.info({ host, port }, 'Starting Admin server');
           resolve(ok(undefined));
         }
       });

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -74,6 +74,8 @@ class Engine {
             } else {
               resolve(err(new HubError(errCode, errMessage)));
             }
+          } else {
+            logger.warn({ id }, 'validation worker promise.response not found');
           }
         });
       } else {
@@ -592,14 +594,12 @@ class Engine {
 
     // 6. Check message body and envelope
     if (this._validationWorker) {
-      const promise = new Promise<HubResult<protobufs.Message>>((resolve) => {
+      return new Promise<HubResult<protobufs.Message>>((resolve) => {
         const id = this._validationWorkerJobId++;
         this._validationWorkerPromiseMap.set(id, resolve);
 
         this._validationWorker?.postMessage({ id, message });
       });
-
-      return promise;
     } else {
       return validations.validateMessage(message);
     }


### PR DESCRIPTION
## Motivation

Fix an issue where the hub wouldn't start without a ethRPC URL. During tests, we don't connect to a ethRPC URL, so the hub should be able to start without one. 

## Change Summary

- Allow hubs to startup without a ethRPC URL. 
- Show warning when starting without a ethRPC url

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
