### PR TITLE
docs: Use SSL or Insecure clients in examples

### DIFF
--- a/.changeset/chilly-bats-kneel.md
+++ b/.changeset/chilly-bats-kneel.md
@@ -1,8 +1,8 @@
 ---
-'@farcaster/hub-nodejs': patch
-'@farcaster/protobufs': patch
-'@farcaster/utils': patch
-'@farcaster/hubble': patch
+'@farcaster/hub-nodejs': minor
+'@farcaster/protobufs': minor
+'@farcaster/utils': minor
+'@farcaster/hubble': minor
 ---
 
 Remove getHubRpcClient, use getSSLRpcClient() or getInsecureRpcClient()

--- a/.changeset/chilly-bats-kneel.md
+++ b/.changeset/chilly-bats-kneel.md
@@ -1,0 +1,8 @@
+---
+'@farcaster/hub-nodejs': patch
+'@farcaster/protobufs': patch
+'@farcaster/utils': patch
+'@farcaster/hubble': patch
+---
+
+Remove getHubRpcClient, use getSSLRpcClient() or getInsecureRpcClient()

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -384,8 +384,9 @@ app
     'Farcaster RPC server address:port to connect to (eg. 127.0.0.1:2283)',
     DEFAULT_RPC_CONSOLE
   )
+  .option('--insecure', 'Allow insecure connections to the RPC server', false)
   .action(async (cliOptions) => {
-    startConsole(cliOptions.server);
+    startConsole(cliOptions.server, cliOptions.insecure);
   });
 
 const readPeerId = async (filePath: string) => {

--- a/apps/hubble/src/console/console.ts
+++ b/apps/hubble/src/console/console.ts
@@ -1,5 +1,5 @@
 import { Empty, Metadata } from '@farcaster/protobufs';
-import { getAdminRpcClient, getAuthMetadata, getHubRpcClient } from '@farcaster/utils';
+import { getAdminRpcClient, getAuthMetadata, getInsecureHubRpcClient, getSSLHubRpcClient } from '@farcaster/utils';
 import path from 'path';
 import * as repl from 'repl';
 import { ADMIN_SERVER_PORT } from '~/rpc/adminServer';
@@ -19,7 +19,7 @@ export interface ConsoleCommandInterface {
   object(): any;
 }
 
-export const startConsole = async (addressString: string) => {
+export const startConsole = async (addressString: string, useInsecure: boolean) => {
   const replServer = repl
     .start({
       prompt: 'hub> ',
@@ -40,7 +40,13 @@ export const startConsole = async (addressString: string) => {
     }
   });
 
-  const rpcClient = await getHubRpcClient(addressString);
+  let rpcClient;
+  if (useInsecure) {
+    rpcClient = getInsecureHubRpcClient(addressString);
+  } else {
+    rpcClient = getSSLHubRpcClient(addressString);
+  }
+
   // Admin server is only available on localhost
   const adminClient = await getAdminRpcClient(`127.0.0.1:${ADMIN_SERVER_PORT}`);
 

--- a/packages/hub-nodejs/README.md
+++ b/packages/hub-nodejs/README.md
@@ -26,10 +26,10 @@ pnpm install @farcaster/hub-nodejs
 ### Fetching Data from Hubs
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const castsResult = await client.getCastsByFid({ fid: 2 });
 

--- a/packages/hub-nodejs/docs/Client.md
+++ b/packages/hub-nodejs/docs/Client.md
@@ -21,8 +21,8 @@ import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
   const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   // To manually choose the authentication method, use these methods instead.
-  // const sslClient = await getSSLHubRpcClient('127.0.0.1:2283');
-  // const insecureClient = await getInsecureClient('127.0.0.1:2283');
+  // const sslClient = getSSLHubRpcClient('127.0.0.1:2283');
+  // const insecureClient = getInsecureClient('127.0.0.1:2283');
 })();
 ```
 

--- a/packages/hub-nodejs/docs/Client.md
+++ b/packages/hub-nodejs/docs/Client.md
@@ -10,15 +10,15 @@ with the IP address and gRPC port of the Hub. Once connected, a Client instance 
 
 ### Constructor
 
-getHubRpcClient returns a Hub RPC Client, defaulting to an SSL connection if supported.
+getInsecureHubRpcClient returns a Hub RPC Client. Use getSSLHubRpcClient if the server you're using supports SSL.
 
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   // To manually choose the authentication method, use these methods instead.
   // const sslClient = await getSSLHubRpcClient('127.0.0.1:2283');
@@ -110,10 +110,10 @@ if (castResult.isOk()) {
 Methods that return multiple values support pagination in requests with a `pageSize` and `pageToken` property.
 
 ```typescript
-import { getHubRpcClient, HubResult, MessagesResponse } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient, HubResult, MessagesResponse } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   let nextPageToken: Uint8Array | undefined = undefined;
   let isNextPage = true;
@@ -147,10 +147,10 @@ Returns an active signer message given an fid and the public key of the signer.
 #### Usage
 
 ```typescript
-import { getHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const signerPubKeyHex = '5feb9e21f3df044197e634e3602a594a3423c71c6f208876074dc5a3e0d7b9ce';
 
@@ -187,10 +187,10 @@ Returns all active signers created by an fid in reverse chronological order.
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const signersResult = await client.getAllSignerMessagesByFid({ fid: 2 });
 
@@ -222,10 +222,10 @@ Returns all active and inactive signers created by an fid in reverse chronologic
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const signersResult = await client.getAllSignerMessagesByFid({ fid: 2 });
 
@@ -257,10 +257,10 @@ Returns a specific piece of metadata about the user.
 #### Usage
 
 ```typescript
-import { getHubRpcClient, UserDataType } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient, UserDataType } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const userDataResult = await client.getUserData({ fid: 2, userDataType: UserDataType.DISPLAY });
 
@@ -290,10 +290,10 @@ Returns all metadata about the user.
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const userDataResult = await client.getAllUserDataMessagesByFid({ fid: 2 });
 
@@ -329,10 +329,10 @@ Returns an active cast for a user.
 #### Usage
 
 ```typescript
-import { getHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const castHashHex = '460a87ace7014adefe4a2944fb62833b1bf2a6be';
   const castHashBytes = hexStringToBytes(castHashHex)._unsafeUnwrap(); // Safety: castHashHex is known and can't error
@@ -365,10 +365,10 @@ Returns active casts for a user in reverse chronological order.
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const castsResult = await client.getCastsByFid({ fid: 2 });
 
@@ -400,10 +400,10 @@ Returns all active casts that mention an fid in reverse chronological order.
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const castsResult = await client.getCastsByMention({ fid: 2 });
 
@@ -435,10 +435,10 @@ Returns all active casts that are replies to a specific cast in reverse chronolo
 #### Usage
 
 ```typescript
-import { getHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const castHashHex = 'ee04762bea3060ce3cca154bced5947de04aa253';
   const castHashBytes = hexStringToBytes(castHashHex)._unsafeUnwrap(); // Safety: castHashHex is known
@@ -473,10 +473,10 @@ Returns all active and inactive casts for a user in reverse chronological order.
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const castsResult = await client.getAllCastMessagesByFid({ fid: 2 });
   castsResult.map((casts) => console.log(casts.messages));
@@ -507,10 +507,10 @@ Returns an active reaction of a particular type made by a user to a cast.
 #### Usage
 
 ```typescript
-import { getHubRpcClient, hexStringToBytes, ReactionType } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient, hexStringToBytes, ReactionType } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const castHashHex = 'ee04762bea3060ce3cca154bced5947de04aa253'; // Cast to fetch reactions for
   const castHashBytes = hexStringToBytes(castHashHex)._unsafeUnwrap(); // Safety: castHashHex is known and can't error
@@ -551,10 +551,10 @@ Returns all active reactions made by users to a cast.
 #### Usage
 
 ```typescript
-import { getHubRpcClient, hexStringToBytes, ReactionType } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient, hexStringToBytes, ReactionType } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const castHashHex = 'ee04762bea3060ce3cca154bced5947de04aa253'; // Cast to fetch reactions for
   const castHashBytes = hexStringToBytes(castHashHex)._unsafeUnwrap(); // Safety: castHashHex is known and can't error
@@ -596,10 +596,10 @@ Returns all active reactions made by a user in reverse chronological order.
 #### Usage
 
 ```typescript
-import { getHubRpcClient, ReactionType } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient, ReactionType } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const reactionsResult = await client.getReactionsByFid({ fid: 2, reactionType: ReactionType.LIKE });
 
@@ -632,10 +632,10 @@ Returns all active and inactive reactions made by a user in reverse chronologica
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const reactionsResult = await client.getAllReactionMessagesByFid({ fid: 2 });
 
@@ -667,10 +667,10 @@ Returns an active verification for a specific Ethereum address made by a user.
 #### Usage
 
 ```typescript
-import { getHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient, hexStringToBytes } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const addressHex = '0x2D596314b27dcf1d6a4296e95D9a4897810cE4b5';
   const addressBytes = hexStringToBytes(addressHex)._unsafeUnwrap(); // Safety: addressHex is known and can't error
@@ -703,10 +703,10 @@ Returns all active verifications for Ethereum addresses made by a user in revers
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const verificationsResult = await client.getVerificationsByFid({ fid: 2 });
 
@@ -742,10 +742,10 @@ Returns all active and inactive verifications for Ethereum addresses made by a u
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const verificationsResult = await client.getAllVerificationMessagesByFid({ fid: 2 });
 
@@ -785,10 +785,10 @@ which helps with recovery when clients get disconnected temporarily.
 #### Usage
 
 ```typescript
-import { getHubRpcClient, HubEventType } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient, HubEventType } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const subscribeResult = await client.subscribe({
     eventTypes: [HubEventType.MERGE_MESSAGE],
@@ -826,10 +826,10 @@ Submits a new message to the Hub. A Hub can choose to require basic authenticati
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const message; // Any valid message constructed with a Builder
 
@@ -863,10 +863,10 @@ Returns the on-chain event most recently associated with changing an fid's owner
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const idrResult = await client.getIdRegistryEvent({ fid: 2 });
 
@@ -895,10 +895,10 @@ Returns the on-chain event most recently associated with changing an fname's own
 #### Usage
 
 ```typescript
-import { getHubRpcClient } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/hub-nodejs';
 
 (async () => {
-  const client = await getHubRpcClient('127.0.0.1:2283');
+  const client = getInsecureHubRpcClient('127.0.0.1:2283');
 
   const fnameBytes = new TextEncoder().encode('v');
   const nrResult = await client.getNameRegistryEvent({ name: fnameBytes });

--- a/packages/hub-nodejs/examples/chron-feed/index.ts
+++ b/packages/hub-nodejs/examples/chron-feed/index.ts
@@ -74,7 +74,7 @@ const castToString = (cast: CastAddMessage, nameMapping: Map<number, string>) =>
 (async () => {
   // Set address as an environment variable or pass in directly here
   const client = getInsecureHubRpcClient(HUB_URL);
-  // const client = await getSSLHubRpcClient(HUB_URL); // Use this if you're using SSL
+  // const client = getSSLHubRpcClient(HUB_URL); // Use this if you're using SSL
 
   // 1. Create a mapping of fids to fnames, which we'll need later to display messages
   const fidToFname = new Map<number, string>();

--- a/packages/hub-nodejs/examples/chron-feed/index.ts
+++ b/packages/hub-nodejs/examples/chron-feed/index.ts
@@ -3,7 +3,7 @@
 import {
   CastAddMessage,
   fromFarcasterTime,
-  getHubRpcClient,
+  getInsecureHubRpcClient,
   HubAsyncResult,
   HubRpcClient,
   isCastAddMessage,
@@ -73,7 +73,8 @@ const castToString = (cast: CastAddMessage, nameMapping: Map<number, string>) =>
 
 (async () => {
   // Set address as an environment variable or pass in directly here
-  const client = await getHubRpcClient(HUB_URL);
+  const client = getInsecureHubRpcClient(HUB_URL);
+  // const client = await getSSLHubRpcClient(HUB_URL); // Use this if you're using SSL
 
   // 1. Create a mapping of fids to fnames, which we'll need later to display messages
   const fidToFname = new Map<number, string>();

--- a/packages/hub-nodejs/examples/write-data/index.ts
+++ b/packages/hub-nodejs/examples/write-data/index.ts
@@ -1,12 +1,12 @@
 import {
   EthersEip712Signer,
   FarcasterNetwork,
-  getHubRpcClient,
   makeSignerAdd,
   makeUserDataAdd,
   NobleEd25519Signer,
   UserDataType,
 } from '@farcaster/hub-nodejs';
+import { getInsecureHubRpcClient } from '@farcaster/utils';
 import * as ed from '@noble/ed25519';
 import { Wallet } from 'ethers';
 
@@ -56,7 +56,9 @@ const HUB_URL = process.env['HUB_ADDR'] || ''; // URL of the Hub
    * generating it yourself if your application manages the user's mnemonic. Now you can submit it to the Hub.
    */
 
-  const client = await getHubRpcClient(HUB_URL);
+  const client = getInsecureHubRpcClient(HUB_URL);
+  // const client = await getSSLHubRpcClient(HUB_URL); if you want to use SSL
+
   const result = await client.submitMessage(signerAdd);
   result.isOk() ? console.log('SignerAdd was published successfully!') : console.log(result.error);
 

--- a/packages/hub-nodejs/examples/write-data/index.ts
+++ b/packages/hub-nodejs/examples/write-data/index.ts
@@ -57,7 +57,7 @@ const HUB_URL = process.env['HUB_ADDR'] || ''; // URL of the Hub
    */
 
   const client = getInsecureHubRpcClient(HUB_URL);
-  // const client = await getSSLHubRpcClient(HUB_URL); if you want to use SSL
+  // const client = getSSLHubRpcClient(HUB_URL); if you want to use SSL
 
   const result = await client.submitMessage(signerAdd);
   result.isOk() ? console.log('SignerAdd was published successfully!') : console.log(result.error);

--- a/packages/hub-nodejs/src/index.test.ts
+++ b/packages/hub-nodejs/src/index.test.ts
@@ -1,6 +1,6 @@
-import { getClient } from '.';
+import { getInsecureClient } from '.';
 
 test('Client can be constructed', async () => {
-  const client = await getClient('127.0.0.1:0');
+  const client = getInsecureClient('127.0.0.1:0');
   expect(client).toBeTruthy();
 });

--- a/packages/protobufs/src/index.ts
+++ b/packages/protobufs/src/index.ts
@@ -21,25 +21,6 @@ export const getServer = (): grpc.Server => {
   return server;
 };
 
-export const getClient = async (address: string): Promise<HubServiceClient> => {
-  return new Promise((resolve) => {
-    try {
-      const sslClientResult = getSSLClient(address);
-
-      sslClientResult.waitForReady(Date.now() + 2000, (err) => {
-        if (!err) {
-          resolve(sslClientResult);
-        } else {
-          resolve(getInsecureClient(address));
-        }
-      });
-    } catch (e) {
-      // Fall back to insecure client
-      resolve(getInsecureClient(address));
-    }
-  });
-};
-
 export const getSSLClient = (address: string): HubServiceClient => {
   return new HubServiceClient(address, grpc.credentials.createSsl());
 };

--- a/packages/utils/src/client.ts
+++ b/packages/utils/src/client.ts
@@ -15,7 +15,12 @@ import { err, ok } from 'neverthrow';
 import { HubError, HubErrorCode, HubResult } from './errors';
 
 const fromServiceError = (err: ServiceError): HubError => {
-  return new HubError(err.metadata.get('errCode')[0] as HubErrorCode, err.details);
+  let context = err.details;
+  if (err.code === 14 && err.details === 'No connection established') {
+    context =
+      'Connection failed: please check that the hub’s address, ports and authentication config are correct. ' + context;
+  }
+  return new HubError(err.metadata.get('errCode')[0] as HubErrorCode, context);
 };
 
 // grpc-js generates a Client stub that uses callbacks for async calls. Callbacks are

--- a/packages/utils/src/client.ts
+++ b/packages/utils/src/client.ts
@@ -5,7 +5,6 @@ import {
   ClientReadableStream,
   ClientUnaryCall,
   getAdminClient,
-  getClient,
   getInsecureClient,
   getSSLClient,
   HubServiceClient,
@@ -101,10 +100,6 @@ const promisifyClient = <C extends Client>(client: C) => {
 };
 
 export type HubRpcClient = PromisifiedClient<HubServiceClient>;
-
-export const getHubRpcClient = async (address: string): Promise<HubRpcClient> => {
-  return promisifyClient(await getClient(address));
-};
 
 export const getSSLHubRpcClient = (address: string): HubRpcClient => {
   return promisifyClient(getSSLClient(address));


### PR DESCRIPTION
## Motivation

Using `getHubRpcClient` can be slow because it attempts a SSL connection first, and has to wait for a timeout. Update the docs to use `getSSLHubRpcClient` or `getInsecureHubRpcClient` directly. 

## Change Summary

- Update docs

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
