### PR TITLE
fix: Remove peerIDs checked into config file

### DIFF
--- a/apps/hubble/.config/hub.config.ts
+++ b/apps/hubble/.config/hub.config.ts
@@ -19,10 +19,10 @@ export const Config = {
   /** A list of MultiAddrs to use for bootstrapping */
   // bootstrap: [],
   /** An "allow list" of Peer Ids. Blocks all other connections */
-  allowedPeers: [
-    '12D3KooWGNNs8uJkmJfThyrnESRBhfuNUAGeGrLb1PYssNnwQy11', // prod hub
-    '12D3KooWMDdQaMWCkQ8Gf3C6zdJdMEfFs8R2pw8YQw2HgoY8qhzA', // @adityapk00
-  ],
+  // allowedPeers: [
+  //   '12D3KooWGNNs8uJkmJfThyrnESRBhfuNUAGeGrLb1PYssNnwQy11', // prod hub
+  //   '12D3KooWMDdQaMWCkQ8Gf3C6zdJdMEfFs8R2pw8YQw2HgoY8qhzA', // @adityapk00
+  // ],
   /** The IP address libp2p should listen on. */
   ip: '127.0.0.1',
   /** The IP address that libp2p should announce to peers */


### PR DESCRIPTION
## Motivation

Remove the peer list in the hub config, so it can be managed via CLI args more easily. 

## Change Summary

- Remove hard coded peer list

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
