### PR TITLE
fix: Add a simple cache to the sync trie

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -349,14 +349,14 @@ export class Hub implements HubInterface {
     await this.adminServer.stop();
     await this.gossipNode.stop();
 
+    // Stop sync
+    await this.syncEngine.stop();
+
     // Stop cron tasks
     this.revokeSignerJobScheduler.stop();
     this.pruneMessagesJobScheduler.stop();
     this.periodSyncJobScheduler.stop();
     this.pruneEventsJobScheduler.stop();
-
-    // Stop sync
-    await this.syncEngine.stop();
 
     // Stop the ETH registry provider
     if (this.ethRegistryProvider) {

--- a/apps/hubble/src/network/p2p/gossipNode.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.ts
@@ -18,11 +18,8 @@ import { addressInfoFromParts, checkNodeAddrs, ipMultiAddrStrFromAddressInfo } f
 
 const MultiaddrLocalHost = '/ip4/127.0.0.1';
 
-/**
- *  The maximum number of pending merge messages before we drop new incoming gossip or sync messages.
- *  50k is about 5 mins worth of messages.
- */
-export const MAX_MESSAGE_QUEUE_SIZE = 50_000;
+/** The maximum number of pending merge messages before we drop new incoming gossip or sync messages. */
+export const MAX_MESSAGE_QUEUE_SIZE = 100_000;
 
 const log = logger.child({ component: 'Node' });
 

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -25,6 +25,7 @@ describe('MerkleTrie', () => {
     );
     const trie = new MerkleTrie(db);
     await Promise.all(syncIds.map((id) => trie.insert(id)));
+    await trie.commitToDb();
     return trie;
   };
 
@@ -113,6 +114,7 @@ describe('MerkleTrie', () => {
       const syncIdStr = Buffer.from(syncId.syncId()).toString('hex');
 
       await trie.insert(syncId);
+      await trie.commitToDb();
 
       expect(await trie.exists(syncId)).toBeTruthy();
 
@@ -142,6 +144,8 @@ describe('MerkleTrie', () => {
       expect(await trie.insert(syncId2)).toBeTruthy();
       expect(await trie.exists(syncId2)).toBeTruthy();
 
+      await trie.commitToDb();
+
       leafs = 0;
       //eslint-disable-next-line @typescript-eslint/no-unused-vars
       count = await forEachDbItem(db, async (i, key, value) => {
@@ -169,6 +173,7 @@ describe('MerkleTrie', () => {
       async () => {
         const syncIds = await NetworkFactories.SyncId.createList(20);
         await Promise.all(syncIds.map(async (syncId) => await trie.insert(syncId)));
+        await trie.commitToDb();
 
         // Now initialize a new merkle trie from the same DB
         const trie2 = new MerkleTrie(db);
@@ -183,6 +188,7 @@ describe('MerkleTrie', () => {
 
         // Delete half the items from the first trie
         await Promise.all(syncIds.slice(0, syncIds.length / 2).map(async (syncId) => trie.delete(syncId)));
+        await trie.commitToDb();
 
         // Initialize a new trie from the same DB
         const trie3 = new MerkleTrie(db);
@@ -276,6 +282,8 @@ describe('MerkleTrie', () => {
       const id = await NetworkFactories.SyncId.create();
 
       await trie.insert(id);
+      await trie.commitToDb();
+
       expect(await trie.items()).toEqual(1);
 
       let count = await forEachDbItem(db);
@@ -283,6 +291,8 @@ describe('MerkleTrie', () => {
 
       // Delete
       await trie.delete(id);
+      await trie.commitToDb();
+
       count = await forEachDbItem(db);
       expect(count).toEqual(0);
     });
@@ -293,12 +303,15 @@ describe('MerkleTrie', () => {
 
       await trie.insert(syncId1);
       await trie.insert(syncId2);
+      await trie.commitToDb();
 
       let count = await forEachDbItem(db);
       expect(count).toBeGreaterThan(1 + TIMESTAMP_LENGTH);
 
       // Delete
       await trie.delete(syncId1);
+      await trie.commitToDb();
+
       count = await forEachDbItem(db);
       expect(count).toEqual(1 + TIMESTAMP_LENGTH);
     });
@@ -342,6 +355,7 @@ describe('MerkleTrie', () => {
 
       await trie.insert(syncId1);
       await trie.insert(syncId2);
+      await trie.commitToDb();
 
       const rootHash = await trie.rootHash();
 
@@ -351,6 +365,7 @@ describe('MerkleTrie', () => {
       expect(await trie2.rootHash()).toEqual(rootHash);
 
       expect(await trie2.delete(syncId1)).toBeTruthy();
+      await trie2.commitToDb();
 
       expect(await trie2.rootHash()).not.toEqual(rootHash);
       expect(await trie2.exists(syncId1)).toBeFalsy();
@@ -363,6 +378,7 @@ describe('MerkleTrie', () => {
 
       await trie.insert(syncId1);
       await trie.insert(syncId2);
+      await trie.commitToDb();
 
       const rootHash = await trie.rootHash();
 
@@ -371,6 +387,7 @@ describe('MerkleTrie', () => {
 
       // Now try deleting syncId1
       expect(await trie.delete(syncId1)).toBeTruthy();
+      await trie.commitToDb();
 
       expect(await trie.rootHash()).not.toEqual(rootHash);
       expect(await trie.exists(syncId1)).toBeFalsy();

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -124,6 +124,7 @@ describe('Multi peer sync engine', () => {
 
     // Create a new sync engine from the existing engine, and see if all the messages from the engine
     // are loaded into the sync engine Merkle Trie properly.
+    await syncEngine1.trie.commitToDb();
     const reinitSyncEngine = new SyncEngine(engine1, testDb1);
     await reinitSyncEngine.initialize();
 

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -65,6 +65,7 @@ describe('SyncEngine', () => {
     );
 
     await sleepWhile(() => syncEngine.syncTrieQSize > 0, 1000);
+    await syncEngine.trie.commitToDb();
     return results;
   };
 

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -122,10 +122,16 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     // Interrupt any ongoing sync
     this._interruptSync = true;
 
+    // First, save the trie to disk
+    await this._trie.commitToDb();
+
     // Wait for syncing to stop.
     try {
       await sleepWhile(() => this._isSyncing, SYNC_INTERRUPT_TIMEOUT);
       await sleepWhile(() => this.syncTrieQSize > 0, SYNC_INTERRUPT_TIMEOUT);
+
+      // Write the trie to disk one last time, in case there were any changes
+      await this._trie.commitToDb();
     } catch (e) {
       log.error({ err: e }, 'Interrupting sync timed out');
     }

--- a/apps/hubble/src/network/sync/syncEnginePerf.test.ts
+++ b/apps/hubble/src/network/sync/syncEnginePerf.test.ts
@@ -54,66 +54,70 @@ describe('SyncEngine', () => {
     );
   };
 
-  test('should not fetch all messages when snapshot contains non-existent prefix', async () => {
-    const nowOrig = Date.now;
-    let syncEngine1;
-    let syncEngine2;
+  test(
+    'should not fetch all messages when snapshot contains non-existent prefix',
+    async () => {
+      const nowOrig = Date.now;
+      let syncEngine1;
+      let syncEngine2;
 
-    try {
-      testDb.clear();
-      testDb2.clear();
+      try {
+        testDb.clear();
+        testDb2.clear();
 
-      const engine1 = new Engine(testDb, FarcasterNetwork.TESTNET);
-      syncEngine1 = new SyncEngine(engine1, testDb);
-      const engine2 = new Engine(testDb2, FarcasterNetwork.TESTNET);
-      syncEngine2 = new SyncEngine(engine2, testDb2);
+        const engine1 = new Engine(testDb, FarcasterNetwork.TESTNET);
+        syncEngine1 = new SyncEngine(engine1, testDb);
+        const engine2 = new Engine(testDb2, FarcasterNetwork.TESTNET);
+        syncEngine2 = new SyncEngine(engine2, testDb2);
 
-      await engine1.mergeIdRegistryEvent(custodyEvent);
-      await engine1.mergeMessage(signerAdd);
-      await engine2.mergeIdRegistryEvent(custodyEvent);
-      await engine2.mergeMessage(signerAdd);
+        await engine1.mergeIdRegistryEvent(custodyEvent);
+        await engine1.mergeMessage(signerAdd);
+        await engine2.mergeIdRegistryEvent(custodyEvent);
+        await engine2.mergeMessage(signerAdd);
 
-      // Merge the same messages into both engines.
-      const messages = await addMessagesWithTimestamps([30662167, 30662169, 30662172], engine1);
-      for (const message of messages) {
-        await engine2.mergeMessage(message);
+        // Merge the same messages into both engines.
+        const messages = await addMessagesWithTimestamps([30662167, 30662169, 30662172], engine1);
+        for (const message of messages) {
+          await engine2.mergeMessage(message);
+        }
+
+        // Sanity check, they should equal
+        expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
+
+        // A timestamp after all the messages
+        Date.now = () => 1609459200000 + 30662200 * 1000;
+
+        const snapshot2 = (await syncEngine2.getSnapshot())._unsafeUnwrap();
+        expect((snapshot2.prefix as Buffer).toString('utf8')).toEqual('0030662');
+        // Force a non-existent prefix (the original bug #536 is fixed)
+        snapshot2.prefix = Buffer.from('00306622', 'hex');
+
+        let rpcClient = new MockRpcClient(engine2, syncEngine2);
+        await syncEngine1.performSync(snapshot2, rpcClient as unknown as HubRpcClient);
+        expect(rpcClient.getAllSyncIdsByPrefixCalls.length).toEqual(0);
+        expect(rpcClient.getAllMessagesBySyncIdsCalls.length).toEqual(0);
+
+        // Sanity check, they should equal
+        expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
+
+        // Even with a bad snapshot, we should still not call the sync APIs because the hashes match
+        rpcClient = new MockRpcClient(engine2, syncEngine2);
+        await syncEngine1.performSync(
+          {
+            numMessages: 1000,
+            prefix: Buffer.from('999999'),
+            excludedHashes: [EMPTY_HASH],
+          },
+          rpcClient as unknown as HubRpcClient
+        );
+        expect(rpcClient.getAllSyncIdsByPrefixCalls.length).toEqual(0);
+        expect(rpcClient.getAllMessagesBySyncIdsCalls.length).toEqual(0);
+      } finally {
+        Date.now = nowOrig;
+        await syncEngine1?.stop();
+        await syncEngine2?.stop();
       }
-
-      // Sanity check, they should equal
-      expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
-
-      // A timestamp after all the messages
-      Date.now = () => 1609459200000 + 30662200 * 1000;
-
-      const snapshot2 = (await syncEngine2.getSnapshot())._unsafeUnwrap();
-      expect((snapshot2.prefix as Buffer).toString('utf8')).toEqual('0030662');
-      // Force a non-existent prefix (the original bug #536 is fixed)
-      snapshot2.prefix = Buffer.from('00306622', 'hex');
-
-      let rpcClient = new MockRpcClient(engine2, syncEngine2);
-      await syncEngine1.performSync(snapshot2, rpcClient as unknown as HubRpcClient);
-      expect(rpcClient.getAllSyncIdsByPrefixCalls.length).toEqual(0);
-      expect(rpcClient.getAllMessagesBySyncIdsCalls.length).toEqual(0);
-
-      // Sanity check, they should equal
-      expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
-
-      // Even with a bad snapshot, we should still not call the sync APIs because the hashes match
-      rpcClient = new MockRpcClient(engine2, syncEngine2);
-      await syncEngine1.performSync(
-        {
-          numMessages: 1000,
-          prefix: Buffer.from('999999'),
-          excludedHashes: [EMPTY_HASH],
-        },
-        rpcClient as unknown as HubRpcClient
-      );
-      expect(rpcClient.getAllSyncIdsByPrefixCalls.length).toEqual(0);
-      expect(rpcClient.getAllMessagesBySyncIdsCalls.length).toEqual(0);
-    } finally {
-      Date.now = nowOrig;
-      await syncEngine1?.stop();
-      await syncEngine2?.stop();
-    }
-  });
+    },
+    15 * 1000
+  );
 });

--- a/apps/hubble/src/network/sync/trieNode.test.ts
+++ b/apps/hubble/src/network/sync/trieNode.test.ts
@@ -35,7 +35,7 @@ describe('TrieNode', () => {
       expect(root.items).toEqual(0);
       expect(root.hash.length).toEqual(0);
 
-      await root.insert(id.syncId(), db, db.transaction());
+      await root.insert(id.syncId(), db, new Map());
 
       expect(root.items).toEqual(1);
       expect(root.hash).toBeTruthy();
@@ -45,10 +45,10 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await NetworkFactories.SyncId.create();
 
-      await root.insert(id.syncId(), db, db.transaction());
+      await root.insert(id.syncId(), db, new Map());
       expect(root.items).toEqual(1);
       const previousHash = root.hash;
-      await root.insert(id.syncId(), db, db.transaction());
+      await root.insert(id.syncId(), db, new Map());
 
       expect(root.hash).toEqual(previousHash);
       expect(root.items).toEqual(1);
@@ -58,7 +58,7 @@ describe('TrieNode', () => {
       const trie = new TrieNode();
       const syncId = await NetworkFactories.SyncId.create();
 
-      await trie.insert(syncId.syncId(), db, db.transaction());
+      await trie.insert(syncId.syncId(), db, new Map());
 
       expect(trie.value).toBeFalsy();
     });
@@ -67,7 +67,7 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await NetworkFactories.SyncId.create();
 
-      await root.insert(id.syncId(), db, db.transaction());
+      await root.insert(id.syncId(), db, new Map());
       let node = root;
       // Timestamp portion of the key is not collapsed, but the hash portion is
       for (let i = 0; i < TIMESTAMP_LENGTH; i++) {
@@ -100,10 +100,8 @@ describe('TrieNode', () => {
 
       const root = new TrieNode();
 
-      let txn = (await root.insert(id1.syncId(), db, db.transaction())).txn;
-      await db.commit(txn);
-      txn = (await root.insert(id2.syncId(), db, db.transaction())).txn;
-      await db.commit(txn);
+      await root.insert(id1.syncId(), db, new Map());
+      await root.insert(id2.syncId(), db, new Map());
 
       const splitNode = traverse(root);
       expect(splitNode.items).toEqual(2);
@@ -129,10 +127,10 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await NetworkFactories.SyncId.create();
 
-      await root.insert(id.syncId(), db, db.transaction());
+      await root.insert(id.syncId(), db, new Map());
       expect(root.items).toEqual(1);
 
-      await root.delete(id.syncId(), db, db.transaction());
+      await root.delete(id.syncId(), db, new Map());
       expect(root.items).toEqual(0);
       expect(Buffer.from(root.hash).toString('hex')).toEqual(EMPTY_HASH);
     });
@@ -142,12 +140,12 @@ describe('TrieNode', () => {
       const id1 = await NetworkFactories.SyncId.create(undefined, { transient: { date: sharedDate } });
       const id2 = await NetworkFactories.SyncId.create(undefined, { transient: { date: sharedDate } });
 
-      await root.insert(id1.syncId(), db, db.transaction());
+      await root.insert(id1.syncId(), db, new Map());
       const previousHash = root.hash;
-      await root.insert(id2.syncId(), db, db.transaction());
+      await root.insert(id2.syncId(), db, new Map());
       expect(root.items).toEqual(2);
 
-      await root.delete(id2.syncId(), db, db.transaction());
+      await root.delete(id2.syncId(), db, new Map());
       expect(root.items).toEqual(1);
       expect(await root.exists(id2.syncId(), db)).toBeFalsy();
       expect(root.hash).toEqual(previousHash);
@@ -162,14 +160,14 @@ describe('TrieNode', () => {
       });
 
       const root = new TrieNode();
-      await root.insert(id1.syncId(), db, db.transaction());
+      await root.insert(id1.syncId(), db, new Map());
       const previousRootHash = root.hash;
       const leafNode = traverse(root);
-      await root.insert(id2.syncId(), db, db.transaction());
+      await root.insert(id2.syncId(), db, new Map());
 
       expect(root.hash).not.toEqual(previousRootHash);
 
-      await root.delete(id2.syncId(), db, db.transaction());
+      await root.delete(id2.syncId(), db, new Map());
 
       const newLeafNode = traverse(root);
       expect(newLeafNode).toEqual(leafNode);
@@ -188,11 +186,11 @@ describe('TrieNode', () => {
       for (let i = 0; i < ids.length; i++) {
         // Safety: i is controlled by the loop and cannot be used to inject
         // eslint-disable-next-line security/detect-object-injection
-        await root.insert(ids[i] as Uint8Array, db, db.transaction());
+        await root.insert(ids[i] as Uint8Array, db, new Map());
       }
 
       // Remove the first id
-      await root.delete(ids[0] as Uint8Array, db, db.transaction());
+      await root.delete(ids[0] as Uint8Array, db, new Map());
 
       // Expect the other two ids to be present
       expect(await root.exists(ids[1] as Uint8Array, db)).toBeTruthy();
@@ -209,11 +207,11 @@ describe('TrieNode', () => {
       for (let i = 0; i < ids.length; i++) {
         // Safety: i is controlled by the loop and cannot be used to inject
         // eslint-disable-next-line security/detect-object-injection
-        await root.insert(ids[i] as Uint8Array, db, db.transaction());
+        await root.insert(ids[i] as Uint8Array, db, new Map());
       }
 
       // Remove the first id
-      await root.delete(ids[0] as Uint8Array, db, db.transaction());
+      await root.delete(ids[0] as Uint8Array, db, new Map());
 
       // Expect the other  ids to be present
       expect(await root.exists(ids[1] as Uint8Array, db)).toBeTruthy();
@@ -231,7 +229,7 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await NetworkFactories.SyncId.create();
 
-      await root.insert(id.syncId(), db, db.transaction());
+      await root.insert(id.syncId(), db, new Map());
       expect(root.items).toEqual(1);
 
       expect(await root.exists(id.syncId(), db)).toBeTruthy();
@@ -241,10 +239,10 @@ describe('TrieNode', () => {
       const root = new TrieNode();
       const id = await NetworkFactories.SyncId.create();
 
-      await root.insert(id.syncId(), db, db.transaction());
+      await root.insert(id.syncId(), db, new Map());
       expect(root.items).toEqual(1);
 
-      await root.delete(id.syncId(), db, db.transaction());
+      await root.delete(id.syncId(), db, new Map());
       expect(await root.exists(id.syncId(), db)).toBeFalsy();
       expect(root.items).toEqual(0);
     });
@@ -258,7 +256,7 @@ describe('TrieNode', () => {
       });
 
       const root = new TrieNode();
-      await root.insert(id1.syncId(), db, db.transaction());
+      await root.insert(id1.syncId(), db, new Map());
 
       // id2 shares the same prefix, but doesn't exist, so it should return undefined
 

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
@@ -44,42 +44,46 @@ describe('doJobs', () => {
     expect(result._unsafeUnwrap()).toEqual(undefined);
   });
 
-  test('prunes messages for all fids', async () => {
-    const timestampToPrune = 1; // 1 second after farcaster epoch (1/1/22)
+  test(
+    'prunes messages for all fids',
+    async () => {
+      const timestampToPrune = 1; // 1 second after farcaster epoch (1/1/22)
 
-    const fid1 = Factories.Fid.build();
+      const fid1 = Factories.Fid.build();
 
-    const signer1 = Factories.Ed25519Signer.build();
-    const signer1Key = (await signer1.getSignerKey())._unsafeUnwrap();
-    await seedSigner(engine, fid1, signer1Key);
-    await seedMessagesFromTimestamp(engine, fid1, signer1, timestampToPrune);
+      const signer1 = Factories.Ed25519Signer.build();
+      const signer1Key = (await signer1.getSignerKey())._unsafeUnwrap();
+      await seedSigner(engine, fid1, signer1Key);
+      await seedMessagesFromTimestamp(engine, fid1, signer1, timestampToPrune);
 
-    const fid2 = Factories.Fid.build();
+      const fid2 = Factories.Fid.build();
 
-    const signer2 = Factories.Ed25519Signer.build();
-    const signer2Key = (await signer2.getSignerKey())._unsafeUnwrap();
-    await seedSigner(engine, fid2, signer2Key);
-    await seedMessagesFromTimestamp(engine, fid2, signer2, timestampToPrune);
+      const signer2 = Factories.Ed25519Signer.build();
+      const signer2Key = (await signer2.getSignerKey())._unsafeUnwrap();
+      await seedSigner(engine, fid2, signer2Key);
+      await seedMessagesFromTimestamp(engine, fid2, signer2, timestampToPrune);
 
-    for (const fid of [fid1, fid2]) {
-      const casts = await engine.getCastsByFid(fid);
-      expect(casts._unsafeUnwrap().messages.length).toEqual(1);
+      for (const fid of [fid1, fid2]) {
+        const casts = await engine.getCastsByFid(fid);
+        expect(casts._unsafeUnwrap().messages.length).toEqual(1);
 
-      const reactions = await engine.getReactionsByFid(fid);
-      expect(reactions._unsafeUnwrap().messages.length).toEqual(1);
-    }
+        const reactions = await engine.getReactionsByFid(fid);
+        expect(reactions._unsafeUnwrap().messages.length).toEqual(1);
+      }
 
-    const result = await scheduler.doJobs();
-    expect(result._unsafeUnwrap()).toEqual(undefined);
+      const result = await scheduler.doJobs();
+      expect(result._unsafeUnwrap()).toEqual(undefined);
 
-    for (const fid of [fid1, fid2]) {
-      const casts = await engine.getCastsByFid(fid);
-      expect(casts._unsafeUnwrap().messages).toEqual([]);
+      for (const fid of [fid1, fid2]) {
+        const casts = await engine.getCastsByFid(fid);
+        expect(casts._unsafeUnwrap().messages).toEqual([]);
 
-      const reactions = await engine.getReactionsByFid(fid);
-      expect(reactions._unsafeUnwrap().messages).toEqual([]);
-    }
+        const reactions = await engine.getReactionsByFid(fid);
+        expect(reactions._unsafeUnwrap().messages).toEqual([]);
+      }
 
-    expect(prunedMessages.length).toEqual(4);
-  });
+      expect(prunedMessages.length).toEqual(4);
+    },
+    15 * 1000
+  );
 });


### PR DESCRIPTION
## Motivation

Add a simple cache to the sync trie to prevent writing to RockDB every time. 

## Change Summary

- Add write cache
- Commit to DB when unloading trie. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
