### PR TITLE
docs(hub-nodejs): more cleanups and fixes

### DIFF
--- a/packages/hub-nodejs/docs/Builders.md
+++ b/packages/hub-nodejs/docs/Builders.md
@@ -65,7 +65,7 @@ import { FarcasterNetwork, toFarcasterTime } from '@farcaster/hub-nodejs';
 
 const unixTimestamp = 1679029607159;
 
-// unsafeUnwrap() is safe here because we know the timestamp is valid
+// Safety: timestamp is known and cannot error
 const farcasterTimestamp = toFarcasterTime(unixTimestamp)._unsafeUnwrap();
 
 const dataOptions = {
@@ -95,7 +95,7 @@ Returns a message which authorizes a new Ed25519 Signer to create messages on be
 import { makeSignerAdd, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 const signerHex = '0x027fb58156b2733495acb24248e5e3ddf7ad8be4b85321c1e598e06ed030f51f'; // public key of the Ed25519 key-pair to authorize
-const signerBytes = hexStringToBytes(signerHex)._unsafeUnwrap();
+const signerBytes = hexStringToBytes(signerHex)._unsafeUnwrap(); // Safety: signerHex is known and cannot error
 const name = 'foo'; // label to help the user identify this signers
 
 const signerAdd = await makeSignerAdd({ signer: signerBytes, name }, dataOptions, eip712Signer);
@@ -127,7 +127,7 @@ Returns a message which revokes a previously authorized Ed25519 Signer.
 import { makeSignerRemove, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 const signerHex = '0x027fb58156b2733495acb24248e5e3ddf7ad8be4b85321c1e598e06ed030f51f'; // public key of the Ed25519 key-pair to revoke
-const signerBytes = hexStringToBytes(signerHex)._unsafeUnwrap();
+const signerBytes = hexStringToBytes(signerHex)._unsafeUnwrap(); // Safety: signerHex is known and cannot error
 
 const signerRemove = await makeSignerRemove({ signer: signerBytes }, dataOptions, eip712Signer);
 ```
@@ -342,7 +342,7 @@ import {
   makeVerificationEthAddressClaim,
 } from '@farcaster/hub-nodejs';
 
-// Safety: input is known and cannot throw, so safe to unwrap in the example
+// Safety: eip712Signer is known and can't error
 const addressBytes = (await eip712Signer.getSignerKey())._unsafeUnwrap();
 
 const fid = 1;
@@ -356,7 +356,7 @@ if (claimResult.isOk()) {
 
   // Sign the claim
   const ethSignResult = await eip712Signer.signVerificationEthAddressClaim(claim);
-  const ethSignature = ethSignResult._unsafeUnwrap();
+  const ethSignature = ethSignResult._unsafeUnwrap(); // Safety: claim is known and can't error
 
   // Construct a Verification Add Message with the claim signature
   const verificationBody = {
@@ -394,7 +394,7 @@ Returns a message that removes a previously added Verification.
 ```typescript
 import { makeVerificationRemove } from '@farcaster/hub-nodejs';
 
-// Safety: input is known and cannot throw, so safe to unwrap in the example
+// Safety: eip712Signer is known and can't error
 const addressBytes = (await eip712Signer.getSignerKey())._unsafeUnwrap();
 
 const verificationRemoveBody = {

--- a/packages/hub-nodejs/docs/Builders.md
+++ b/packages/hub-nodejs/docs/Builders.md
@@ -187,10 +187,12 @@ Returns a message that removes an existing Cast.
 #### Usage
 
 ```typescript
-import { makeCastRemove } from '@farcaster/hub-nodejs';
+import { hexStringToBytes, makeCastRemove } from '@farcaster/hub-nodejs';
 
-const targetHashHex = '006f082f70dfb2de81e7852f3b79f1cdf2aa6b86'; // Hash of the Cast being deleted as a hex string
-const targetHashBytes = new Uint8Array(Buffer.from(targetHashHex, 'hex')); //  Hash of the Cast being deleted as bytes
+const targetHashHex = '006f082f70dfb2de81e7852f3b79f1cdf2aa6b86';
+
+// Safety: targetHashHex is known and can't error
+const targetHashBytes = hexStringToBytes(targetHashHex)._unsafeUnwrap();
 
 const castRemove = await makeCastRemove(
   {
@@ -224,10 +226,11 @@ Returns a message that adds a Reaction to an existing Cast.
 #### Usage
 
 ```typescript
-import { makeReactionAdd, ReactionType } from '@farcaster/hub-nodejs';
+import { hexStringToBytes, makeReactionAdd, ReactionType } from '@farcaster/hub-nodejs';
 
-const targetHashHex = '006f082f70dfb2de81e7852f3b79f1cdf2aa6b86'; // Hash of the Cast being deleted as a hex string
-const targetHashBytes = new Uint8Array(Buffer.from(targetHashHex, 'hex')); //  Hash of the Cast being deleted as bytes
+const targetHashHex = '006f082f70dfb2de81e7852f3b79f1cdf2aa6b86';
+// Safety: targetHashHex is known and can't error
+const targetHashBytes = hexStringToBytes(targetHashHex)._unsafeUnwrap();
 
 const reactionLikeBody = {
   type: ReactionType.LIKE,
@@ -263,10 +266,12 @@ Returns a message that removes an existing Reaction to an existing Cast.
 #### Usage
 
 ```typescript
-import { makeReactionRemove, ReactionType } from '@farcaster/hub-nodejs';
+import { hexStringToBytes, makeReactionRemove, ReactionType } from '@farcaster/hub-nodejs';
 
-const targetHashHex = '006f082f70dfb2de81e7852f3b79f1cdf2aa6b86'; // Hash of the Cast being deleted as a hex string
-const targetHashBytes = new Uint8Array(Buffer.from(targetHashHex, 'hex')); //  Hash of the Cast being deleted as bytes
+const targetHashHex = '006f082f70dfb2de81e7852f3b79f1cdf2aa6b86';
+
+// Safety: targetHashHex is known and can't error
+const targetHashBytes = hexStringToBytes(targetHashHex)._unsafeUnwrap();
 
 const reactionLikeBody = {
   type: ReactionType.LIKE,

--- a/packages/hub-nodejs/docs/Builders.md
+++ b/packages/hub-nodejs/docs/Builders.md
@@ -112,7 +112,7 @@ const signerAdd = await makeSignerAdd({ signer: signerBytes, name }, dataOptions
 | Name          | Type                                              | Description                                                                |
 | :------------ | :------------------------------------------------ | :------------------------------------------------------------------------- |
 | `body`        | [`SignerAddBody`](./Messages.md#signeraddbody)    | A valid VerificationAddEd25519 body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions`                              | Optional arguments to construct the message.                               |
+| `dataOptions` | [`DataOptions`](#data-options)                    | Optional arguments to construct the message.                               |
 | `signer`      | [`Eip712Signer`](./signers/EthersEip712Signer.md) | An Eip712Signer generated from the user's custody address.                 |
 
 ---
@@ -143,7 +143,7 @@ const signerRemove = await makeSignerRemove({ signer: signerBytes }, dataOptions
 | Name          | Type                                                 | Description                                                      |
 | :------------ | :--------------------------------------------------- | :--------------------------------------------------------------- |
 | `body`        | [`SignerRemoveBody`](./Messages.md#signerremovebody) | A valid SignerRemove body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions`                                 | Optional metadata to construct the message.                      |
+| `dataOptions` | [`DataOptions`](#data-options)                       | Optional metadata to construct the message.                      |
 | `signer`      | [`Eip712Signer`](./signers/EthersEip712Signer.md)    | An Eip712Signer generated from the user's custody address.       |
 
 ---
@@ -175,7 +175,7 @@ const cast = await makeCastAdd(
 | Name          | Type                                               | Description                                                 |
 | :------------ | :------------------------------------------------- | :---------------------------------------------------------- |
 | `body`        | [`CastAddBody`](./Messages.md#castaddbody)         | A valid CastAdd body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions`                               | Optional metadata to construct the message.                 |
+| `dataOptions` | [`DataOptions`](#data-options)                     | Optional metadata to construct the message.                 |
 | `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md) | A currently valid Signer for the fid.                       |
 
 ---
@@ -214,7 +214,7 @@ const castRemove = await makeCastRemove(
 | Name          | Type                                               | Description                                                    |
 | :------------ | :------------------------------------------------- | :------------------------------------------------------------- |
 | `body`        | [`CastRemoveBody`](./Messages.md#castremovebody)   | A valid CastRemove body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions`                               | Optional metadata to construct the message.                    |
+| `dataOptions` | [`DataOptions`](#data-options)                     | Optional metadata to construct the message.                    |
 | `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md) | A currently valid Signer for the fid.                          |
 
 ---
@@ -254,7 +254,7 @@ const like = await makeReactionAdd(reactionLikeBody, dataOptions, ed25519Signer)
 | Name          | Type                                               | Description                                                     |
 | :------------ | :------------------------------------------------- | :-------------------------------------------------------------- |
 | `body`        | [`ReactionBody`](./Messages.md#reactionbody)       | A valid ReactionAdd body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions`                               | Optional metadata to construct the message.                     |
+| `dataOptions` | [`DataOptions`](#data-options)                     | Optional metadata to construct the message.                     |
 | `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md) | A currently valid Signer for the fid.                           |
 
 ---
@@ -295,7 +295,7 @@ const like = await makeReactionRemove(reactionLikeBody, dataOptions, ed25519Sign
 | Name          | Type                                               | Description                                                        |
 | :------------ | :------------------------------------------------- | :----------------------------------------------------------------- |
 | `body`        | [`ReactionBody`](./Messages.md#reactionbody)       | A valid ReactionRemove body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions`                               | Optional metadata to construct the message.                        |
+| `dataOptions` | [`DataOptions`](#data-options)                     | Optional metadata to construct the message.                        |
 | `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md) | A currently valid Signer for the fid.                              |
 
 ---
@@ -328,7 +328,7 @@ const userDataPfpAdd = await makeUserDataAdd(userDataPfpBody, dataOptions, ed255
 | Name          | Type                                               | Description                                                  |
 | :------------ | :------------------------------------------------- | :----------------------------------------------------------- |
 | `body`        | [`UserDataBody`](./Messages.md#userdatabody)       | A valid UserData body object containing the data to be sent. |
-| `dataOptions` | `MessageDataOptions`                               | Optional metadata to construct the message.                  |
+| `dataOptions` | [`DataOptions`](#data-options)                     | Optional metadata to construct the message.                  |
 | `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md) | A currently valid Signer for the fid.                        |
 
 ---
@@ -385,7 +385,7 @@ if (claimResult.isOk()) {
 | Name          | Type                                               | Description                                                                            |
 | :------------ | :------------------------------------------------- | :------------------------------------------------------------------------------------- |
 | `body`        | [`VerificationAddEthAddressBody`](#)               | An object which contains an Eip712 Signature from the Ethereum Address being verified. |
-| `dataOptions` | `MessageDataOptions`                               | Optional metadata to construct the message.                                            |
+| `dataOptions` | [`DataOptions`](#data-options)                     | Optional metadata to construct the message.                                            |
 | `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md) | A currently valid Signer for the fid.                                                  |
 
 ---
@@ -420,5 +420,5 @@ const verificationRemoveMessage = await makeVerificationRemove(verificationRemov
 | Name          | Type                                                             | Description                                                          |
 | :------------ | :--------------------------------------------------------------- | :------------------------------------------------------------------- |
 | `body`        | [`VerificationRemoveBody`](./Messages.md#verificationremovebody) | An object which contains data about the Verification being removed . |
-| `dataOptions` | `MessageDataOptions`                                             | Optional metadata to construct the message.                          |
+| `dataOptions` | [`DataOptions`](#data-options)                                   | Optional metadata to construct the message.                          |
 | `signer`      | [`Ed25519Signer`](./signers/NobleEd25519Signer.md)               | A currently valid Signer for the fid.                                |

--- a/packages/hub-nodejs/docs/Client.md
+++ b/packages/hub-nodejs/docs/Client.md
@@ -147,11 +147,14 @@ Returns an active signer message given an fid and the public key of the signer.
 #### Usage
 
 ```typescript
+import { getHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
+
 (async () => {
   const client = await getHubRpcClient('127.0.0.1:2283');
 
   const signerPubKeyHex = '5feb9e21f3df044197e634e3602a594a3423c71c6f208876074dc5a3e0d7b9ce';
-  const signer = Uint8Array.from(Buffer.from(signerPubKeyHex, 'hex'));
+
+  const signer = hexStringToBytes(signerPubKeyHex)._unsafeUnwrap(); // Safety: signerPubKeyHex is known and can't error
 
   const signerResult = await client.getSigner({
     fid: 2,
@@ -326,13 +329,13 @@ Returns an active cast for a user.
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = await getHubRpcClient('127.0.0.1:2283');
 
   const castHashHex = '460a87ace7014adefe4a2944fb62833b1bf2a6be';
-  const castHashBytes = Buffer.from(castHashHex, 'hex');
+  const castHashBytes = hexStringToBytes(castHashHex)._unsafeUnwrap(); // Safety: castHashHex is known and can't error
 
   const castResult = await client.getCast({ fid: 2, hash: castHashBytes });
 
@@ -432,15 +435,15 @@ Returns all active casts that are replies to a specific cast in reverse chronolo
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = await getHubRpcClient('127.0.0.1:2283');
 
   const castHashHex = 'ee04762bea3060ce3cca154bced5947de04aa253';
-  const castHashBytes = Buffer.from(castHashHex, 'hex');
+  const castHashBytes = hexStringToBytes(castHashHex)._unsafeUnwrap(); // Safety: castHashHex is known
 
-  const castsResult = await client.getCastsByParent({ fid: 2, hash: castHashBytes });
+  const castsResult = await client.getCastsByParent({ castId: { fid: 2, hash: castHashBytes } });
 
   castsResult.map((casts) => console.log(casts.messages));
 })();
@@ -504,13 +507,13 @@ Returns an active reaction of a particular type made by a user to a cast.
 #### Usage
 
 ```typescript
-import { getHubRpcClient, ReactionType } from '@farcaster/hub-nodejs';
+import { getHubRpcClient, hexStringToBytes, ReactionType } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = await getHubRpcClient('127.0.0.1:2283');
 
   const castHashHex = 'ee04762bea3060ce3cca154bced5947de04aa253'; // Cast to fetch reactions for
-  const castHashBytes = Buffer.from(castHashHex, 'hex');
+  const castHashBytes = hexStringToBytes(castHashHex)._unsafeUnwrap(); // Safety: castHashHex is known and can't error
 
   const reactionsResult = await client.getReaction({
     fid: 8150,
@@ -548,13 +551,13 @@ Returns all active reactions made by users to a cast.
 #### Usage
 
 ```typescript
-import { getHubRpcClient, ReactionType } from '@farcaster/hub-nodejs';
+import { getHubRpcClient, hexStringToBytes, ReactionType } from '@farcaster/hub-nodejs';
 
 (async () => {
   const client = await getHubRpcClient('127.0.0.1:2283');
 
   const castHashHex = 'ee04762bea3060ce3cca154bced5947de04aa253'; // Cast to fetch reactions for
-  const castHashBytes = Buffer.from(castHashHex, 'hex');
+  const castHashBytes = hexStringToBytes(castHashHex)._unsafeUnwrap(); // Safety: castHashHex is known and can't error
 
   const reactionsResult = await client.getReactionsByCast({
     reactionType: ReactionType.LIKE,

--- a/packages/hub-nodejs/docs/Client.md
+++ b/packages/hub-nodejs/docs/Client.md
@@ -670,7 +670,7 @@ import { getHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
   const client = await getHubRpcClient('127.0.0.1:2283');
 
   const addressHex = '0x2D596314b27dcf1d6a4296e95D9a4897810cE4b5';
-  const addressBytes = hexStringToBytes(addressHex)._unsafeUnwrap(); // Safety: we know the address is valid
+  const addressBytes = hexStringToBytes(addressHex)._unsafeUnwrap(); // Safety: addressHex is known and can't error
 
   const verificationResult = await client.getVerification({ fid: 2, address: addressBytes });
 

--- a/packages/hub-nodejs/docs/Utils.md
+++ b/packages/hub-nodejs/docs/Utils.md
@@ -198,9 +198,9 @@ const eip712Signer = new EthersEip712Signer(wallet);
 
 // Construct the claim object with the block number of a recent block
 const blockHashHex = '0x1d3b0456c920eb503450c7efdcf9b5cf1f5184bf04e5d8ecbcead188a0d02018';
-const blockHashBytes = hexStringToBytes(blockHashHex)._unsafeUnwrap();
+const blockHashBytes = hexStringToBytes(blockHashHex)._unsafeUnwrap(); // Safety: blockHashHex is known and can't error
 
-const addressBytes = (await eip712Signer.getSignerKey())._unsafeUnwrap();
+const addressBytes = (await eip712Signer.getSignerKey())._unsafeUnwrap(); // Safety: eip712Signer is known and can't error
 const claimResult = makeVerificationEthAddressClaim(1, addressBytes, FarcasterNetwork.DEVNET, blockHashBytes);
 ```
 

--- a/packages/hub-nodejs/docs/signers/EthersEip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersEip712Signer.md
@@ -94,7 +94,7 @@ Generates a 256-bit signature for a VerificationClaim and returns the bytes.
 import { FarcasterNetwork, hexStringToBytes, makeVerificationEthAddressClaim } from '@farcaster/hub-nodejs';
 
 const blockHashHex = '0x1d3b0456c920eb503450c7efdcf9b5cf1f5184bf04e5d8ecbcead188a0d02018';
-const blockHashBytes = hexStringToBytes(blockHashHex)._unsafeUnwrap(); // Safety: we control the input and know it's valid
+const blockHashBytes = hexStringToBytes(blockHashHex)._unsafeUnwrap(); // Safety: blockHashHex is known and can't error
 
 const ethereumAddressResult = await eip712Signer.getSignerKey();
 

--- a/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
+++ b/packages/hub-nodejs/docs/signers/EthersV5Eip712Signer.md
@@ -94,7 +94,7 @@ Generates a 256-bit signature for a VerificationClaim and returns the bytes.
 import { FarcasterNetwork, hexStringToBytes, makeVerificationEthAddressClaim } from '@farcaster/hub-nodejs';
 
 const blockHashHex = '0x1d3b0456c920eb503450c7efdcf9b5cf1f5184bf04e5d8ecbcead188a0d02018';
-const blockHashBytes = hexStringToBytes(blockHashHex)._unsafeUnwrap(); // Safety: we control the input and know it's valid
+const blockHashBytes = hexStringToBytes(blockHashHex)._unsafeUnwrap(); // Safety: blockHashHex is known and can't erro
 
 const ethereumAddressResult = await eip712Signer.getSignerKey();
 


### PR DESCRIPTION
## Motivation

More cleanups for documentation. 

## Change Summary

- document unsafeUnwrap usage consistently
- replace all instances of `Buffer.from` with `hexStringToBytes`

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

No changeset for docs only PRs