### PR TITLE
fix: Sync stalls when peer is not responding

### DIFF
--- a/apps/hubble/src/console/console.ts
+++ b/apps/hubble/src/console/console.ts
@@ -1,4 +1,4 @@
-import { Empty } from '@farcaster/protobufs';
+import { Empty, Metadata } from '@farcaster/protobufs';
 import { getAdminRpcClient, getAuthMetadata, getHubRpcClient } from '@farcaster/utils';
 import path from 'path';
 import * as repl from 'repl';
@@ -75,9 +75,17 @@ export const startConsole = async (addressString: string) => {
   replServer.context['getAuthMetadata'] = getAuthMetadata;
 
   // Run the info command to start
-  replServer.output.write(
-    'Connected Info: ' + JSON.stringify(await (commands[0] as RpcClientCommand).object().getInfo(Empty.create())) + '\n'
-  );
+
+  const info = await rpcClient.getInfo(Empty.create(), new Metadata(), { deadline: Date.now() + 2000 });
+
+  if (info.isErr()) {
+    replServer.output.write('Could not connect to hub at "' + addressString + '"\n');
+    // eslint-disable-next-line no-console
+    console.log(info.error);
+    process.exit(1);
+  }
+
+  replServer.output.write('Connected Info: ' + JSON.stringify(info.value) + '\n');
 
   replServer.displayPrompt();
 };

--- a/apps/hubble/src/network/sync/periodicSyncJob.ts
+++ b/apps/hubble/src/network/sync/periodicSyncJob.ts
@@ -42,7 +42,7 @@ export class PeriodicSyncJobScheduler {
 
   async doJobs() {
     this._jobCount += 1;
-    log.info({ jobCount: this._jobCount, memory: process.memoryUsage() }, 'starting periodic sync job');
+    log.info({ jobCount: this._jobCount }, 'starting periodic sync job');
 
     // Do a diff sync
     const syncResult = await ResultAsync.fromPromise(this._syncEngine.diffSyncIfRequired(this._hub), (e) => e);

--- a/apps/hubble/src/network/sync/syncEngine.test.ts
+++ b/apps/hubble/src/network/sync/syncEngine.test.ts
@@ -211,7 +211,7 @@ describe('SyncEngine', () => {
     const mockRPCClient = mock<HubRpcClient>();
     const rpcClient = instance(mockRPCClient);
     let called = false;
-    when(mockRPCClient.getSyncMetadataByPrefix(anything())).thenCall(async () => {
+    when(mockRPCClient.getSyncMetadataByPrefix(anything(), anything(), anything())).thenCall(async () => {
       const shouldSync = await syncEngine.shouldSync({
         prefix: new Uint8Array(),
         numMessages: 10,


### PR DESCRIPTION
## Motivation

Two bug fixes:
1. Sync stalls when client is not responding
2. Get a write lock when unloading the merkle trie

## Change Summary

- Set deadline when calling RPC methods
- Get a write lock when unloading the merkle trie, so as to not run into a deadlock
- Improve logging

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
