### PR TITLE
docs(hub-nodejs): configuration for use with ethersv5

### DIFF
--- a/packages/hub-nodejs/docs/README.md
+++ b/packages/hub-nodejs/docs/README.md
@@ -10,12 +10,11 @@
 
 ## Idiosyncrasies
 
-There are four important things to know about the package:
-
-- Fixed length data is encoded in [byte formats](./Utils.md#bytes), instead of strings.
-- Errors are handled with [a monadic pattern](./Utils.md#errors), instead of try-catch.
-- Timestamps are calculated from the [Farcaster epoch](./Utils.md#time), not the Unix epoch.
-- Only Nodejs is supported, and browser support is a [work in progress](https://github.com/farcasterxyz/hubble/issues/573).
+1. Timestamps are calculated from the [Farcaster epoch](./Utils.md#time), not the Unix epoch.
+2. Errors are handled with [a monadic pattern](./Utils.md#errors), instead of try-catch.
+3. [Ethers](https://www.npmjs.com/package/ethers) and [noble](https://www.npmjs.com/package/@noble/ed25519) are required to create new messages.
+4. Only Nodejs is supported, and browser support is a [work in progress](https://github.com/farcasterxyz/hubble/issues/573).
+5. Fixed length data is encoded in [byte formats](./Utils.md#bytes), instead of strings.
 
 There are also a few Farcaster-specific terms that are very commonly used in this package:
 
@@ -26,3 +25,75 @@ There are also a few Farcaster-specific terms that are very commonly used in thi
 | Fname    | A Farcaster username, issued by the Name Registry on Ethereum.            |
 | Hub      | A node in the Farcaster network which stores Farcaster Messages           |
 | Reaction | A public action between a user and a piece of content (e.g. like, recast) |
+
+## Troubleshooting
+
+### Ethers v5
+
+If you must use Ethers v5 in your application, implement an `Ethersv5Eip712Signer` and use it instead of the included [`EthersEip712Signer`](./signers/EthersEip712Signer.md).
+
+```typescript
+import { ResultAsync } from 'neverthrow';
+import {
+  hexStringToBytes,
+  HubAsyncResult,
+  HubError,
+  VerificationEthAddressClaim,
+  Eip712Signer,
+  eip712,
+} from '@farcaster/hub-nodejs';
+import {
+  Signer as EthersAbstractSigner,
+  TypedDataSigner as EthersTypedDataSigner,
+} from '@ethersproject/abstract-signer';
+
+export type TypedDataSigner = EthersAbstractSigner & EthersTypedDataSigner;
+
+export class Ethersv5Eip712Signer extends Eip712Signer {
+  private readonly _typedDataSigner: TypedDataSigner;
+
+  constructor(typedDataSigner: TypedDataSigner) {
+    super();
+    this._typedDataSigner = typedDataSigner;
+  }
+
+  public async getSignerKey(): HubAsyncResult<Uint8Array> {
+    return ResultAsync.fromPromise(
+      this._typedDataSigner.getAddress(),
+      (e) => new HubError('unknown', e as Error)
+    ).andThen(hexStringToBytes);
+  }
+
+  public async signMessageHash(hash: Uint8Array): HubAsyncResult<Uint8Array> {
+    const hexSignature = await ResultAsync.fromPromise(
+      this._typedDataSigner._signTypedData(
+        eip712.EIP_712_FARCASTER_DOMAIN,
+        { MessageData: eip712.EIP_712_FARCASTER_MESSAGE_DATA },
+        { hash }
+      ),
+      (e) => new HubError('bad_request.invalid_param', e as Error)
+    );
+
+    return hexSignature.andThen((hex) => hexStringToBytes(hex));
+  }
+
+  public async signVerificationEthAddressClaim(claim: VerificationEthAddressClaim): HubAsyncResult<Uint8Array> {
+    const hexSignature = await ResultAsync.fromPromise(
+      this._typedDataSigner._signTypedData(
+        eip712.EIP_712_FARCASTER_DOMAIN,
+        { VerificationClaim: eip712.EIP_712_FARCASTER_VERIFICATION_CLAIM },
+        claim
+      ),
+      (e) => new HubError('bad_request.invalid_param', e as Error)
+    );
+
+    return hexSignature.andThen((hex) => hexStringToBytes(hex));
+  }
+}
+```
+
+This can be called with
+
+```
+const signer = new EthersEip712Signer(ethersWalletInstance);
+```

--- a/packages/hub-nodejs/docs/signers/EthersEip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersEip712Signer.md
@@ -1,6 +1,6 @@
 # EthersEip712Signer
 
-An Eip712Signer that is initialized with an [ethers](https://github.com/ethers-io/ethers.js/) Ethereum wallet and can be used with [Builders](../builders/builders.md) to sign Farcaster Messages.
+An Eip712Signer that is initialized with an [Ethers v6](https://github.com/ethers-io/ethers.js/) Ethereum wallet and can be used with [Builders](../builders/builders.md) to sign Farcaster Messages. If you're looking for Ethers v5 support, see [this troubleshooting guide](../README.md#ethers-v5).
 
 ## Properties
 


### PR DESCRIPTION
## Motivation

Help users on Ethers v5 start using hub-nodejs without having to upgrade.

## Change Summary

Added documentation to explain how to write a new class to use Ethers v5.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

No changeset since this is a docs PR. 