### PR TITLE
docs: release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@
    3. [Handling Errors](#33-handling-errors)
    4. [Creating the PR](#34-creating-the-pr)
    5. [Adding Changesets](#35-adding-changesets)
+   6. [Releasing Versions](#36-releasing-versions)
 4. [Troubleshooting](#4-troubleshooting)
 
 ## 1. How to Contribute
@@ -264,6 +265,19 @@ when the repo manager runs a release process.
 2. Select the packages being modified with the space key
 3. Select minor version if breaking change or patch otherwise, since we haven't release 1.0 yet
 4. Commit the generates files into your branch.
+
+### 3.6 Releasing Versions
+
+Permissions to publish to the @farcaster organization in NPM is necessary. This is a non-reversible process so if you
+are at all unsure about how to proceed, please reach out to Varun ([Github](https://github.com/varunsrin) | [Warpcast](https://warpcast.com/v))
+
+1. Checkout a new branch and run `yarn changeset version`
+2. Check that the version bumps are consistent with our versioning system
+3. Check that all CHANGELOG.mds represent the important changes made
+4. Check in all the files and merge the branch to main
+5. Checkout main, pull down to the merged commit (should be latest) and run `yarn changeset publish`
+6. Hubble is private and must be manually tagged with `git tag -a @farcaster/hubble@<version>` if bumped.
+7. Run `git push origin <tag>` on each tag to push up the tags.
 
 ## 4. TroubleShooting
 


### PR DESCRIPTION
## Motivation

Documenting manual processes.

## Change Summary

Add documentation for release instructions.

## Merge Checklist

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

No changeset for docs prs
