### PR TITLE
feat: commit one event at a time

### DIFF
--- a/apps/hubble/src/storage/db/message.ts
+++ b/apps/hubble/src/storage/db/message.ts
@@ -231,6 +231,16 @@ export const getMessagesPageByPrefix = async <T extends protobufs.Message>(
   }
 };
 
+export const getMessagesBySignerIterator = (
+  db: RocksDB,
+  fid: number,
+  signer: Uint8Array,
+  type?: protobufs.MessageType
+): Iterator => {
+  const prefix = makeMessageBySignerKey(fid, signer, type);
+  return db.iteratorByPrefix(prefix, { values: false });
+};
+
 /** Get an array of messages for a given fid and signer */
 export const getAllMessagesBySigner = async <T extends protobufs.Message>(
   db: RocksDB,

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -770,7 +770,9 @@ class Engine {
             (e) =>
               log.error(
                 { errCode: e.errCode },
-                `failed to revoke message ${fnameAddHex} for fid ${fid} due to NameRegistryEvent transfer: ${e.message}`
+                `failed to revoke message ${fnameAddHex._unsafeUnwrap()} for fid ${fid} due to NameRegistryEvent transfer: ${
+                  e.message
+                }`
               )
           );
         }

--- a/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
+++ b/apps/hubble/src/storage/jobs/pruneMessagesJob.test.ts
@@ -26,7 +26,8 @@ const pruneMessageListener = (event: protobufs.PruneMessageHubEvent) => {
   prunedMessages.push(event.pruneMessageBody.message);
 };
 
-beforeAll(() => {
+beforeAll(async () => {
+  await engine.start();
   engine.eventHandler.on('pruneMessage', pruneMessageListener);
 });
 

--- a/apps/hubble/src/storage/stores/storeEventHandler.test.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.test.ts
@@ -1,6 +1,6 @@
 import { CastAddMessage, HubEvent, HubEventType } from '@farcaster/protobufs';
 import { Factories } from '@farcaster/utils';
-import { ok } from 'neverthrow';
+import { ok, Result } from 'neverthrow';
 import { jestRocksDB } from '~/storage/db/jestUtils';
 import { getMessage, makeTsHash, putMessageTransaction } from '~/storage/db/message';
 import { UserPostfix } from '~/storage/db/types';
@@ -58,9 +58,9 @@ describe('commitTransaction', () => {
       mergeMessageBody: { message, deletedMessages: [] },
     };
 
-    const result = await eventHandler.commitTransaction(txn, [eventArgs]);
+    const result = await eventHandler.commitTransaction(txn, eventArgs);
     expect(result.isOk()).toBeTruthy();
-    const [eventId] = result._unsafeUnwrap();
+    const eventId = result._unsafeUnwrap();
     expect(eventId).toBeGreaterThan(0);
     await expect(
       getMessage(
@@ -75,38 +75,38 @@ describe('commitTransaction', () => {
     expect(events).toEqual([event._unsafeUnwrap()]);
   });
 
-  test('saves and broadcasts events in order', async () => {
-    const events1: HubEventArgs[] = [];
-    const events2: HubEventArgs[] = [];
+  // test('saves and broadcasts events in order', async () => {
+  //   const events1: HubEventArgs[] = [];
+  //   const events2: HubEventArgs[] = [];
 
-    for (let i = 0; i < 10; i++) {
-      const message = await Factories.Message.create();
-      const eventBody = { type: HubEventType.MERGE_MESSAGE, mergeMessageBody: { message, deletedMessages: [] } };
-      if (Math.random() > 0.5) {
-        events1.push(eventBody);
-      } else {
-        events2.push(eventBody);
-      }
-    }
+  //   for (let i = 0; i < 10; i++) {
+  //     const message = await Factories.Message.create();
+  //     const eventBody = { type: HubEventType.MERGE_MESSAGE, mergeMessageBody: { message, deletedMessages: [] } };
+  //     if (Math.random() > 0.5) {
+  //       events1.push(eventBody);
+  //     } else {
+  //       events2.push(eventBody);
+  //     }
+  //   }
 
-    const [result1, result2] = await Promise.all([
-      eventHandler.commitTransaction(db.transaction(), events1),
-      eventHandler.commitTransaction(db.transaction(), events2),
-    ]);
+  //   const [result1, result2] = await Promise.all([
+  //     eventHandler.commitTransaction(db.transaction(), events1),
+  //     eventHandler.commitTransaction(db.transaction(), events2),
+  //   ]);
 
-    expect(result1.isOk()).toBeTruthy();
-    expect(result2.isOk()).toBeTruthy();
+  //   expect(result1.isOk()).toBeTruthy();
+  //   expect(result2.isOk()).toBeTruthy();
 
-    expect(Math.max(...result1._unsafeUnwrap())).toBeLessThan(Math.min(...result2._unsafeUnwrap()));
+  //   expect(Math.max(...result1._unsafeUnwrap())).toBeLessThan(Math.min(...result2._unsafeUnwrap()));
 
-    expect(events.length).toEqual(10);
+  //   expect(events.length).toEqual(10);
 
-    let lastId = 0;
-    for (const event of events) {
-      expect(event.id).toBeGreaterThan(lastId);
-      lastId = event.id;
-    }
-  });
+  //   let lastId = 0;
+  //   for (const event of events) {
+  //     expect(event.id).toBeGreaterThan(lastId);
+  //     lastId = event.id;
+  //   }
+  // });
 });
 
 describe('pruneEvents', () => {
@@ -127,12 +127,18 @@ describe('pruneEvents', () => {
       mergeMessageBody: { message: message3, deletedMessages: [] },
     };
 
-    const result1 = await eventHandler.commitTransaction(db.transaction(), [eventArgs1, eventArgs2]);
+    const result1 = Result.combine([
+      await eventHandler.commitTransaction(db.transaction(), eventArgs1),
+      await eventHandler.commitTransaction(db.transaction(), eventArgs2),
+    ]);
     expect(result1.isOk()).toBeTruthy();
 
     await sleep(2_000);
 
-    const result2 = await eventHandler.commitTransaction(db.transaction(), [eventArgs3, eventArgs4]);
+    const result2 = Result.combine([
+      await eventHandler.commitTransaction(db.transaction(), eventArgs3),
+      await eventHandler.commitTransaction(db.transaction(), eventArgs4),
+    ]);
     expect(result2.isOk()).toBeTruthy();
 
     const allEvents1 = await eventHandler.getEvents();

--- a/apps/hubble/src/storage/stores/storeEventHandler.test.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.test.ts
@@ -74,39 +74,6 @@ describe('commitTransaction', () => {
     expect(event).toMatchObject(ok(eventArgs));
     expect(events).toEqual([event._unsafeUnwrap()]);
   });
-
-  // test('saves and broadcasts events in order', async () => {
-  //   const events1: HubEventArgs[] = [];
-  //   const events2: HubEventArgs[] = [];
-
-  //   for (let i = 0; i < 10; i++) {
-  //     const message = await Factories.Message.create();
-  //     const eventBody = { type: HubEventType.MERGE_MESSAGE, mergeMessageBody: { message, deletedMessages: [] } };
-  //     if (Math.random() > 0.5) {
-  //       events1.push(eventBody);
-  //     } else {
-  //       events2.push(eventBody);
-  //     }
-  //   }
-
-  //   const [result1, result2] = await Promise.all([
-  //     eventHandler.commitTransaction(db.transaction(), events1),
-  //     eventHandler.commitTransaction(db.transaction(), events2),
-  //   ]);
-
-  //   expect(result1.isOk()).toBeTruthy();
-  //   expect(result2.isOk()).toBeTruthy();
-
-  //   expect(Math.max(...result1._unsafeUnwrap())).toBeLessThan(Math.min(...result2._unsafeUnwrap()));
-
-  //   expect(events.length).toEqual(10);
-
-  //   let lastId = 0;
-  //   for (const event of events) {
-  //     expect(event.id).toBeGreaterThan(lastId);
-  //     lastId = event.id;
-  //   }
-  // });
 });
 
 describe('pruneEvents', () => {

--- a/apps/hubble/src/storage/stores/storeEventHandler.ts
+++ b/apps/hubble/src/storage/stores/storeEventHandler.ts
@@ -191,36 +191,6 @@ class StoreEventHandler extends TypedEmitter<StoreEvents> {
       });
   }
 
-  // async commitTransaction(txn: Transaction, eventArgs: HubEventArgs[]): HubAsyncResult<number[]> {
-  //   return this._lock
-  //     .acquire('commit', async () => {
-  //       const events: HubEvent[] = [];
-
-  //       for (const args of eventArgs) {
-  //         const eventId = this._generator.generateId();
-  //         if (eventId.isErr()) {
-  //           throw eventId.error;
-  //         }
-  //         const event = HubEvent.create({ ...args, id: eventId.value });
-  //         // TODO: validate event
-  //         events.push(event);
-  //         txn = putEventTransaction(txn, event);
-  //       }
-
-  //       await this._db.commit(txn);
-
-  //       for (const event of events) {
-  //         void this._storageCache.processEvent(event);
-  //         void this.broadcastEvent(event);
-  //       }
-
-  //       return ok(events.map((event) => event.id));
-  //     })
-  //     .catch((e: Error) => {
-  //       return err(isHubError(e) ? e : new HubError('unavailable.storage_failure', e.message));
-  //     });
-  // }
-
   async pruneEvents(timeLimit?: number): HubAsyncResult<void> {
     const toId = makeEventId(Date.now() - FARCASTER_EPOCH - (timeLimit ?? PRUNE_TIME_LIMIT_DEFAULT), 0);
 

--- a/apps/hubble/src/storage/stores/types.ts
+++ b/apps/hubble/src/storage/stores/types.ts
@@ -2,8 +2,6 @@ import * as protobufs from '@farcaster/protobufs';
 
 export const MERGE_TIMEOUT_DEFAULT = 10_000; // 10 seconds
 
-export const COMMIT_BATCH_DEFAULT = 100; // 100 messages per commit transaction
-
 export type StorePruneOptions = {
   pruneSizeLimit?: number; // Max number of messages per fid
   pruneTimeLimit?: number; // Max age (in seconds) of any message in the store

--- a/apps/hubble/src/storage/stores/types.ts
+++ b/apps/hubble/src/storage/stores/types.ts
@@ -2,6 +2,8 @@ import * as protobufs from '@farcaster/protobufs';
 
 export const MERGE_TIMEOUT_DEFAULT = 10_000; // 10 seconds
 
+export const COMMIT_BATCH_DEFAULT = 100; // 100 messages per commit transaction
+
 export type StorePruneOptions = {
   pruneSizeLimit?: number; // Max number of messages per fid
   pruneTimeLimit?: number; // Max age (in seconds) of any message in the store

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -5,7 +5,6 @@ import { err, ok, ResultAsync } from 'neverthrow';
 import { getIdRegistryEventByCustodyAddress } from '~/storage/db/idRegistryEvent';
 import {
   deleteMessageTransaction,
-  getAllMessagesBySigner,
   getMessage,
   getMessagesPageByPrefix,
   getMessagesPruneIterator,
@@ -141,11 +140,12 @@ class UserDataStore {
       }
     }
 
-    const result = await this._eventHandler.commitTransaction(txn, events);
+    // TODO
+    const result = await this._eventHandler.commitTransaction(txn, events[0] as any);
     if (result.isErr()) {
       throw result.error;
     }
-    return result.value[0] as number;
+    return result.value;
   }
 
   /** Merges a UserDataAdd message into the set */
@@ -167,88 +167,80 @@ class UserDataStore {
       });
   }
 
-  async revokeMessagesBySigner(fid: number, signer: Uint8Array): HubAsyncResult<number[]> {
-    // Get all UserDataAdd messages signed by signer
-    const userDataAdds = await ResultAsync.fromPromise(
-      getAllMessagesBySigner<protobufs.UserDataAddMessage>(this._db, fid, signer, protobufs.MessageType.USER_DATA_ADD),
-      (e) => e as HubError
-    );
-    if (userDataAdds.isErr()) {
-      return err(userDataAdds.error);
-    }
-
-    // Create a rocksdb transaction
+  async revoke(message: protobufs.Message): HubAsyncResult<number> {
     let txn = this._db.transaction();
-
-    // Create list of events to broadcast
-    const events: Omit<protobufs.RevokeMessageHubEvent, 'id'>[] = [];
-
-    // Add a delete operation to the transaction for each UserDataAdd
-    for (const message of userDataAdds.value) {
+    if (protobufs.isUserDataAddMessage(message)) {
       txn = this.deleteUserDataAddTransaction(txn, message);
-      events.push({ type: protobufs.HubEventType.REVOKE_MESSAGE, revokeMessageBody: { message } });
+    } else {
+      return err(new HubError('bad_request.invalid_param', 'invalid message type'));
     }
 
-    if (events.length > 0) {
-      return this._eventHandler.commitTransaction(txn, events);
-    } else {
-      return ok([]);
-    }
+    return this._eventHandler.commitTransaction(txn, {
+      type: protobufs.HubEventType.REVOKE_MESSAGE,
+      revokeMessageBody: { message },
+    });
   }
 
   async pruneMessages(fid: number): HubAsyncResult<number[]> {
-    let sizeToPrune: number;
+    const commits: number[] = [];
+
     const cachedCount = this._eventHandler.getCacheMessageCount(fid, UserPostfix.UserDataMessage);
-    if (cachedCount.isOk()) {
-      sizeToPrune = cachedCount.value - this._pruneSizeLimit;
-    } else {
-      // Count number of UserDataAdd messages for this fid
-      const prefix = makeMessagePrimaryKey(fid, UserPostfix.UserDataMessage);
-      let calculatedCount = 0;
-      for await (const [,] of this._db.iteratorByPrefix(prefix, { values: false })) {
-        calculatedCount = calculatedCount + 1;
-      }
-      sizeToPrune = calculatedCount - this._pruneSizeLimit;
+
+    // Require storage cache to be synced to prune
+    if (cachedCount.isErr()) {
+      return err(cachedCount.error);
     }
 
-    // Keep track of the messages that get pruned so that we can emit pruneMessage events after the transaction settles
-    const events: Omit<protobufs.PruneMessageHubEvent, 'id'>[] = [];
-
-    // Create a rocksdb transaction to include all the mutations
-    let pruneTxn = this._db.transaction();
+    // Return immediately if there are no messages to prune
+    if (cachedCount.value === 0) {
+      return ok(commits);
+    }
 
     // Create a rocksdb iterator for all messages with the given prefix
     const pruneIterator = getMessagesPruneIterator(this._db, fid, UserPostfix.UserDataMessage);
 
-    const getNextResult = () => ResultAsync.fromPromise(getNextMessageFromIterator(pruneIterator), () => undefined);
-
-    // For each message in order, prune it if the store is over the size limit
-    let nextMessage = await getNextResult();
-    while (nextMessage.isOk() && sizeToPrune > 0) {
-      const message = nextMessage.value;
-
-      // Add a delete operation to the transaction depending on the message type
-      if (protobufs.isUserDataAddMessage(message)) {
-        pruneTxn = this.deleteUserDataAddTransaction(pruneTxn, message);
-      } else {
-        throw new HubError('unknown', 'invalid message type');
+    const pruneNextMessage = async (): HubAsyncResult<number | undefined> => {
+      const nextMessage = await ResultAsync.fromPromise(getNextMessageFromIterator(pruneIterator), () => undefined);
+      if (nextMessage.isErr()) {
+        return ok(undefined); // Nothing left to prune
       }
 
-      // Create prune event body and store for broadcasting later
-      events.push({ type: protobufs.HubEventType.PRUNE_MESSAGE, pruneMessageBody: { message } });
+      const count = this._eventHandler.getCacheMessageCount(fid, UserPostfix.UserDataMessage);
+      if (count.isErr()) {
+        return err(count.error);
+      }
 
-      // Decrement the number of messages yet to prune, and try to get the next message from the iterator
-      sizeToPrune = Math.max(0, sizeToPrune - 1);
-      nextMessage = await getNextResult();
+      if (count.value <= this._pruneSizeLimit) {
+        return ok(undefined);
+      }
+
+      let txn = this._db.transaction();
+
+      if (protobufs.isUserDataAddMessage(nextMessage.value)) {
+        txn = this.deleteUserDataAddTransaction(txn, nextMessage.value);
+      } else {
+        return err(new HubError('unknown', 'invalid message type'));
+      }
+
+      return this._eventHandler.commitTransaction(txn, {
+        type: protobufs.HubEventType.PRUNE_MESSAGE,
+        pruneMessageBody: { message: nextMessage.value },
+      });
+    };
+
+    let pruneResult = await pruneNextMessage();
+    while (pruneResult.isOk() && pruneResult.value !== undefined) {
+      commits.push(pruneResult.value);
+      pruneResult = await pruneNextMessage();
     }
 
     await pruneIterator.end();
 
-    if (events.length > 0) {
-      return this._eventHandler.commitTransaction(pruneTxn, events);
-    } else {
-      return ok([]);
+    if (pruneResult.isErr()) {
+      return err(pruneResult.error);
     }
+
+    return ok(commits);
   }
 
   /* -------------------------------------------------------------------------- */
@@ -273,11 +265,11 @@ class UserDataStore {
     };
 
     // Commit the RocksDB transaction
-    const result = await this._eventHandler.commitTransaction(txn, [hubEvent]);
+    const result = await this._eventHandler.commitTransaction(txn, hubEvent);
     if (result.isErr()) {
       throw result.error;
     }
-    return result.value[0] as number;
+    return result.value;
   }
 
   private userDataMessageCompare(aTimestampHash: Uint8Array, bTimestampHash: Uint8Array): number {

--- a/apps/hubble/src/test/bench/syncEngine.ts
+++ b/apps/hubble/src/test/bench/syncEngine.ts
@@ -34,9 +34,10 @@ class MockEngine {
   }
 
   async mergeMessage(message: protobufs.Message): Promise<HubResult<void>> {
-    await this.eventHandler.commitTransaction(this.db.transaction(), [
-      { type: protobufs.HubEventType.MERGE_MESSAGE, mergeMessageBody: { message, deletedMessages: [] } },
-    ]);
+    await this.eventHandler.commitTransaction(this.db.transaction(), {
+      type: protobufs.HubEventType.MERGE_MESSAGE,
+      mergeMessageBody: { message, deletedMessages: [] },
+    });
 
     return ok(undefined);
   }


### PR DESCRIPTION
## Motivation

Pruning and revoking messages should happen gradually and not clog the commit queue.

## Change Summary

* Only allow one event to be committed at a time
* Break pruning and revoking messages up into many commits
* Ensure prune and revoke iterators are closed, even if there is a failure
* Move revoking of UserDataAdd messages when fnames are transferred into engine

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [ ] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
