### PR TITLE
feat: Reset DB if DB_RESET_TOKEN is set

### DIFF
--- a/.changeset/wise-peaches-remain.md
+++ b/.changeset/wise-peaches-remain.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Reset DB if DB_RESET_TOKEN is set


### PR DESCRIPTION
## Motivation

Reset DB if DB_RESET_TOKEN is set

## Change Summary

- If DB_RESET_TOKEN is set and its value is different from what it was the last time the DB started, reset the DB. 
- Write value of DB_RESET_TOKEN to disk to remember for next restarts

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
