### PR TITLE
feat: IP based rate limiting for submitMessage RPC

### DIFF
--- a/.changeset/spicy-ants-sin.md
+++ b/.changeset/spicy-ants-sin.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Add IP-based rate limiting for submitMessage()

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -38,9 +38,9 @@
     "chance": "~1.1.11",
     "csv-stringify": "~6.3.0",
     "eslint-config-custom": "*",
-    "prettier-config-custom": "*",
     "fishery": "~2.2.2",
     "pino-pretty": "~10.0.0",
+    "prettier-config-custom": "*",
     "progress": "~2.0.3",
     "ts-mockito": "~2.6.1"
   },
@@ -65,6 +65,7 @@
     "neverthrow": "~6.0.0",
     "node-cron": "~3.0.2",
     "pino": "~8.11.0",
+    "rate-limiter-flexible": "^2.4.1",
     "rocksdb": "~5.2.1",
     "rwlock": "~5.0.0",
     "tiny-typed-emitter": "~2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6256,7 +6256,7 @@ quick-lru@^5.1.1:
   resolved "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
-rate-limiter-flexible@^2.3.11, rate-limiter-flexible@^2.3.9:
+rate-limiter-flexible@^2.3.11, rate-limiter-flexible@^2.3.9, rate-limiter-flexible@^2.4.1:
   version "2.4.1"
   resolved "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.4.1.tgz#c74cfe36ac2cbfe56f68ded9a3b4b2fde1963c41"
   integrity sha512-dgH4T44TzKVO9CLArNto62hJOwlWJMLUjVVr/ii0uUzZXEXthDNr7/yefW5z/1vvHAfycc1tnuiYyNJ8CTRB3g==


### PR DESCRIPTION
## Motivation

Add ip based rate limits for submitMessage. Currently 20k messages/min

## Change Summary

- Add IP based rate limiting

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
