### PR TITLE
chore: bump ethers to 6.2.1

### DIFF
--- a/apps/hubble/package.json
+++ b/apps/hubble/package.json
@@ -60,7 +60,7 @@
     "@multiformats/multiaddr": "^11.0.0",
     "async-lock": "^1.4.0",
     "commander": "~10.0.0",
-    "ethers": "~6.1.0",
+    "ethers": "^6.2.1",
     "libp2p": "0.42.2",
     "neverthrow": "~6.0.0",
     "node-cron": "~3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,6 +40,11 @@
   resolved "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.8.9.tgz#67b3acadebbb551669c9a1da15fac951db795b85"
   integrity sha512-93OmGCV0vO8+JQ3FHG+gZk/MPHzzMPDRiCiFcCQNTCnHaaxsacO3ScTPGlu2wX2dOtgfalbchPcw1cOYYjHCYQ==
 
+"@adraffy/ens-normalize@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz#223572538f6bea336750039bb43a4016dcc8182d"
+  integrity sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ==
+
 "@ampproject/remapping@^2.2.0":
   version "2.2.0"
   resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -4010,6 +4015,18 @@ esutils@^2.0.2:
     "@ethersproject/wallet" "5.7.0"
     "@ethersproject/web" "5.7.1"
     "@ethersproject/wordlists" "5.7.0"
+
+ethers@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.npmjs.org/ethers/-/ethers-6.2.1.tgz#3ba2c4ff02e6131828bd8b6bfa0885d112bd43b4"
+  integrity sha512-bwDC1A6a0NlokpjzYGnKSVo68eBNsTRdzN0nHgmpTsvowEuRDHorhMiFg/tx/7WMl2bGESfABsfH0MPZUp+EJQ==
+  dependencies:
+    "@adraffy/ens-normalize" "1.9.0"
+    "@noble/hashes" "1.1.2"
+    "@noble/secp256k1" "1.7.1"
+    aes-js "4.0.0-beta.3"
+    tslib "2.4.0"
+    ws "8.5.0"
 
 ethers@~6.1.0:
   version "6.1.0"


### PR DESCRIPTION
This error was causing us trouble if we could't connect to our provider.

Fixed here https://github.com/ethers-io/ethers.js/issues/3924