### PR TITLE
fix: Terminate webworker at end of tests

### DIFF
--- a/.changeset/wise-sloths-tan.md
+++ b/.changeset/wise-sloths-tan.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Terminate webworkers when shutting down

--- a/apps/hubble/src/eth/ethEventsProvider.test.ts
+++ b/apps/hubble/src/eth/ethEventsProvider.test.ts
@@ -104,6 +104,10 @@ beforeAll(async () => {
   mockNameRegistry = new Contract('0x000002', NameRegistry.abi, mockRPCProvider);
 });
 
+afterAll(async () => {
+  await engine.stop();
+});
+
 describe('process events', () => {
   beforeEach(async () => {
     ethEventsProvider = new EthEventsProvider(hub, mockRPCProvider, mockIdRegistry, mockNameRegistry, 1, 10000);

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -363,6 +363,9 @@ export class Hub implements HubInterface {
       await this.ethRegistryProvider.stop();
     }
 
+    // Stop the engine
+    await this.engine.stop();
+
     // Close the DB, which will flush all data to disk. Just before we close, though, write that
     // we've cleanly shutdown.
     await this.writeHubCleanShutdown(true);

--- a/apps/hubble/src/network/p2p/gossipNode.test.ts
+++ b/apps/hubble/src/network/p2p/gossipNode.test.ts
@@ -113,6 +113,10 @@ describe('GossipNode', () => {
       castAdd = await Factories.CastAddMessage.create({ data: { fid, network } }, { transient: { signer } });
     });
 
+    afterAll(async () => {
+      await engine.stop();
+    });
+
     test('gossip messages only from rpc', async () => {
       let numMessagesGossiped = 0;
       const mockGossipNode = {

--- a/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
+++ b/apps/hubble/src/network/sync/multiPeerSyncEngine.test.ts
@@ -99,6 +99,7 @@ describe('Multi peer sync engine', () => {
     clientForServer1.$.close();
     await server1.stop();
     await syncEngine1.stop();
+    await engine1.stop();
   });
 
   test('toBytes test', async () => {
@@ -188,6 +189,7 @@ describe('Multi peer sync engine', () => {
       expect(await syncEngine1.trie.rootHash()).toEqual(await syncEngine2.trie.rootHash());
 
       await syncEngine2.stop();
+      await engine2.stop();
     },
     TEST_TIMEOUT_LONG
   );
@@ -272,6 +274,9 @@ describe('Multi peer sync engine', () => {
     await sleepWhile(() => syncEngine2.syncTrieQSize > 0, 1000);
 
     expect(await syncEngine2.trie.rootHash()).toEqual(beforeRootHash);
+
+    await syncEngine2.stop();
+    await engine2.stop();
   });
 
   test('Merge with multiple signers', async () => {
@@ -327,6 +332,7 @@ describe('Multi peer sync engine', () => {
     expect(await syncEngine1.trie.items()).toEqual(await syncEngine2.trie.items());
 
     await syncEngine2.stop();
+    await engine2.stop();
   });
 
   xtest(
@@ -426,6 +432,9 @@ describe('Multi peer sync engine', () => {
       // console.log('MerkleTrie total time', totalTime, 'seconds. Messages per second:', totalMessages / totalTime);
 
       expect(await reinitSyncEngine.trie.rootHash()).toEqual(await syncEngine1.trie.rootHash());
+
+      await syncEngine2.stop();
+      await engine2.stop();
     },
     TEST_TIMEOUT_LONG
   );

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -48,6 +48,7 @@ describe('SyncEngine', () => {
 
   afterEach(async () => {
     await syncEngine.stop();
+    await engine.stop();
   });
 
   const addMessagesWithTimestamps = async (timestamps: number[]) => {
@@ -196,6 +197,7 @@ describe('SyncEngine', () => {
     expect(await syncEngine2.trie.rootHash()).toEqual(await syncEngine.trie.rootHash());
 
     await syncEngine2.stop();
+    await engine2.stop();
   });
 
   test('snapshotTimestampPrefix trims the seconds', async () => {

--- a/apps/hubble/src/network/sync/syncEnginePerf.test.ts
+++ b/apps/hubble/src/network/sync/syncEnginePerf.test.ts
@@ -39,6 +39,10 @@ describe('SyncEngine', () => {
     engine = new Engine(testDb, FarcasterNetwork.TESTNET);
   });
 
+  afterEach(async () => {
+    await engine.stop();
+  });
+
   const addMessagesWithTimestamps = async (timestamps: number[], mergeEngine?: Engine) => {
     return await Promise.all(
       timestamps.map(async (t) => {
@@ -61,13 +65,16 @@ describe('SyncEngine', () => {
       let syncEngine1;
       let syncEngine2;
 
+      let engine1;
+      let engine2;
+
       try {
         testDb.clear();
         testDb2.clear();
 
-        const engine1 = new Engine(testDb, FarcasterNetwork.TESTNET);
+        engine1 = new Engine(testDb, FarcasterNetwork.TESTNET);
         syncEngine1 = new SyncEngine(engine1, testDb);
-        const engine2 = new Engine(testDb2, FarcasterNetwork.TESTNET);
+        engine2 = new Engine(testDb2, FarcasterNetwork.TESTNET);
         syncEngine2 = new SyncEngine(engine2, testDb2);
 
         await engine1.mergeIdRegistryEvent(custodyEvent);
@@ -115,7 +122,10 @@ describe('SyncEngine', () => {
       } finally {
         Date.now = nowOrig;
         await syncEngine1?.stop();
+        await engine1?.stop();
+
         await syncEngine2?.stop();
+        await engine2?.stop();
       }
     },
     15 * 1000

--- a/apps/hubble/src/rpc/test/bulkService.test.ts
+++ b/apps/hubble/src/rpc/test/bulkService.test.ts
@@ -23,6 +23,7 @@ beforeAll(async () => {
 afterAll(async () => {
   client.$.close();
   await server.stop();
+  await engine.stop();
 });
 
 const fid = Factories.Fid.build();

--- a/apps/hubble/src/rpc/test/castService.test.ts
+++ b/apps/hubble/src/rpc/test/castService.test.ts
@@ -23,6 +23,7 @@ beforeAll(async () => {
 afterAll(async () => {
   client.$.close();
   await server.stop();
+  await engine.stop();
 });
 
 const fid = Factories.Fid.build();

--- a/apps/hubble/src/rpc/test/concurrency.test.ts
+++ b/apps/hubble/src/rpc/test/concurrency.test.ts
@@ -30,6 +30,7 @@ afterAll(async () => {
   client2.$.close();
   client3.$.close();
   await server.stop();
+  await engine.stop();
 });
 
 const fid = Factories.Fid.build();

--- a/apps/hubble/src/rpc/test/eventService.test.ts
+++ b/apps/hubble/src/rpc/test/eventService.test.ts
@@ -22,6 +22,7 @@ beforeAll(async () => {
 
 afterAll(async () => {
   await server.stop();
+  await engine.stop();
 });
 
 const fid = Factories.Fid.build();

--- a/apps/hubble/src/rpc/test/reactionService.test.ts
+++ b/apps/hubble/src/rpc/test/reactionService.test.ts
@@ -23,6 +23,7 @@ beforeAll(async () => {
 afterAll(async () => {
   client.$.close();
   await server.stop();
+  await engine.stop();
 });
 
 const fid = Factories.Fid.build();

--- a/apps/hubble/src/rpc/test/rpcAuth.test.ts
+++ b/apps/hubble/src/rpc/test/rpcAuth.test.ts
@@ -30,6 +30,10 @@ beforeAll(async () => {
   );
 });
 
+afterAll(async () => {
+  await engine.stop();
+});
+
 describe('auth tests', () => {
   test('fails with invalid password', async () => {
     const authServer = new Server(hub, engine, new SyncEngine(engine, db), undefined, 'admin:password');

--- a/apps/hubble/src/rpc/test/signerService.test.ts
+++ b/apps/hubble/src/rpc/test/signerService.test.ts
@@ -24,6 +24,7 @@ beforeAll(async () => {
 afterAll(async () => {
   client.$.close();
   await server.stop();
+  await engine.stop();
 });
 
 const assertMessagesMatchResult = (result: HubResult<protobufs.MessagesResponse>, messages: protobufs.Message[]) => {

--- a/apps/hubble/src/rpc/test/submitService.test.ts
+++ b/apps/hubble/src/rpc/test/submitService.test.ts
@@ -25,6 +25,7 @@ beforeAll(async () => {
 afterAll(async () => {
   client.$.close();
   await server.stop();
+  await engine.stop();
 });
 
 const fid = Factories.Fid.build();

--- a/apps/hubble/src/rpc/test/userDataService.test.ts
+++ b/apps/hubble/src/rpc/test/userDataService.test.ts
@@ -24,6 +24,7 @@ beforeAll(async () => {
 afterAll(async () => {
   client.$.close();
   await server.stop();
+  await engine.stop();
 });
 
 const fid = Factories.Fid.build();

--- a/apps/hubble/src/rpc/test/verificationService.test.ts
+++ b/apps/hubble/src/rpc/test/verificationService.test.ts
@@ -23,6 +23,7 @@ beforeAll(async () => {
 afterAll(async () => {
   client.$.close();
   await server.stop();
+  await engine.stop();
 });
 
 const fid = Factories.Fid.build();

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -57,6 +57,10 @@ beforeAll(async () => {
   );
 });
 
+afterAll(async () => {
+  await engine.stop();
+});
+
 describe('mergeIdRegistryEvent', () => {
   test('succeeds', async () => {
     await expect(engine.mergeIdRegistryEvent(custodyEvent)).resolves.toBeInstanceOf(Ok);
@@ -305,6 +309,7 @@ describe('mergeMessage', () => {
         )
       )
     );
+    await mainnetEngine.stop();
   });
 });
 

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -86,6 +86,12 @@ class Engine {
     }
   }
 
+  async stop(): Promise<void> {
+    if (this._validationWorker) {
+      await this._validationWorker.terminate();
+    }
+  }
+
   async mergeMessages(messages: protobufs.Message[]): Promise<Array<HubResult<number>>> {
     return Promise.all(messages.map((message) => this.mergeMessage(message)));
   }

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
@@ -34,8 +34,9 @@ beforeEach(() => {
   prunedMessages = [];
 });
 
-afterAll(() => {
+afterAll(async () => {
   engine.eventHandler.off('pruneMessage', pruneMessageListener);
+  await engine.stop();
 });
 
 describe('doJobs', () => {

--- a/apps/hubble/src/storage/jobs/revokeSignerJob.test.ts
+++ b/apps/hubble/src/storage/jobs/revokeSignerJob.test.ts
@@ -49,6 +49,10 @@ beforeAll(async () => {
   verificationRemove = await Factories.VerificationRemoveMessage.create({ data: { fid } }, { transient: { signer } });
 });
 
+afterAll(async () => {
+  await engine.stop();
+});
+
 beforeEach(async () => {
   await seedSigner(engine, fid, signerKey);
 });

--- a/apps/hubble/src/test/mocks.ts
+++ b/apps/hubble/src/test/mocks.ts
@@ -11,7 +11,7 @@ export class MockHub implements HubInterface {
 
   constructor(db: RocksDB, engine: Engine) {
     this.db = db;
-    this.engine = engine ?? new Engine(db, protobufs.FarcasterNetwork.TESTNET);
+    this.engine = engine;
   }
 
   async submitMessage(message: protobufs.Message): HubAsyncResult<number> {


### PR DESCRIPTION
## Motivation

Terminate web worker at end of tests and when hubble is shutting down

## Change Summary

- Add webworker.terminate() in stop()

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
