### PR TITLE
fix: Attempt cleanshutdown on unexpected exceptions

### DIFF
--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -73,8 +73,8 @@ app
       await hub.stop();
     };
 
-    const handleShutdownSignal = (signal: NodeJS.Signals) => {
-      logger.warn(`${signal} received`);
+    const handleShutdownSignal = (signalName: string) => {
+      logger.warn(`${signalName} received`);
       if (!isExiting) {
         isExiting = true;
         teardown(hub)
@@ -297,13 +297,15 @@ app
     process.on('uncaughtException', (err) => {
       logger.error({ reason: 'Uncaught exception' }, 'shutting down hub');
       logger.fatal(err);
-      process.exit(1);
+
+      handleShutdownSignal('uncaughtException');
     });
 
     process.on('unhandledRejection', (err) => {
       logger.error({ reason: 'Unhandled Rejection' }, 'shutting down hub');
       logger.fatal(err);
-      process.exit(1);
+
+      handleShutdownSignal('unhandledRejection');
     });
   });
 


### PR DESCRIPTION
## Motivation

When an unexpected rejection or exception occurs, attempt to clean shutdown first before force-exiting

## Change Summary

- Attempt clean shutdown with errors
- Rebuild sync trie if previous shutdown was not clean

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
