### PR TITLE
docs: minor adjustments to signer related docs

### DIFF
--- a/packages/hub-nodejs/docs/Builders.md
+++ b/packages/hub-nodejs/docs/Builders.md
@@ -90,12 +90,13 @@ Returns a message which authorizes a new Ed25519 Signer to create messages on be
 #### Usage
 
 ```typescript
-import { makeSignerAdd } from '@farcaster/hub-nodejs';
+import { makeSignerAdd, hexStringToBytes } from '@farcaster/hub-nodejs';
 
-const signer = '0x027fb58156b2733495acb24248e5e3ddf7ad8be4b85321c1e598e06ed030f51f'; // public key of the Ed25519 key-pair to authorize
+const signerHex = '0x027fb58156b2733495acb24248e5e3ddf7ad8be4b85321c1e598e06ed030f51f'; // public key of the Ed25519 key-pair to authorize
+const signerBytes = hexStringToBytes(signerHex)._unsafeUnwrap();
 const name = 'foo'; // label to help the user identify this signers
 
-const signerAdd = await makeSignerAdd({ signer, name }, dataOptions, eip712Signer);
+const signerAdd = await makeSignerAdd({ signer: signerBytes, name }, dataOptions, eip712Signer);
 ```
 
 #### Returns
@@ -121,11 +122,12 @@ Returns a message which revokes a previously authorized Ed25519 Signer.
 #### Usage
 
 ```typescript
-import { makeSignerRemove } from '@farcaster/hub-nodejs';
+import { makeSignerRemove, hexStringToBytes } from '@farcaster/hub-nodejs';
 
-const signer = '0x027fb58156b2733495acb24248e5e3ddf7ad8be4b85321c1e598e06ed030f51f'; // public key of the Ed25519 key-pair to revoke
+const signerHex = '0x027fb58156b2733495acb24248e5e3ddf7ad8be4b85321c1e598e06ed030f51f'; // public key of the Ed25519 key-pair to revoke
+const signerBytes = hexStringToBytes(signerHex)._unsafeUnwrap();
 
-const signerRemove = await makeSignerRemove({ signer }, dataOptions, eip712Signer);
+const signerRemove = await makeSignerRemove({ signer: signerBytes }, dataOptions, eip712Signer);
 ```
 
 #### Returns

--- a/packages/hub-nodejs/docs/Builders.md
+++ b/packages/hub-nodejs/docs/Builders.md
@@ -92,10 +92,10 @@ Returns a message which authorizes a new Ed25519 Signer to create messages on be
 ```typescript
 import { makeSignerAdd } from '@farcaster/hub-nodejs';
 
-// Safety: input is known and cannot throw, so safe to unwrap in the example
-const addressBytes = (await eip712Signer.getSignerKey())._unsafeUnwrap();
+const signer = '0x027fb58156b2733495acb24248e5e3ddf7ad8be4b85321c1e598e06ed030f51f'; // public key of the Ed25519 key-pair to authorize
+const name = 'foo'; // label to help the user identify this signers
 
-const signerAdd = await makeSignerAdd({ signer: ed25519Signer.addressBytes, name: 'foo' }, dataOptions, eip712Signer);
+const signerAdd = await makeSignerAdd({ signer, name }, dataOptions, eip712Signer);
 ```
 
 #### Returns
@@ -123,10 +123,9 @@ Returns a message which revokes a previously authorized Ed25519 Signer.
 ```typescript
 import { makeSignerRemove } from '@farcaster/hub-nodejs';
 
-// Safety: input is known and cannot throw, so safe to unwrap in the example
-const addressBytes = (await eip712Signer.getSignerKey())._unsafeUnwrap();
+const signer = '0x027fb58156b2733495acb24248e5e3ddf7ad8be4b85321c1e598e06ed030f51f'; // public key of the Ed25519 key-pair to revoke
 
-const signerRemove = await makeSignerRemove({ signer: addressBytes }, dataOptions, eip712Signer);
+const signerRemove = await makeSignerRemove({ signer }, dataOptions, eip712Signer);
 ```
 
 #### Returns
@@ -342,10 +341,11 @@ import {
 // Safety: input is known and cannot throw, so safe to unwrap in the example
 const addressBytes = (await eip712Signer.getSignerKey())._unsafeUnwrap();
 
+const fid = 1;
 const blockHashHex = '0x1d3b0456c920eb503450c7efdcf9b5cf1f5184bf04e5d8ecbcead188a0d02018';
 const blockHashBytes = hexStringToBytes(blockHashHex)._unsafeUnwrap();
 
-const claimResult = makeVerificationEthAddressClaim(1, addressBytes, FarcasterNetwork.DEVNET, blockHashBytes);
+const claimResult = makeVerificationEthAddressClaim(fid, addressBytes, FarcasterNetwork.DEVNET, blockHashBytes);
 
 if (claimResult.isOk()) {
   const claim = claimResult.value;

--- a/packages/hub-nodejs/docs/signers/EthersEip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersEip712Signer.md
@@ -41,7 +41,9 @@ Returns the 160-bit address in bytes.
 
 ```typescript
 const ethereumAddressResult = await eip712Signer.getSignerKey();
-console.log(ethereumAddressResult._unsafeUnwrap());
+if (ethereumAddressResult.isOk()) {
+  console.log(ethereumAddressResult.value);
+}
 ```
 
 #### Returns
@@ -62,8 +64,10 @@ import { randomBytes } from 'ethers';
 
 const bytes = randomBytes(32);
 const hash = blake3(bytes, { dkLen: 20 });
-const signature = await eip712Signer.signMessageHash(hash);
-console.log(signature);
+const signatureResult = await eip712Signer.signMessageHash(hash);
+if (signatureResult.isOk()) {
+  console.log(signatureResult.value);
+}
 ```
 
 #### Returns
@@ -104,7 +108,9 @@ if (ethereumAddressResult.isOk()) {
 
   if (claimResult.isOk()) {
     const verificationResult = await eip712Signer.signVerificationEthAddressClaim(claimResult.value);
-    console.log(verificationResult);
+    if (verificationResult.isOk()) {
+      console.log(verificationResult.value);
+    }
   }
 }
 ```

--- a/packages/hub-nodejs/docs/signers/NobleEd25519Signer.md
+++ b/packages/hub-nodejs/docs/signers/NobleEd25519Signer.md
@@ -45,8 +45,10 @@ Returns the 256-bit public key in bytes.
 #### Usage
 
 ```typescript
-const signerKey = await signer.getSignerKey();
-console.log(signerKey._unsafeUnwrap());
+const signerKeyResult = await signer.getSignerKey();
+if (signerKeyResult.isOk()) {
+  console.log(signerKeyResult.value);
+}
 ```
 
 #### Returns
@@ -67,8 +69,10 @@ import { createHash, randomBytes } from 'crypto';
 const messageBytes = randomBytes(32);
 const messageHash = createHash('sha256').update(messageBytes).digest();
 
-const signature = await signer.signMessageHash(messageHash);
-console.log(signature._unsafeUnwrap());
+const signatureResult = await signer.signMessageHash(messageHash);
+if (signatureResult.isOk()) {
+  console.log(signatureResult.value);
+}
 ```
 
 #### Returns

--- a/packages/hub-nodejs/docs/signers/NobleEd25519Signer.md
+++ b/packages/hub-nodejs/docs/signers/NobleEd25519Signer.md
@@ -55,7 +55,7 @@ if (signerKeyResult.isOk()) {
 
 | Value                        | Description                          |
 | :--------------------------- | :----------------------------------- |
-| `HubAsyncResult<Uint8Array>` | Rhe 256-bit address as a Uint8Array. |
+| `HubAsyncResult<Uint8Array>` | The 256-bit address as a Uint8Array. |
 
 ### signMessageHash
 


### PR DESCRIPTION
- updates `makeSignerAdd` and `makeSignerRemove` examples to make it clear an Ed25519 public key hex string is the input to the `signer` property of `SignerAddBody` and `SignerRemoveBody`
- consistent handling of `HubAsyncResult` in signer examples