### PR TITLE
feat: Dynamically recover from syncTrie corruption

### DIFF
--- a/apps/hubble/.config/hub.config.ts
+++ b/apps/hubble/.config/hub.config.ts
@@ -35,6 +35,8 @@ export const Config = {
   rpcPort: DEFAULT_RPC_PORT,
   /** RPC Auth, disabled by default */
   // rpcAuth: 'admin:password',
+  /** Per-IP rate limiting for the RPC server*/
+  rpcRateLimit: 20000,
   /** The name of the RocksDB instance */
   dbName: 'rocks.hub._default',
   /** Clear the RocksDB instance before starting */

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -61,6 +61,10 @@ app
     '--rpc-auth <username:password>',
     'Enable Auth for RPC submit methods with the username and password. (default: disabled)'
   )
+  .option(
+    '--rpc-rate-limit <number>',
+    'Impose a Per IP rate limit per minute. Set to -1 for no rate limits (default: 20k/min)'
+  )
   .option('--admin-server-enabled', 'Enable the admin server. (default: disabled)')
   .option('--admin-server-host <host>', "The host the admin server should listen on. (default: '127.0.0.1')")
   .option('--db-name <name>', 'The name of the RocksDB instance')

--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -187,7 +187,7 @@ describe('MerkleTrie', () => {
         await Promise.all(syncIds.map(async (syncId) => expect(await trie2.exists(syncId)).toBeTruthy()));
 
         // Delete half the items from the first trie
-        await Promise.all(syncIds.slice(0, syncIds.length / 2).map(async (syncId) => trie.delete(syncId)));
+        await Promise.all(syncIds.slice(0, syncIds.length / 2).map(async (syncId) => trie.deleteBySyncId(syncId)));
         await trie.commitToDb();
 
         // Initialize a new trie from the same DB
@@ -227,7 +227,7 @@ describe('MerkleTrie', () => {
 
       expect(await trie.exists(syncId)).toBeTruthy();
 
-      await trie.delete(syncId);
+      await trie.deleteBySyncId(syncId);
       expect(await trie.items()).toEqual(0);
       expect(await trie.rootHash()).toEqual(EMPTY_HASH);
 
@@ -240,7 +240,7 @@ describe('MerkleTrie', () => {
 
       const rootHashBeforeDelete = await trie.rootHash();
       const syncId2 = await NetworkFactories.SyncId.create();
-      expect(await trie.delete(syncId2)).toBeFalsy();
+      expect(await trie.deleteBySyncId(syncId2)).toBeFalsy();
 
       const rootHashAfterDelete = await trie.rootHash();
       expect(rootHashAfterDelete).toEqual(rootHashBeforeDelete);
@@ -255,7 +255,7 @@ describe('MerkleTrie', () => {
       const rootHashBeforeDelete = await trie.rootHash();
       trie.insert(syncId2);
 
-      trie.delete(syncId2);
+      trie.deleteBySyncId(syncId2);
       expect(await trie.rootHash()).toEqual(rootHashBeforeDelete);
     });
 
@@ -267,7 +267,7 @@ describe('MerkleTrie', () => {
       await firstTrie.insert(syncId1);
       await firstTrie.insert(syncId2);
 
-      await firstTrie.delete(syncId1);
+      await firstTrie.deleteBySyncId(syncId1);
 
       const secondTrie = new MerkleTrie(db2);
       await secondTrie.insert(syncId2);
@@ -290,7 +290,7 @@ describe('MerkleTrie', () => {
       expect(count).toEqual(1 + TIMESTAMP_LENGTH);
 
       // Delete
-      await trie.delete(id);
+      await trie.deleteBySyncId(id);
       await trie.commitToDb();
 
       count = await forEachDbItem(db);
@@ -309,7 +309,7 @@ describe('MerkleTrie', () => {
       expect(count).toBeGreaterThan(1 + TIMESTAMP_LENGTH);
 
       // Delete
-      await trie.delete(syncId1);
+      await trie.deleteBySyncId(syncId1);
       await trie.commitToDb();
 
       count = await forEachDbItem(db);
@@ -336,7 +336,7 @@ describe('MerkleTrie', () => {
       await Promise.all(syncIds.map(async (syncId) => trie.insert(syncId)));
 
       // Delete half of the items
-      await Promise.all(syncIds.slice(0, syncIds.length / 2).map(async (syncId) => trie.delete(syncId)));
+      await Promise.all(syncIds.slice(0, syncIds.length / 2).map(async (syncId) => trie.deleteBySyncId(syncId)));
 
       // Check that the items are still there
       await Promise.all(
@@ -364,7 +364,7 @@ describe('MerkleTrie', () => {
 
       expect(await trie2.rootHash()).toEqual(rootHash);
 
-      expect(await trie2.delete(syncId1)).toBeTruthy();
+      expect(await trie2.deleteBySyncId(syncId1)).toBeTruthy();
       await trie2.commitToDb();
 
       expect(await trie2.rootHash()).not.toEqual(rootHash);
@@ -386,7 +386,7 @@ describe('MerkleTrie', () => {
       (await trie.getNode(new Uint8Array()))?.unloadChildren();
 
       // Now try deleting syncId1
-      expect(await trie.delete(syncId1)).toBeTruthy();
+      expect(await trie.deleteBySyncId(syncId1)).toBeTruthy();
       await trie.commitToDb();
 
       expect(await trie.rootHash()).not.toEqual(rootHash);

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -124,11 +124,15 @@ class MerkleTrie {
     });
   }
 
-  public async delete(id: SyncId): Promise<boolean> {
+  public async deleteBySyncId(id: SyncId): Promise<boolean> {
+    return this.deleteByBytes(id.syncId());
+  }
+
+  public async deleteByBytes(id: Uint8Array): Promise<boolean> {
     return new Promise((resolve) => {
       this._lock.writeLock(async (release) => {
         try {
-          const { status, dbUpdatesMap } = await this._root.delete(id.syncId(), this._db, new Map());
+          const { status, dbUpdatesMap } = await this._root.delete(id, this._db, new Map());
           this._updatePendingDbUpdates(dbUpdatesMap);
           await this._unloadFromMemory();
 

--- a/apps/hubble/src/rpc/server.ts
+++ b/apps/hubble/src/rpc/server.ts
@@ -258,6 +258,7 @@ export default class Server {
               messages.filter((message) => message.data === undefined || message.hash.length === 0).length > 0;
 
             if (corruptedMessages) {
+              log.warn({ component: 'gRPC Server' }, 'Found corrupted messages, rebuilding some syncIDs');
               // Don't wait for this to finish, just return the messages we have.
               this.syncEngine?.rebuildSyncIds(request.syncIds);
               messages = messages.filter((message) => message.data !== undefined && message.hash.length > 0);


### PR DESCRIPTION
## Motivation

Dynamically recover from sync trie corruption. 

## Change Summary

- Check outgoing messages to remove unavailable messages from the sync trie. 

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
