### PR TITLE
fix(hubble): crash by bumping ethers to 6.2.1

### DIFF
--- a/.changeset/tame-avocados-develop.md
+++ b/.changeset/tame-avocados-develop.md
@@ -1,0 +1,7 @@
+---
+'@farcaster/hub-nodejs': patch
+'@farcaster/utils': patch
+'@farcaster/hubble': patch
+---
+
+upgrade ethers to 6.2.1

--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -60,7 +60,7 @@
     "@multiformats/multiaddr": "^11.0.0",
     "async-lock": "^1.4.0",
     "commander": "~10.0.0",
-    "ethers": "~6.1.0",
+    "ethers": "~6.2.1",
     "libp2p": "0.42.2",
     "neverthrow": "~6.0.0",
     "node-cron": "~3.0.2",

--- a/packages/hub-nodejs/package.json
+++ b/packages/hub-nodejs/package.json
@@ -19,7 +19,7 @@
     "@farcaster/protobufs": "0.1.9",
     "@farcaster/utils": "0.3.0",
     "@noble/hashes": "^1.3.0",
-    "ethers": "~6.1.0",
+    "ethers": "~6.2.1",
     "neverthrow": "^6.0.0"
   },
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,7 +21,7 @@
     "@farcaster/protobufs": "0.1.9",
     "@noble/ed25519": "^1.7.3",
     "@noble/hashes": "^1.3.0",
-    "ethers": "~6.1.0",
+    "ethers": "~6.2.1",
     "neverthrow": "^6.0.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,10 +35,10 @@
     uuid "^8.3.2"
     xml2js "^0.4.23"
 
-"@adraffy/ens-normalize@1.8.9":
-  version "1.8.9"
-  resolved "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.8.9.tgz#67b3acadebbb551669c9a1da15fac951db795b85"
-  integrity sha512-93OmGCV0vO8+JQ3FHG+gZk/MPHzzMPDRiCiFcCQNTCnHaaxsacO3ScTPGlu2wX2dOtgfalbchPcw1cOYYjHCYQ==
+"@adraffy/ens-normalize@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz#223572538f6bea336750039bb43a4016dcc8182d"
+  integrity sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ==
 
 "@ampproject/remapping@^2.2.0":
   version "2.2.0"
@@ -4011,12 +4011,12 @@ esutils@^2.0.2:
     "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
 
-ethers@~6.1.0:
-  version "6.1.0"
-  resolved "https://registry.npmjs.org/ethers/-/ethers-6.1.0.tgz#de9c3acbb865fda6c080e80ec88ae0aada046947"
-  integrity sha512-aC45YGbvgXt7Nses5WsdQwc1cUIrrQt32zeFShNW7ZT3RQCIHBnd4nmbE5sJmrp70uTdwkRHkr4cZr1D/YwFPg==
+ethers@~6.2.1:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/ethers/-/ethers-6.2.1.tgz#3ba2c4ff02e6131828bd8b6bfa0885d112bd43b4"
+  integrity sha512-bwDC1A6a0NlokpjzYGnKSVo68eBNsTRdzN0nHgmpTsvowEuRDHorhMiFg/tx/7WMl2bGESfABsfH0MPZUp+EJQ==
   dependencies:
-    "@adraffy/ens-normalize" "1.8.9"
+    "@adraffy/ens-normalize" "1.9.0"
     "@noble/hashes" "1.1.2"
     "@noble/secp256k1" "1.7.1"
     aes-js "4.0.0-beta.3"


### PR DESCRIPTION
## Motivation

Ethers 6.x threw an unhandled exception if the RPC connection was open due to a listener and the server errored out. See: https://github.com/ethers-io/ethers.js/issues/3924 

## Change Summary

Upgrade ethers to 6.2.1

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [x] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)