### PR TITLE
feat: add storage cache to speed up pruning

### DIFF
--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -168,6 +168,7 @@ export class Hub implements HubInterface {
     this.options = options;
     this.rocksDB = new RocksDB(options.rocksDBName ? options.rocksDBName : randomDbName());
     this.gossipNode = new GossipNode();
+
     this.engine = new Engine(this.rocksDB, options.network);
     this.syncEngine = new SyncEngine(this.engine, this.rocksDB);
 
@@ -274,6 +275,8 @@ export class Hub implements HubInterface {
         log.warn('You should rebuild the sync trie (with --rebuild-sync-trie) to avoid inconsistencies');
       }
     }
+
+    await this.engine.start();
 
     // Start the ETH registry provider first
     if (this.ethRegistryProvider) {

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -58,6 +58,10 @@ beforeAll(async () => {
   );
 });
 
+beforeAll(async () => {
+  await engine.start();
+});
+
 afterAll(async () => {
   await engine.stop();
 });

--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -5,8 +5,8 @@ import { jestRocksDB } from '~/storage/db/jestUtils';
 import Engine from '~/storage/engine';
 import SignerStore from '~/storage/stores/signerStore';
 import { sleep } from '~/utils/crypto';
-import { getMessage, makeTsHash, typeToSetPostfix } from '../db/message';
-import { StoreEvents } from '../stores/storeEventHandler';
+import { getMessage, makeTsHash, typeToSetPostfix } from '~/storage/db/message';
+import { StoreEvents } from '~/storage/stores/storeEventHandler';
 
 const db = jestRocksDB('protobufs.engine.test');
 const network = protobufs.FarcasterNetwork.TESTNET;

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -64,6 +64,10 @@ class Engine {
     this.handleMergeIdRegistryEvent = this.handleMergeIdRegistryEvent.bind(this);
     this.handleRevokeMessageEvent = this.handleRevokeMessageEvent.bind(this);
     this.handlePruneMessageEvent = this.handlePruneMessageEvent.bind(this);
+  }
+
+  async start(): Promise<void> {
+    log.info('starting engine');
 
     const workerPath = './build/storage/engine/validation.worker.js';
     try {
@@ -93,10 +97,6 @@ class Engine {
     } catch (e) {
       logger.warn({ workerPath, e }, 'failed to create validation worker, falling back to main thread');
     }
-  }
-
-  async start(): Promise<void> {
-    log.info('starting engine');
 
     this.eventHandler.on('mergeIdRegistryEvent', this.handleMergeIdRegistryEvent);
     this.eventHandler.on('mergeMessage', this.handleMergeMessageEvent);
@@ -688,6 +688,10 @@ class Engine {
     if (fromAddress && fromAddress.length > 0) {
       const revokeResult = await this.revokeMessagesBySigner(idRegistryEvent.fid, fromAddress);
       if (revokeResult.isErr()) {
+        log.error(
+          { errCode: revokeResult.error.errCode },
+          `revokeMessagesBySigner error: ${revokeResult.error.message}`
+        );
         return err(revokeResult.error);
       }
     }
@@ -701,6 +705,10 @@ class Engine {
     if (protobufs.isSignerRemoveMessage(message)) {
       const revokeResult = await this.revokeMessagesBySigner(message.data.fid, message.data.signerRemoveBody.signer);
       if (revokeResult.isErr()) {
+        log.error(
+          { errCode: revokeResult.error.errCode },
+          `revokeMessagesBySigner error: ${revokeResult.error.message}`
+        );
         return err(revokeResult.error);
       }
     }
@@ -714,6 +722,10 @@ class Engine {
     if (protobufs.isSignerAddMessage(message)) {
       const revokeResult = await this.revokeMessagesBySigner(message.data.fid, message.data.signerAddBody.signer);
       if (revokeResult.isErr()) {
+        log.error(
+          { errCode: revokeResult.error.errCode },
+          `revokeMessagesBySigner error: ${revokeResult.error.message}`
+        );
         return err(revokeResult.error);
       }
     }
@@ -727,6 +739,10 @@ class Engine {
     if (protobufs.isSignerAddMessage(message)) {
       const revokeResult = await this.revokeMessagesBySigner(message.data.fid, message.data.signerAddBody.signer);
       if (revokeResult.isErr()) {
+        log.error(
+          { errCode: revokeResult.error.errCode },
+          `revokeMessagesBySigner error: ${revokeResult.error.message}`
+        );
         return err(revokeResult.error);
       }
     }

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -62,6 +62,7 @@ class Engine {
   }
 
   async start(): Promise<void> {
+    log.info('starting engine');
     const workerPath = './build/storage/engine/validation.worker.js';
     try {
       if (fs.existsSync(workerPath)) {
@@ -97,9 +98,11 @@ class Engine {
     this.eventHandler.on('pruneMessage', this.handlePruneMessageEvent.bind(this));
 
     await this._storageCache.syncFromDb(this._db);
+    log.info('engine started');
   }
 
   async stop(): Promise<void> {
+    log.info('stopping engine');
     this.eventHandler.off('mergeIdRegistryEvent', this.handleMergeIdRegistryEvent.bind(this));
     this.eventHandler.off('mergeMessage', this.handleMergeMessageEvent.bind(this));
     this.eventHandler.off('revokeMessage', this.handleRevokeMessageEvent.bind(this));
@@ -109,6 +112,7 @@ class Engine {
       await this._validationWorker.terminate();
       this._validationWorker = undefined;
     }
+    log.info('engine stopped');
   }
 
   async mergeMessages(messages: protobufs.Message[]): Promise<Array<HubResult<number>>> {

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -59,6 +59,11 @@ class Engine {
     this._castStore = new CastStore(db, this.eventHandler);
     this._userDataStore = new UserDataStore(db, this.eventHandler);
     this._verificationStore = new VerificationStore(db, this.eventHandler);
+
+    this.handleMergeMessageEvent = this.handleMergeMessageEvent.bind(this);
+    this.handleMergeIdRegistryEvent = this.handleMergeIdRegistryEvent.bind(this);
+    this.handleRevokeMessageEvent = this.handleRevokeMessageEvent.bind(this);
+    this.handlePruneMessageEvent = this.handlePruneMessageEvent.bind(this);
   }
 
   async start(): Promise<void> {
@@ -92,10 +97,10 @@ class Engine {
       logger.warn({ workerPath, e }, 'failed to create validation worker, falling back to main thread');
     }
 
-    this.eventHandler.on('mergeIdRegistryEvent', this.handleMergeIdRegistryEvent.bind(this));
-    this.eventHandler.on('mergeMessage', this.handleMergeMessageEvent.bind(this));
-    this.eventHandler.on('revokeMessage', this.handleRevokeMessageEvent.bind(this));
-    this.eventHandler.on('pruneMessage', this.handlePruneMessageEvent.bind(this));
+    this.eventHandler.on('mergeIdRegistryEvent', this.handleMergeIdRegistryEvent);
+    this.eventHandler.on('mergeMessage', this.handleMergeMessageEvent);
+    this.eventHandler.on('revokeMessage', this.handleRevokeMessageEvent);
+    this.eventHandler.on('pruneMessage', this.handlePruneMessageEvent);
 
     await this._storageCache.syncFromDb(this._db);
     log.info('engine started');
@@ -103,10 +108,10 @@ class Engine {
 
   async stop(): Promise<void> {
     log.info('stopping engine');
-    this.eventHandler.off('mergeIdRegistryEvent', this.handleMergeIdRegistryEvent.bind(this));
-    this.eventHandler.off('mergeMessage', this.handleMergeMessageEvent.bind(this));
-    this.eventHandler.off('revokeMessage', this.handleRevokeMessageEvent.bind(this));
-    this.eventHandler.off('pruneMessage', this.handlePruneMessageEvent.bind(this));
+    this.eventHandler.off('mergeIdRegistryEvent', this.handleMergeIdRegistryEvent);
+    this.eventHandler.off('mergeMessage', this.handleMergeMessageEvent);
+    this.eventHandler.off('revokeMessage', this.handleRevokeMessageEvent);
+    this.eventHandler.off('pruneMessage', this.handlePruneMessageEvent);
 
     if (this._validationWorker) {
       await this._validationWorker.terminate();

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -64,10 +64,7 @@ class Engine {
     this.handleMergeIdRegistryEvent = this.handleMergeIdRegistryEvent.bind(this);
     this.handleRevokeMessageEvent = this.handleRevokeMessageEvent.bind(this);
     this.handlePruneMessageEvent = this.handlePruneMessageEvent.bind(this);
-  }
 
-  async start(): Promise<void> {
-    log.info('starting engine');
     const workerPath = './build/storage/engine/validation.worker.js';
     try {
       if (fs.existsSync(workerPath)) {
@@ -96,6 +93,10 @@ class Engine {
     } catch (e) {
       logger.warn({ workerPath, e }, 'failed to create validation worker, falling back to main thread');
     }
+  }
+
+  async start(): Promise<void> {
+    log.info('starting engine');
 
     this.eventHandler.on('mergeIdRegistryEvent', this.handleMergeIdRegistryEvent);
     this.eventHandler.on('mergeMessage', this.handleMergeMessageEvent);

--- a/apps/hubble/src/storage/engine/storageCache.test.ts
+++ b/apps/hubble/src/storage/engine/storageCache.test.ts
@@ -1,0 +1,82 @@
+import { ok, err } from 'neverthrow';
+import { HubEvent, HubEventType } from '@farcaster/protobufs';
+import { Factories, HubError } from '@farcaster/utils';
+import { jestRocksDB } from '~/storage/db/jestUtils';
+import { putMessage } from '~/storage/db/message';
+import { UserPostfix } from '~/storage/db/types';
+import { StorageCache } from '~/storage/engine/storageCache';
+
+const db = jestRocksDB('engine.storageCache.test');
+
+let cache: StorageCache;
+
+beforeEach(() => {
+  cache = new StorageCache();
+});
+
+describe('syncFromDb', () => {
+  test('populates cache with messages from db', async () => {
+    const usage = [
+      { fid: Factories.Fid.build(), usage: { cast: 3, reaction: 2, verification: 4, userData: 1, signer: 0 } },
+      { fid: Factories.Fid.build(), usage: { cast: 2, reaction: 3, verification: 0, userData: 2, signer: 5 } },
+    ];
+    for (const fidUsage of usage) {
+      for (let i = 0; i < fidUsage.usage.cast; i++) {
+        const message = await Factories.CastAddMessage.create({ data: { fid: fidUsage.fid } });
+        await putMessage(db, message);
+      }
+
+      for (let i = 0; i < fidUsage.usage.reaction; i++) {
+        const message = await Factories.ReactionAddMessage.create({ data: { fid: fidUsage.fid } });
+        await putMessage(db, message);
+      }
+
+      for (let i = 0; i < fidUsage.usage.verification; i++) {
+        const message = await Factories.VerificationAddEthAddressMessage.create({ data: { fid: fidUsage.fid } });
+        await putMessage(db, message);
+      }
+
+      for (let i = 0; i < fidUsage.usage.userData; i++) {
+        const message = await Factories.UserDataAddMessage.create({ data: { fid: fidUsage.fid } });
+        await putMessage(db, message);
+      }
+
+      for (let i = 0; i < fidUsage.usage.signer; i++) {
+        const message = await Factories.SignerAddMessage.create({ data: { fid: fidUsage.fid } });
+        await putMessage(db, message);
+      }
+    }
+    await cache.syncFromDb(db);
+    for (const fidUsage of usage) {
+      expect(cache.getMessageCount(fidUsage.fid, UserPostfix.CastMessage)).toEqual(ok(fidUsage.usage.cast));
+      expect(cache.getMessageCount(fidUsage.fid, UserPostfix.ReactionMessage)).toEqual(ok(fidUsage.usage.reaction));
+      expect(cache.getMessageCount(fidUsage.fid, UserPostfix.VerificationMessage)).toEqual(
+        ok(fidUsage.usage.verification)
+      );
+      expect(cache.getMessageCount(fidUsage.fid, UserPostfix.UserDataMessage)).toEqual(ok(fidUsage.usage.userData));
+      expect(cache.getMessageCount(fidUsage.fid, UserPostfix.SignerMessage)).toEqual(ok(fidUsage.usage.signer));
+    }
+  });
+});
+
+describe('processEvent', () => {
+  test('increments count with merge cast message event', async () => {
+    const fid = Factories.Fid.build();
+    const message = await Factories.CastAddMessage.create({ data: { fid } });
+    const event = HubEvent.create({ type: HubEventType.MERGE_MESSAGE, mergeMessageBody: { message } });
+
+    await cache.syncFromDb(db);
+    expect(cache.getMessageCount(fid, UserPostfix.CastMessage)).toEqual(ok(0));
+    cache.processEvent(event);
+    expect(cache.getMessageCount(fid, UserPostfix.CastMessage)).toEqual(ok(1));
+  });
+
+  test('fails when cache is not synced', async () => {
+    const fid = Factories.Fid.build();
+    const message = await Factories.CastAddMessage.create({ data: { fid } });
+    const event = HubEvent.create({ type: HubEventType.MERGE_MESSAGE, mergeMessageBody: { message } });
+    expect(cache.processEvent(event)).toEqual(
+      err(new HubError('unavailable.storage_failure', 'storage cache is not synced with db'))
+    );
+  });
+});

--- a/apps/hubble/src/storage/engine/storageCache.ts
+++ b/apps/hubble/src/storage/engine/storageCache.ts
@@ -1,0 +1,101 @@
+import {
+  HubEvent,
+  isMergeMessageHubEvent,
+  isPruneMessageHubEvent,
+  isRevokeMessageHubEvent,
+  Message,
+} from '@farcaster/protobufs';
+import { ok, err } from 'neverthrow';
+import { HubError, HubResult } from '~/../../../packages/utils/dist';
+import RocksDB from '~/storage/db/rocksdb';
+import { FID_BYTES, RootPrefix, UserMessagePostfix, UserMessagePostfixMax } from '~/storage/db/types';
+import { logger } from '~/utils/logger';
+import { makeFidKey, typeToSetPostfix } from '../db/message';
+
+const makeKey = (fid: number, set: UserMessagePostfix): string => {
+  return Buffer.concat([makeFidKey(fid), Buffer.from([set])]).toString('hex');
+};
+
+const log = logger.child({ component: 'StorageCache' });
+
+export class StorageCache {
+  private _usage: Map<string, number>;
+  private _synced = false;
+
+  constructor(usage?: Map<string, number>) {
+    this._usage = usage ?? new Map();
+  }
+
+  async syncFromDb(db: RocksDB): Promise<void> {
+    log.info('starting storage cache sync');
+    const usage = new Map<string, number>();
+
+    const prefix = Buffer.from([RootPrefix.User]);
+
+    const iterator = db.iteratorByPrefix(prefix);
+
+    for await (const [key] of iterator) {
+      const postfix = (key as Buffer).readUint8(1 + FID_BYTES);
+      if (postfix < UserMessagePostfixMax) {
+        const usageKey = (key as Buffer).subarray(1, 1 + FID_BYTES + 1).toString('hex');
+        const count = usage.get(usageKey) ?? 0;
+        usage.set(usageKey, count + 1);
+      }
+    }
+
+    this._usage = usage;
+    this._synced = true;
+    log.info('storage cache synced');
+  }
+
+  getMessageCount(fid: number, set: UserMessagePostfix): HubResult<number> {
+    if (this._synced !== true) {
+      return err(new HubError('unavailable.storage_failure', 'storage cache is not synced with db'));
+    }
+    const key = makeKey(fid, set);
+    return ok(this._usage.get(key) ?? 0);
+  }
+
+  processEvent(event: HubEvent): HubResult<void> {
+    if (this._synced !== true) {
+      const error = new HubError('unavailable.storage_failure', 'storage cache is not synced with db');
+      log.error({ errCode: error.errCode }, `processEvent error: ${error.message}`);
+      return err(error);
+    }
+    if (isMergeMessageHubEvent(event)) {
+      this.addMessage(event.mergeMessageBody.message);
+      for (const message of event.mergeMessageBody.deletedMessages) {
+        this.removeMessage(message);
+      }
+    } else if (isPruneMessageHubEvent(event)) {
+      this.removeMessage(event.pruneMessageBody.message);
+    } else if (isRevokeMessageHubEvent(event)) {
+      this.removeMessage(event.revokeMessageBody.message);
+    }
+    return ok(undefined);
+  }
+
+  private addMessage(message: Message): void {
+    if (message.data !== undefined) {
+      const set = typeToSetPostfix(message.data.type);
+      const fid = message.data.fid;
+      const key = makeKey(fid, set);
+      const count = this._usage.get(key) ?? 0;
+      this._usage.set(key, count + 1);
+    }
+  }
+
+  private removeMessage(message: Message): void {
+    if (message.data !== undefined) {
+      const set = typeToSetPostfix(message.data.type);
+      const fid = message.data.fid;
+      const key = makeKey(fid, set);
+      const count = this._usage.get(key) ?? 0;
+      if (count === 0) {
+        log.error(`error: ${set} store message count is already at 0 for fid ${fid}`);
+      } else {
+        this._usage.set(key, count - 1);
+      }
+    }
+  }
+}

--- a/apps/hubble/src/storage/engine/storageCache.ts
+++ b/apps/hubble/src/storage/engine/storageCache.ts
@@ -6,11 +6,11 @@ import {
   Message,
 } from '@farcaster/protobufs';
 import { ok, err } from 'neverthrow';
-import { HubError, HubResult } from '~/../../../packages/utils/dist';
+import { HubError, HubResult } from '@farcaster/utils';
 import RocksDB from '~/storage/db/rocksdb';
 import { FID_BYTES, RootPrefix, UserMessagePostfix, UserMessagePostfixMax } from '~/storage/db/types';
 import { logger } from '~/utils/logger';
-import { makeFidKey, typeToSetPostfix } from '../db/message';
+import { makeFidKey, typeToSetPostfix } from '~/storage/db/message';
 
 const makeKey = (fid: number, set: UserMessagePostfix): string => {
   return Buffer.concat([makeFidKey(fid), Buffer.from([set])]).toString('hex');

--- a/apps/hubble/src/storage/engine/storageCache.ts
+++ b/apps/hubble/src/storage/engine/storageCache.ts
@@ -50,7 +50,9 @@ export class StorageCache {
 
   getMessageCount(fid: number, set: UserMessagePostfix): HubResult<number> {
     if (this._synced !== true) {
-      return err(new HubError('unavailable.storage_failure', 'storage cache is not synced with db'));
+      const error = new HubError('unavailable.storage_failure', 'storage cache is not synced with db');
+      log.warn({ errCode: error.errCode }, `getMessageCount error: ${error.message}`);
+      return err(error);
     }
     const key = makeKey(fid, set);
     return ok(this._usage.get(key) ?? 0);

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
@@ -4,7 +4,7 @@ import cron from 'node-cron';
 import Engine from '~/storage/engine';
 import { logger } from '~/utils/logger';
 
-export const DEFAULT_PRUNE_MESSAGES_JOB_CRON = '* * * * *'; // Every hour at :00
+export const DEFAULT_PRUNE_MESSAGES_JOB_CRON = '0 * * * *'; // Every hour at :00
 
 const log = logger.child({
   component: 'PruneMessagesJob',

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.ts
@@ -4,7 +4,7 @@ import cron from 'node-cron';
 import Engine from '~/storage/engine';
 import { logger } from '~/utils/logger';
 
-export const DEFAULT_PRUNE_MESSAGES_JOB_CRON = '0 * * * *'; // Every hour at :00
+export const DEFAULT_PRUNE_MESSAGES_JOB_CRON = '* * * * *'; // Every hour at :00
 
 const log = logger.child({
   component: 'PruneMessagesJob',

--- a/apps/hubble/src/storage/stores/castStore.ts
+++ b/apps/hubble/src/storage/stores/castStore.ts
@@ -334,13 +334,14 @@ class CastStore {
     return this._eventHandler.commitTransaction(txn, events);
   }
 
-  async pruneMessages(fid: number): HubAsyncResult<number[]> {
-    // Count number of CastAdd and CastRemove messages for this fid
-    // TODO: persist this count to avoid having to retrieve it with each call
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.CastMessage);
-    let count = 0;
-    for await (const [,] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
-      count = count + 1;
+  async pruneMessages(fid: number, count?: number): HubAsyncResult<number[]> {
+    if (count === undefined) {
+      // Count number of CastAdd and CastRemove messages for this fid
+      const prefix = makeMessagePrimaryKey(fid, UserPostfix.CastMessage);
+      count = 0;
+      for await (const [,] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
+        count = count + 1;
+      }
     }
 
     // Calculate the number of messages that need to be pruned, based on the store's size limit

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -341,13 +341,14 @@ class ReactionStore {
     return this._eventHandler.commitTransaction(txn, events);
   }
 
-  async pruneMessages(fid: number): HubAsyncResult<number[]> {
+  async pruneMessages(fid: number, count?: number): HubAsyncResult<number[]> {
     // Count number of ReactionAdd and ReactionRemove messages for this fid
-    // TODO: persist this count to avoid having to retrieve it with each call
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.ReactionMessage);
-    let count = 0;
-    for await (const [,] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
-      count = count + 1;
+    if (count === undefined) {
+      const prefix = makeMessagePrimaryKey(fid, UserPostfix.ReactionMessage);
+      count = 0;
+      for await (const [,] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
+        count = count + 1;
+      }
     }
 
     // Calculate the number of messages that need to be pruned, based on the store's size limit

--- a/apps/hubble/src/storage/stores/signerStore.ts
+++ b/apps/hubble/src/storage/stores/signerStore.ts
@@ -306,13 +306,14 @@ class SignerStore {
     return this._eventHandler.commitTransaction(txn, events);
   }
 
-  async pruneMessages(fid: number): HubAsyncResult<number[]> {
+  async pruneMessages(fid: number, count?: number): HubAsyncResult<number[]> {
     // Count number of SignerAdd and SignerRemove messages for this fid
-    // TODO: persist this count to avoid having to retrieve it with each call
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.SignerMessage);
-    let count = 0;
-    for await (const [,] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
-      count = count + 1;
+    if (count === undefined) {
+      const prefix = makeMessagePrimaryKey(fid, UserPostfix.SignerMessage);
+      count = 0;
+      for await (const [,] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
+        count = count + 1;
+      }
     }
 
     // Calculate the number of messages that need to be pruned, based on the store's size limit

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -17,6 +17,7 @@ import { err, ok, ResultAsync } from 'neverthrow';
 import { TypedEmitter } from 'tiny-typed-emitter';
 import RocksDB, { Iterator, Transaction } from '~/storage/db/rocksdb';
 import { RootPrefix } from '~/storage/db/types';
+import { StorageCache } from '~/storage/engine/storageCache';
 
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 3 * 1000; // 3 days in ms
 
@@ -124,13 +125,18 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
   private _db: RocksDB;
   private _generator: HubEventIdGenerator;
   private _lock: AsyncLock;
+  private _storageCache?: StorageCache;
 
-  constructor(db: RocksDB) {
+  constructor(db: RocksDB, storageCache?: StorageCache) {
     super();
 
     this._db = db;
     this._generator = new HubEventIdGenerator({ epoch: FARCASTER_EPOCH });
     this._lock = new AsyncLock({ maxPending: 10_000, timeout: 10_000 });
+
+    if (storageCache) {
+      this._storageCache = storageCache;
+    }
   }
 
   async getEvent(id: number): HubAsyncResult<HubEvent> {
@@ -180,7 +186,10 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
         await ResultAsync.fromPromise(this._db.commit(txn), (e) => e as HubError);
 
         for (const event of events) {
-          void this.broadcastEvent(event);
+          if (this._storageCache) {
+            this._storageCache.processEvent(event);
+          }
+          this.broadcastEvent(event);
         }
 
         return ok(events.map((event) => event.id));

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -183,7 +183,7 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
           txn = putEventTransaction(txn, event);
         }
 
-        await ResultAsync.fromPromise(this._db.commit(txn), (e) => e as HubError);
+        await this._db.commit(txn);
 
         for (const event of events) {
           if (this._storageCache) {

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -192,13 +192,14 @@ class UserDataStore {
     return this._eventHandler.commitTransaction(txn, events);
   }
 
-  async pruneMessages(fid: number): HubAsyncResult<number[]> {
+  async pruneMessages(fid: number, count?: number): HubAsyncResult<number[]> {
     // Count number of UserDataAdd messages for this fid
-    // TODO: persist this count to avoid having to retrieve it with each call
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.UserDataMessage);
-    let count = 0;
-    for await (const [,] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
-      count = count + 1;
+    if (count === undefined) {
+      const prefix = makeMessagePrimaryKey(fid, UserPostfix.UserDataMessage);
+      count = 0;
+      for await (const [,] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
+        count = count + 1;
+      }
     }
 
     // Calculate the number of messages that need to be pruned, based on the store's size limit

--- a/apps/hubble/src/storage/stores/verificationStore.ts
+++ b/apps/hubble/src/storage/stores/verificationStore.ts
@@ -236,13 +236,14 @@ class VerificationStore {
     return this._eventHandler.commitTransaction(txn, events);
   }
 
-  async pruneMessages(fid: number): HubAsyncResult<number[]> {
+  async pruneMessages(fid: number, count?: number): HubAsyncResult<number[]> {
     // Count number of verification messages for this fid
-    // TODO: persist this count to avoid having to retrieve it with each call
-    const prefix = makeMessagePrimaryKey(fid, UserPostfix.VerificationMessage);
-    let count = 0;
-    for await (const [,] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
-      count = count + 1;
+    if (count === undefined) {
+      const prefix = makeMessagePrimaryKey(fid, UserPostfix.VerificationMessage);
+      count = 0;
+      for await (const [,] of this._db.iteratorByPrefix(prefix, { keyAsBuffer: true, values: false })) {
+        count = count + 1;
+      }
     }
 
     // Calculate the number of messages that need to be pruned, based on the store's size limit

--- a/packages/utils/src/factories.ts
+++ b/packages/utils/src/factories.ts
@@ -489,7 +489,7 @@ const UserDataAddMessageFactory = Factory.define<protobufs.UserDataAddMessage, {
   }
 );
 
-/** Event Protobufs */
+/** Contract event Protobufs */
 
 const IdRegistryEventTypeFactory = Factory.define<protobufs.IdRegistryEventType>(() => {
   return faker.helpers.arrayElement([protobufs.IdRegistryEventType.REGISTER, protobufs.IdRegistryEventType.TRANSFER]);


### PR DESCRIPTION
## Motivation

Keep track of message counts per fid and store to speed up pruning.

## Change Summary

* Add `StorageCache` class that when started keeps track of the number of messages for each fid/store in memory
* Use values from storage cache when pruning to avoid having to count messages live
* Make storage engine startable and stoppable, and start validation worker and add listeners on start

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
