### PR TITLE
fix: Share dns name when gossiping contactinfo

### DIFF
--- a/.changeset/ten-ducks-roll.md
+++ b/.changeset/ten-ducks-roll.md
@@ -1,0 +1,6 @@
+---
+'@farcaster/protobufs': patch
+'@farcaster/hubble': patch
+---
+
+Gossip dnsName when sharing contact info

--- a/apps/hubble/.config/hub.config.ts
+++ b/apps/hubble/.config/hub.config.ts
@@ -27,6 +27,8 @@ export const Config = {
   ip: '127.0.0.1',
   /** The IP address that libp2p should announce to peers */
   // announceIp: '',
+  /** The server name to announce to peers */
+  // announceServerName: '',
   /** The TCP port libp2p should listen on. */
   gossipPort: DEFAULT_GOSSIP_PORT,
   /** The RPC port to use. */

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -51,6 +51,10 @@ app
     '--announce-ip <ip-address>',
     'The IP address libp2p should announce to other peers. If not provided, the IP address will be fetched from an external service'
   )
+  .option(
+    '--announce-server-name <name>',
+    'The name of the server to announce to peers. This is useful if you have SSL/TLS enabled. (default: "none")'
+  )
   .option('-g, --gossip-port <port>', 'The tcp port libp2p should gossip over. (default: 2282)')
   .option('-r, --rpc-port <port>', 'The tcp port that the rpc server should listen on.  (default: 2283)')
   .option(
@@ -244,6 +248,7 @@ app
       peerId,
       ipMultiAddr: ipMultiAddrResult.value,
       announceIp: cliOptions.announceIp ?? hubConfig.announceIp,
+      announceServerName: cliOptions.announceServerName ?? hubConfig.announceServerName,
       gossipPort: hubAddressInfo.value.port,
       network,
       ethRpcUrl: cliOptions.ethRpcUrl ?? hubConfig.ethRpcUrl,

--- a/apps/hubble/src/network/sync/syncEngine.ts
+++ b/apps/hubble/src/network/sync/syncEngine.ts
@@ -338,13 +338,15 @@ class SyncEngine extends TypedEmitter<SyncEvents> {
     }
     this._syncMergeQ -= messages.length;
 
-    log.info(
-      {
-        total: mergeResults.length,
-        success: mergeResults.filter((r) => r.isOk()).length,
-      },
-      'Merged messages'
-    );
+    if (mergeResults.length > 0) {
+      log.info(
+        {
+          total: mergeResults.length,
+          success: mergeResults.filter((r) => r.isOk()).length,
+        },
+        'Merged messages'
+      );
+    }
 
     // If there was a failed merge, log the error and move on. We'll only log one error, since they're likely all the same.
     const failedMerge = mergeResults.find((r) => r.isErr());

--- a/apps/hubble/src/utils/p2p.ts
+++ b/apps/hubble/src/utils/p2p.ts
@@ -76,10 +76,16 @@ export const p2pMultiAddrStr = (addressInfo: AddressInfo, peerID: string): HubRe
 
 /* Converts GossipAddressInfo to net.AddressInfo */
 export const addressInfoFromGossip = (addressInfo: GossipAddressInfo): HubResult<AddressInfo> => {
-  const address = addressInfo.address;
+  const dnsName = addressInfo.dnsName;
   const port = addressInfo.port;
   const family = addressInfo.family;
+
+  let address = addressInfo.address;
+  if (dnsName && dnsName !== '') {
+    address = dnsName;
+  }
   if (!address || family === 0) return err(new HubError('bad_request.parse_failure', 'Invalid address'));
+
   const addrInfo: AddressInfo = {
     address,
     port,

--- a/packages/protobufs/src/generated/gossip.ts
+++ b/packages/protobufs/src/generated/gossip.ts
@@ -30,6 +30,7 @@ export interface GossipAddressInfo {
   address: string;
   family: number;
   port: number;
+  dnsName: string;
 }
 
 export interface ContactInfoContent {
@@ -49,7 +50,7 @@ export interface GossipMessage {
 }
 
 function createBaseGossipAddressInfo(): GossipAddressInfo {
-  return { address: '', family: 0, port: 0 };
+  return { address: '', family: 0, port: 0, dnsName: '' };
 }
 
 export const GossipAddressInfo = {
@@ -62,6 +63,9 @@ export const GossipAddressInfo = {
     }
     if (message.port !== 0) {
       writer.uint32(24).uint32(message.port);
+    }
+    if (message.dnsName !== '') {
+      writer.uint32(34).string(message.dnsName);
     }
     return writer;
   },
@@ -82,6 +86,9 @@ export const GossipAddressInfo = {
         case 3:
           message.port = reader.uint32();
           break;
+        case 4:
+          message.dnsName = reader.string();
+          break;
         default:
           reader.skipType(tag & 7);
           break;
@@ -95,6 +102,7 @@ export const GossipAddressInfo = {
       address: isSet(object.address) ? String(object.address) : '',
       family: isSet(object.family) ? Number(object.family) : 0,
       port: isSet(object.port) ? Number(object.port) : 0,
+      dnsName: isSet(object.dnsName) ? String(object.dnsName) : '',
     };
   },
 
@@ -103,6 +111,7 @@ export const GossipAddressInfo = {
     message.address !== undefined && (obj.address = message.address);
     message.family !== undefined && (obj.family = Math.round(message.family));
     message.port !== undefined && (obj.port = Math.round(message.port));
+    message.dnsName !== undefined && (obj.dnsName = message.dnsName);
     return obj;
   },
 
@@ -115,6 +124,7 @@ export const GossipAddressInfo = {
     message.address = object.address ?? '';
     message.family = object.family ?? 0;
     message.port = object.port ?? 0;
+    message.dnsName = object.dnsName ?? '';
     return message;
   },
 };

--- a/packages/protobufs/src/schemas/gossip.proto
+++ b/packages/protobufs/src/schemas/gossip.proto
@@ -11,6 +11,7 @@ message GossipAddressInfo {
   string address = 1;
   uint32 family = 2;
   uint32 port = 3;
+  string dns_name = 4;
 }
 
 message ContactInfoContent {


### PR DESCRIPTION
## Motivation

When SSL/TLS is enabled, we also need the server name to be gossiped, so clients can actually check the SSL cert.

## Change Summary

- add `dnsName` to contact info gossip
- Allow setting `--announce-server-name` to set DNS name of server

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
