### PR TITLE
feat: Allow setting rpcAuth via env variables

### DIFF
--- a/.changeset/famous-chefs-nail.md
+++ b/.changeset/famous-chefs-nail.md
@@ -1,0 +1,6 @@
+---
+'@farcaster/utils': patch
+'@farcaster/hubble': patch
+---
+
+Add RPC Auth via Env variables and a new getAuthMetadata method to make it easier to use RPC auth

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -134,6 +134,7 @@ app
     // try to load the config file
     const hubConfig = (await import(resolve(cliOptions.config))).Config;
 
+    // Read PeerID from 1. CLI option, 2. Environment variable, 3. Config file
     let peerId;
     if (cliOptions.id) {
       peerId = await readPeerId(resolve(cliOptions.id));
@@ -152,6 +153,16 @@ app
       logger.info({ identity: peerId.toString() }, 'Read identity from environment');
     } else {
       peerId = await readPeerId(resolve(hubConfig.id));
+    }
+
+    // Read RPC Auth from 1. CLI option, 2. Environment variable, 3. Config file
+    let rpcAuth;
+    if (cliOptions.rpcAuth) {
+      rpcAuth = cliOptions.rpcAuth;
+    } else if (process.env['RPC_AUTH']) {
+      rpcAuth = process.env['RPC_AUTH'];
+    } else {
+      rpcAuth = hubConfig.rpcAuth;
     }
 
     const hubAddressInfo = addressInfoFromParts(
@@ -198,7 +209,7 @@ app
       bootstrapAddrs,
       allowedPeers: cliOptions.allowedPeers ?? hubConfig.allowedPeers,
       rpcPort: cliOptions.rpcPort ?? hubConfig.rpcPort,
-      rpcAuth: cliOptions.rpcAuth ?? hubConfig.rpcAuth,
+      rpcAuth,
       rocksDBName: cliOptions.dbName ?? hubConfig.dbName,
       resetDB: cliOptions.dbReset ?? hubConfig.dbReset,
       rebuildSyncTrie,

--- a/apps/hubble/src/console/console.ts
+++ b/apps/hubble/src/console/console.ts
@@ -1,5 +1,5 @@
 import { Empty } from '@farcaster/protobufs';
-import { getAdminRpcClient, getHubRpcClient } from '@farcaster/utils';
+import { getAdminRpcClient, getAuthMetadata, getHubRpcClient } from '@farcaster/utils';
 import path from 'path';
 import * as repl from 'repl';
 import { ADMIN_SERVER_PORT } from '~/rpc/adminServer';
@@ -70,6 +70,9 @@ export const startConsole = async (addressString: string) => {
   commands.forEach((command) => {
     replServer.context[command.commandName()] = command.object();
   });
+
+  // Add some utility functions
+  replServer.context['getAuthMetadata'] = getAuthMetadata;
 
   // Run the info command to start
   replServer.output.write(

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -178,7 +178,7 @@ export class Hub implements HubInterface {
     this.syncEngine = new SyncEngine(this.engine, this.rocksDB);
 
     this.rpcServer = new Server(this, this.engine, this.syncEngine, this.gossipNode, options.rpcAuth);
-    this.adminServer = new AdminServer(this, this.rocksDB, this.engine, this.syncEngine);
+    this.adminServer = new AdminServer(this, this.rocksDB, this.engine, this.syncEngine, options.rpcAuth);
 
     // Create the ETH registry provider, which will fetch ETH events and push them into the engine.
     // Defaults to Goerli testnet, which is currently used for Production Farcaster Hubs.

--- a/apps/hubble/src/rpc/adminServer.ts
+++ b/apps/hubble/src/rpc/adminServer.ts
@@ -11,7 +11,7 @@ import * as net from 'net';
 import { err, ok } from 'neverthrow';
 import { HubInterface } from '~/hubble';
 import SyncEngine from '~/network/sync/syncEngine';
-import { toServiceError } from '~/rpc/server';
+import { authenticateUser, toServiceError } from '~/rpc/server';
 import RocksDB from '~/storage/db/rocksdb';
 import Engine from '~/storage/engine';
 import { logger } from '~/utils/logger';
@@ -26,7 +26,10 @@ export default class AdminServer {
   private syncEngine: SyncEngine;
   private grpcServer: GrpcServer;
 
-  constructor(hub: HubInterface, db: RocksDB, engine: Engine, syncEngine: SyncEngine) {
+  private rpcAuthUser: string | undefined;
+  private rpcAuthPass: string | undefined;
+
+  constructor(hub: HubInterface, db: RocksDB, engine: Engine, syncEngine: SyncEngine, rpcAuth?: string) {
     this.hub = hub;
     this.db = db;
     this.engine = engine;
@@ -34,6 +37,14 @@ export default class AdminServer {
 
     this.grpcServer = getServer();
     this.grpcServer.addService(AdminServiceService, this.getImpl());
+
+    const [rpcAuthUser, rpcAuthPass] = rpcAuth?.split(':') ?? [undefined, undefined];
+    if (rpcAuthUser && rpcAuthPass) {
+      this.rpcAuthUser = rpcAuthUser;
+      this.rpcAuthPass = rpcAuthPass;
+
+      log.info({ username: this.rpcAuthUser }, 'Admin RPC auth enabled');
+    }
   }
 
   async start(host = '127.0.0.1'): HubAsyncResult<undefined> {
@@ -79,6 +90,13 @@ export default class AdminServer {
     return {
       rebuildSyncTrie: (call, callback) => {
         (async () => {
+          const authResult = await authenticateUser(call.metadata, this.rpcAuthUser, this.rpcAuthPass);
+          if (authResult.isErr()) {
+            logger.warn({ errMsg: authResult.error.message }, 'rebuildSyncTrie failed');
+            callback(toServiceError(new HubError('unauthenticated', 'User is not authenticated')));
+            return;
+          }
+
           await this.syncEngine?.rebuildSyncTrie();
           callback(null, protobufs.Empty.create());
         })();
@@ -86,8 +104,14 @@ export default class AdminServer {
 
       deleteAllMessagesFromDb: (call, callback) => {
         (async () => {
-          log.warn('Deleting all messages from DB');
+          const authResult = await authenticateUser(call.metadata, this.rpcAuthUser, this.rpcAuthPass);
+          if (authResult.isErr()) {
+            logger.warn({ errMsg: authResult.error.message }, 'deleteAllMessagesFromDb failed');
+            callback(toServiceError(new HubError('unauthenticated', 'User is not authenticated')));
+            return;
+          }
 
+          log.warn('Deleting all messages from DB');
           let done = false;
           do {
             const toDelete: Buffer[] = [];
@@ -123,6 +147,13 @@ export default class AdminServer {
       },
 
       submitIdRegistryEvent: async (call, callback) => {
+        const authResult = await authenticateUser(call.metadata, this.rpcAuthUser, this.rpcAuthPass);
+        if (authResult.isErr()) {
+          logger.warn({ errMsg: authResult.error.message }, 'submitIdRegistryEvent failed');
+          callback(toServiceError(new HubError('unauthenticated', 'User is not authenticated')));
+          return;
+        }
+
         const idRegistryEvent = call.request;
         const result = await this.hub?.submitIdRegistryEvent(idRegistryEvent, 'rpc');
         result?.match(
@@ -136,6 +167,13 @@ export default class AdminServer {
       },
 
       submitNameRegistryEvent: async (call, callback) => {
+        const authResult = await authenticateUser(call.metadata, this.rpcAuthUser, this.rpcAuthPass);
+        if (authResult.isErr()) {
+          logger.warn({ errMsg: authResult.error.message }, 'submitNameRegistryEvent failed');
+          callback(toServiceError(new HubError('unauthenticated', 'User is not authenticated')));
+          return;
+        }
+
         const nameRegistryEvent = call.request;
         const result = await this.hub?.submitNameRegistryEvent(nameRegistryEvent, 'rpc');
         result?.match(

--- a/packages/utils/src/client.ts
+++ b/packages/utils/src/client.ts
@@ -119,3 +119,9 @@ export type AdminRpcClient = PromisifiedClient<AdminServiceClient>;
 export const getAdminRpcClient = async (address: string): Promise<AdminRpcClient> => {
   return promisifyClient(await getAdminClient(address));
 };
+
+export const getAuthMetadata = (username: string, password: string): Metadata => {
+  const metadata = new Metadata();
+  metadata.set('authorization', `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`);
+  return metadata;
+};


### PR DESCRIPTION
## Motivation

Allow rpcAuth to be set via 'RPC_AUTH' env variable

## Change Summary

- Accept RPC_AUTH via env variable

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
