### PR TITLE
feat: sort casts and reactions indices by timestamp

### DIFF
--- a/apps/hubble/src/storage/stores/castStore.test.ts
+++ b/apps/hubble/src/storage/stores/castStore.test.ts
@@ -148,7 +148,7 @@ describe('getCastsByParent', () => {
 
   test('returns casts that reply to a parent cast according to pageOptions', async () => {
     const castAddSameParent = await Factories.CastAddMessage.create({
-      data: { fid: castAdd.data.fid + 1, castAddBody: { parentCastId }, timestamp: castAdd.data.timestamp + 1 },
+      data: { castAddBody: { parentCastId }, timestamp: castAdd.data.timestamp + 1 },
     });
 
     await store.merge(castAdd);
@@ -162,6 +162,9 @@ describe('getCastsByParent', () => {
 
     const results2 = await store.getCastsByParent(parentCastId, { pageToken: results1.nextPageToken });
     expect(results2).toEqual({ messages: [castAddSameParent], nextPageToken: undefined });
+
+    const results3 = await store.getCastsByParent(parentCastId, { reverse: true });
+    expect(results3).toEqual({ messages: [castAddSameParent, castAdd], nextPageToken: undefined });
   });
 });
 
@@ -179,7 +182,6 @@ describe('getCastsByMention', () => {
   test('returns casts that mention an fid according to pageOptions', async () => {
     const castAdd2 = await Factories.CastAddMessage.create({
       data: {
-        fid,
         timestamp: castAdd.data.timestamp + 1,
         castAddBody: { mentions: castAdd.data.castAddBody.mentions },
       },
@@ -195,8 +197,12 @@ describe('getCastsByMention', () => {
 
       const results1 = await store.getCastsByMention(mentionFid, { pageSize: 1 });
       expect(results1.messages).toEqual([castAdd]);
+
       const results2 = await store.getCastsByMention(mentionFid, { pageToken: results1.nextPageToken });
       expect(results2).toEqual({ messages: [castAdd2], nextPageToken: undefined });
+
+      const results3 = await store.getCastsByMention(mentionFid, { reverse: true });
+      expect(results3).toEqual({ messages: [castAdd2, castAdd], nextPageToken: undefined });
     }
   });
 });


### PR DESCRIPTION
## Motivation

We want all list methods to return messages sorted by timestamp. The cast and reaction indices thus far have returned messages grouped by fid and/or reaction type and then ordered by timestamp.

## Change Summary

* Refactor cast indices to put tsHash before fid
* Refactor reaction indices to put tsHash before fid and put type in the value and filter on it

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
