### PR TITLE
docs(hub-nodejs): more cleanup based on user testing

### DIFF
--- a/.changeset/witty-trainers-bake.md
+++ b/.changeset/witty-trainers-bake.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hub-nodejs': patch
+---
+
+fixed documentation links on npm

--- a/packages/hub-nodejs/README.md
+++ b/packages/hub-nodejs/README.md
@@ -9,7 +9,7 @@ A lightweight, fast Typescript interface for Farcaster Hubs. Designed to work wi
 - Has helpers to create and sign Farcaster messages.
 - Written entirely in TypeScript, with strict types for safety.
 
-Read the [documentation](./docs/README.md), see more [examples](./examples/) or get started with the guide below.
+Read the [documentation](https://github.com/farcasterxyz/hubble/tree/main/packages/hub-nodejs/docs), see more [examples](https://github.com/farcasterxyz/hubble/tree/main/packages/hub-nodejs/examples) or get started with the guide below.
 
 ## Installation
 
@@ -39,7 +39,7 @@ import { getHubRpcClient } from '@farcaster/hub-nodejs';
 
 ## Contributing
 
-Please see our [contributing guidelines](../../CONTRIBUTING.md) before making a pull request.
+Please see our [contributing guidelines](https://github.com/farcasterxyz/hubble/blob/main/CONTRIBUTING.md) before making a pull request.
 
 ## License
 

--- a/packages/hub-nodejs/docs/Client.md
+++ b/packages/hub-nodejs/docs/Client.md
@@ -830,6 +830,9 @@ import { getHubRpcClient } from '@farcaster/hub-nodejs';
 
   const message; // Any valid message constructed with a Builder
 
+  const authMetadata = getAuthMetadata('username', 'password'); // Only necessary if the hubble instance requires auth
+  const submitResult = await client.submitMessage(message, authMetadata);
+
   const submitResult = await client.submitMessage(message);
   console.log(submitResult);
 })();
@@ -843,11 +846,10 @@ import { getHubRpcClient } from '@farcaster/hub-nodejs';
 
 #### Parameters
 
-| Name        | Type      | Description                        |
-| :---------- | :-------- | :--------------------------------- |
-| `message`   | `Message` | The message being submitted        |
-| `username?` | `string`  | (optional) Username for basic auth |
-| `password?` | `string`  | (optional) Password for basic auth |
+| Name        | Type      | Description                                                  |
+| :---------- | :-------- | :----------------------------------------------------------- |
+| `message`   | `Message` | The message being submitted                                  |
+| `metadata?` | `string`  | (optional) Username and password metadata for authentication |
 
 ---
 

--- a/packages/hub-nodejs/examples/README.md
+++ b/packages/hub-nodejs/examples/README.md
@@ -1,16 +1,15 @@
 # Examples
 
-A collection of Typescript examples showcasing the things you can do with hub-nodejs.
+A collection of Typescript examples showcasing the things you can do with `hub-nodejs`. Each example is a self-
+contained repository that includes a StackBlitz link to run it in a cloud REPL.
 
-Each example is a self-contained repository that can be checked out and executed locally, and also includes a
-StackBlitz link to run it in a cloud REPL. Contributions are always welcome!
+- [Generate a chronological feed](./chron-feed/)
+- [Writing data for a user](./write-data/)
+- [Building casts correctly](./make-cast/)
 
-- [Generate a chronological feed](./feed/)
-- [Writing data with a signer](./write-data/)
-- [Constructing casts with mentions and embeds](./make-cast/)
-
-Other examples that would be useful to developers:
+Other examples that should be added:
 
 - Subscribe to updates about a user
+- Rotating signers without losing messages
 
-- Rotating Signers gracefully
+Contributions for these examples and more are welcome!

--- a/packages/hub-nodejs/examples/chron-feed/README.md
+++ b/packages/hub-nodejs/examples/chron-feed/README.md
@@ -1,3 +1,3 @@
 ## Generate a chronological feed
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/farcasterxyz/hubble/tree/main/packages/hub-nodejs/examples/feed)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/farcasterxyz/hubble/tree/main/packages/hub-nodejs/examples/chron-feed)


### PR DESCRIPTION
## Motivation

Fixing issues discovered from having users play around with the docs.

## Change Summary

- `submitMessage` signature was documented incorrectly
-  links to feed example and stackblitz were broken
- relative links were not working on the lib's npm page 

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
