### PR TITLE
fix: Don't get recursive snapshots

### DIFF
--- a/apps/hubble/src/network/sync/merkleTrie.test.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.test.ts
@@ -607,31 +607,4 @@ describe('MerkleTrie', () => {
     values = await trie.getAllValues(Buffer.from('166518233'));
     expect(values?.length).toEqual(1);
   });
-
-  describe('getDivergencePrefix', () => {
-    test('returns the prefix with the most common excluded hashes', async () => {
-      const trie = await trieWithIds([1665182332, 1665182343, 1665182345]);
-      const prefixToTest = Buffer.from('1665182343');
-      const oldSnapshot = await trie.getSnapshot(prefixToTest);
-      trie.insert(await NetworkFactories.SyncId.create(undefined, { transient: { date: new Date(1665182353000) } }));
-
-      // Since message above was added at 1665182353, the two tries diverged at 16651823 for our prefix
-      let divergencePrefix = await trie.getDivergencePrefix(prefixToTest, oldSnapshot.excludedHashes);
-      expect(divergencePrefix).toEqual(Buffer.from('16651823'));
-
-      // divergence prefix should be the full prefix, if snapshots are the same
-      const currentSnapshot = await trie.getSnapshot(prefixToTest);
-      divergencePrefix = await trie.getDivergencePrefix(prefixToTest, currentSnapshot.excludedHashes);
-      expect(divergencePrefix).toEqual(prefixToTest);
-
-      // divergence prefix should empty if excluded hashes are empty
-      divergencePrefix = await trie.getDivergencePrefix(prefixToTest, []);
-      expect(divergencePrefix.length).toEqual(0);
-
-      // divergence prefix should be our prefix if provided hashes are longer
-      const with5 = Buffer.concat([prefixToTest, Buffer.from('5')]);
-      divergencePrefix = await trie.getDivergencePrefix(with5, [...currentSnapshot.excludedHashes, 'different']);
-      expect(divergencePrefix).toEqual(prefixToTest);
-    });
-  });
 });

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -199,38 +199,6 @@ class MerkleTrie {
         await this._unloadFromMemory(false);
 
         resolve(r);
-        release();
-      });
-    });
-  }
-
-  /**
-   * Returns the subset of the prefix common to two different tries by comparing excluded hashes.
-   *
-   * @param prefix - the prefix of the external trie.
-   * @param excludedHashes - the excluded hashes of the external trie.
-   */
-  public async getDivergencePrefix(prefix: Uint8Array, excludedHashes: string[]): Promise<Uint8Array> {
-    return new Promise((resolve) => {
-      this._lock.readLock(async (release) => {
-        const ourExcludedHashes = (await this.getSnapshot(prefix)).excludedHashes;
-
-        await this._unloadFromMemory(false);
-
-        let subPrefixResolved = false;
-        for (let i = 0; i < prefix.length; i++) {
-          // NOTE: `i` is controlled by for loop and hence not at risk of object injection.
-          // eslint-disable-next-line security/detect-object-injection
-          if (ourExcludedHashes[i] !== excludedHashes[i]) {
-            subPrefixResolved = true;
-            resolve(prefix.slice(0, i));
-            break;
-          }
-        }
-
-        if (!subPrefixResolved) {
-          resolve(prefix);
-        }
 
         release();
       });

--- a/apps/hubble/src/network/sync/merkleTrie.ts
+++ b/apps/hubble/src/network/sync/merkleTrie.ts
@@ -104,15 +104,6 @@ class MerkleTrie {
   public async insert(id: SyncId): Promise<boolean> {
     return new Promise((resolve) => {
       this._lock.writeLock(async (release) => {
-        // We time out inserts into the sync trie so as to not hold the lock for too long.
-        // Missing messages will be synced on the next sync cycle.
-        const insertTimeout = setTimeout(() => {
-          log.error({ id, cacheSize: this._callsSinceLastUnload }, 'Trie Insert Timeout');
-
-          resolve(false);
-          release();
-        }, 10_000);
-
         try {
           const { status, dbUpdatesMap } = await this._root.insert(id.syncId(), this._db, new Map());
           this._updatePendingDbUpdates(dbUpdatesMap);
@@ -125,8 +116,6 @@ class MerkleTrie {
           log.error({ e }, 'Insert Error');
 
           resolve(false);
-        } finally {
-          clearTimeout(insertTimeout);
         }
 
         release();
@@ -141,15 +130,6 @@ class MerkleTrie {
   public async deleteByBytes(id: Uint8Array): Promise<boolean> {
     return new Promise((resolve) => {
       this._lock.writeLock(async (release) => {
-        // We time out deletes into the sync trie so as to not hold the lock for too long.
-        // Missing messages will be synced on the next sync cycle.
-        const deleteTimeout = setTimeout(() => {
-          log.error({ id, cacheSize: this._callsSinceLastUnload }, 'Trie Delete Timeout');
-
-          resolve(false);
-          release();
-        }, 10_000);
-
         try {
           const { status, dbUpdatesMap } = await this._root.delete(id, this._db, new Map());
           this._updatePendingDbUpdates(dbUpdatesMap);
@@ -160,8 +140,6 @@ class MerkleTrie {
           log.error({ e }, 'Delete Error');
 
           resolve(false);
-        } finally {
-          clearTimeout(deleteTimeout);
         }
 
         release();

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -54,6 +54,8 @@ class Engine {
   private _revokeSignerQueue: RevokeMessagesBySignerJobQueue;
   private _revokeSignerWorker: RevokeMessagesBySignerJobWorker;
 
+  private _isPruning = false;
+
   constructor(db: RocksDB, network: protobufs.FarcasterNetwork) {
     this._db = db;
     this._network = network;
@@ -262,6 +264,10 @@ class Engine {
     return ok(undefined);
   }
 
+  public isPruning(): boolean {
+    return this._isPruning;
+  }
+
   async pruneMessages(fid: number): HubAsyncResult<void> {
     const logPruneResult = (result: HubResult<number[]>, store: string): void => {
       result.match(
@@ -275,6 +281,9 @@ class Engine {
         }
       );
     };
+
+    // Record that we are pruning so that we don't try to sync in the middle of pruning
+    this._isPruning = true;
 
     const signerResult = await this._signerStore.pruneMessages(fid);
     logPruneResult(signerResult, 'signer');
@@ -291,6 +300,8 @@ class Engine {
     const userDataResult = await this._userDataStore.pruneMessages(fid);
     logPruneResult(userDataResult, 'user data');
 
+    // Record that we are done pruning
+    this._isPruning = false;
     return ok(undefined);
   }
 

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -54,8 +54,6 @@ class Engine {
   private _revokeSignerQueue: RevokeMessagesBySignerJobQueue;
   private _revokeSignerWorker: RevokeMessagesBySignerJobWorker;
 
-  private _isPruning = false;
-
   constructor(db: RocksDB, network: protobufs.FarcasterNetwork) {
     this._db = db;
     this._network = network;
@@ -264,10 +262,6 @@ class Engine {
     return ok(undefined);
   }
 
-  public isPruning(): boolean {
-    return this._isPruning;
-  }
-
   async pruneMessages(fid: number): HubAsyncResult<void> {
     const logPruneResult = (result: HubResult<number[]>, store: string): void => {
       result.match(
@@ -281,9 +275,6 @@ class Engine {
         }
       );
     };
-
-    // Record that we are pruning so that we don't try to sync in the middle of pruning
-    this._isPruning = true;
 
     const signerResult = await this._signerStore.pruneMessages(fid);
     logPruneResult(signerResult, 'signer');
@@ -300,8 +291,6 @@ class Engine {
     const userDataResult = await this._userDataStore.pruneMessages(fid);
     logPruneResult(userDataResult, 'user data');
 
-    // Record that we are done pruning
-    this._isPruning = false;
     return ok(undefined);
   }
 


### PR DESCRIPTION
## Motivation

This fixes a bug in sync where due to getting recursive snapshots, they were slightly different, causing some messages
to not sync

## Change Summary

- Get divergence prefix without the trie
- Don't do recursive snapshots

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
