### PR TITLE
chore: use subset of ethers Signer class

### DIFF
--- a/.changeset/hungry-nails-collect.md
+++ b/.changeset/hungry-nails-collect.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/utils': patch
+---
+
+chore: use minimally specified ethers signer type

--- a/packages/utils/src/crypto/eip712.ts
+++ b/packages/utils/src/crypto/eip712.ts
@@ -1,8 +1,11 @@
-import { recoverAddress, Signer, TypedDataEncoder } from 'ethers';
+import type { Signer } from 'ethers';
+import { recoverAddress, TypedDataEncoder } from 'ethers';
 import { err, Result, ResultAsync } from 'neverthrow';
 import { bytesToHexString, hexStringToBytes } from '../bytes';
 import { HubAsyncResult, HubError, HubResult } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
+
+export type MinimalEthersSigner = Pick<Signer, 'signTypedData' | 'getAddress'>;
 
 export const EIP_712_FARCASTER_DOMAIN = {
   name: 'Farcaster Verify Ethereum Address',
@@ -37,7 +40,7 @@ export const EIP_712_FARCASTER_MESSAGE_DATA = [
   },
 ];
 
-export const getSignerKey = async (signer: Signer): HubAsyncResult<Uint8Array> => {
+export const getSignerKey = async (signer: MinimalEthersSigner): HubAsyncResult<Uint8Array> => {
   return ResultAsync.fromPromise(signer.getAddress(), (e) => new HubError('unknown', e as Error)).andThen(
     hexStringToBytes
   );
@@ -45,7 +48,7 @@ export const getSignerKey = async (signer: Signer): HubAsyncResult<Uint8Array> =
 
 export const signVerificationEthAddressClaim = async (
   claim: VerificationEthAddressClaim,
-  signer: Signer
+  signer: MinimalEthersSigner
 ): HubAsyncResult<Uint8Array> => {
   const hexSignature = await ResultAsync.fromPromise(
     signer.signTypedData(EIP_712_FARCASTER_DOMAIN, { VerificationClaim: EIP_712_FARCASTER_VERIFICATION_CLAIM }, claim),
@@ -83,7 +86,7 @@ export const verifyVerificationEthAddressClaimSignature = (
   return recoveredHexAddress.andThen((hex) => hexStringToBytes(hex));
 };
 
-export const signMessageHash = async (hash: Uint8Array, signer: Signer): HubAsyncResult<Uint8Array> => {
+export const signMessageHash = async (hash: Uint8Array, signer: MinimalEthersSigner): HubAsyncResult<Uint8Array> => {
   const hexSignature = await ResultAsync.fromPromise(
     signer.signTypedData(EIP_712_FARCASTER_DOMAIN, { MessageData: EIP_712_FARCASTER_MESSAGE_DATA }, { hash }),
     (e) => new HubError('bad_request.invalid_param', e as Error)

--- a/packages/utils/src/signers/ethersEip712Signer.ts
+++ b/packages/utils/src/signers/ethersEip712Signer.ts
@@ -1,15 +1,14 @@
-import { Signer as EthersSigner } from 'ethers';
 import { eip712 } from '../crypto';
 import { HubAsyncResult } from '../errors';
 import { VerificationEthAddressClaim } from '../verifications';
 import { Eip712Signer } from './eip712Signer';
 
 export class EthersEip712Signer extends Eip712Signer {
-  private readonly _ethersSigner: EthersSigner;
+  private readonly _ethersSigner: eip712.MinimalEthersSigner;
 
-  constructor(typedDataSigner: EthersSigner) {
+  constructor(signer: eip712.MinimalEthersSigner) {
     super();
-    this._ethersSigner = typedDataSigner;
+    this._ethersSigner = signer;
   }
 
   public async getSignerKey(): HubAsyncResult<Uint8Array> {


### PR DESCRIPTION
Use type-only import (e.g. `import type`) to import `Signer` from ethers. This will avoid pulling in the entire `Signer` class and its dependencies at compile time.

Add `MinimalEthersSigner` that only contains the class we care about.
