### PR TITLE
chore: update revoke and pruning to continue after error for a single record

### DIFF
--- a/apps/hubble/src/storage/jobs/revokeMessagesBySignerJob.ts
+++ b/apps/hubble/src/storage/jobs/revokeMessagesBySignerJob.ts
@@ -58,8 +58,7 @@ export class RevokeMessagesBySignerJobWorker {
   }
 
   private async processJob(payload: protobufs.RevokeMessagesBySignerJobPayload): HubAsyncResult<void> {
-    const result = await this._engine.revokeMessagesBySigner(payload.fid, payload.signer);
-    return result.map(() => undefined);
+    return this._engine.revokeMessagesBySigner(payload.fid, payload.signer);
   }
 }
 

--- a/apps/hubble/src/storage/stores/reactionStore.ts
+++ b/apps/hubble/src/storage/stores/reactionStore.ts
@@ -27,6 +27,7 @@ import {
   PageOptions,
   StorePruneOptions,
 } from '~/storage/stores/types';
+import { logger } from '~/utils/logger';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 5_000;
 const PRUNE_TIME_LIMIT_DEFAULT = 60 * 60 * 24 * 90; // 90 days
@@ -373,16 +374,22 @@ class ReactionStore {
     };
 
     let pruneResult = await pruneNextMessage();
-    while (pruneResult.isOk() && pruneResult.value !== undefined) {
-      commits.push(pruneResult.value);
+    while (!(pruneResult.isOk() && pruneResult.value === undefined)) {
+      pruneResult.match(
+        (commit) => {
+          if (commit) {
+            commits.push(commit);
+          }
+        },
+        (e) => {
+          logger.error({ errCode: e.errCode }, `error pruning reaction message for fid ${fid}: ${e.message}`);
+        }
+      );
+
       pruneResult = await pruneNextMessage();
     }
 
     await pruneIterator.end();
-
-    if (pruneResult.isErr()) {
-      return err(pruneResult.error);
-    }
 
     return ok(commits);
   }

--- a/apps/hubble/src/storage/stores/userDataStore.ts
+++ b/apps/hubble/src/storage/stores/userDataStore.ts
@@ -19,6 +19,7 @@ import { UserPostfix } from '~/storage/db/types';
 import StoreEventHandler, { HubEventArgs } from '~/storage/stores/storeEventHandler';
 import { MERGE_TIMEOUT_DEFAULT, MessagesPage, PageOptions, StorePruneOptions } from '~/storage/stores/types';
 import { eventCompare } from '~/storage/stores/utils';
+import { logger } from '~/utils/logger';
 
 const PRUNE_SIZE_LIMIT_DEFAULT = 100;
 
@@ -201,16 +202,22 @@ class UserDataStore {
     };
 
     let pruneResult = await pruneNextMessage();
-    while (pruneResult.isOk() && pruneResult.value !== undefined) {
-      commits.push(pruneResult.value);
+    while (!(pruneResult.isOk() && pruneResult.value === undefined)) {
+      pruneResult.match(
+        (commit) => {
+          if (commit) {
+            commits.push(commit);
+          }
+        },
+        (e) => {
+          logger.error({ errCode: e.errCode }, `error pruning user data message for fid ${fid}: ${e.message}`);
+        }
+      );
+
       pruneResult = await pruneNextMessage();
     }
 
     await pruneIterator.end();
-
-    if (pruneResult.isErr()) {
-      return err(pruneResult.error);
-    }
 
     return ok(commits);
   }


### PR DESCRIPTION
## Motivation

Right now if we encounter an error when pruning or revoking a list of messages, the function ends and returns the error. That's suboptimal, because it can result in abandoned messages that should have been revoked but aren't until they're eventually pruned.

## Change Summary

* Update `pruneMessages` in all stores to log an error and continue
* Update `revokeMessagesBySigner` in engine to log an error for failures and continue until the iterator is finished

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
