### PR TITLE
fix: Have gossip node listen on 0.0.0.0 by default

### DIFF
--- a/apps/hubble/.config/hub.config.ts
+++ b/apps/hubble/.config/hub.config.ts
@@ -24,7 +24,7 @@ export const Config = {
   //   '12D3KooWMDdQaMWCkQ8Gf3C6zdJdMEfFs8R2pw8YQw2HgoY8qhzA', // @adityapk00
   // ],
   /** The IP address libp2p should listen on. */
-  ip: '127.0.0.1',
+  ip: '0.0.0.0',
   /** The IP address that libp2p should announce to peers */
   // announceIp: '',
   /** The server name to announce to peers */

--- a/apps/hubble/src/cli.ts
+++ b/apps/hubble/src/cli.ts
@@ -251,6 +251,7 @@ app
     const options: HubOptions = {
       peerId,
       ipMultiAddr: ipMultiAddrResult.value,
+      rpcServerHost: hubAddressInfo.value.address,
       announceIp: cliOptions.announceIp ?? hubConfig.announceIp,
       announceServerName: cliOptions.announceServerName ?? hubConfig.announceServerName,
       gossipPort: hubAddressInfo.value.port,

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -78,8 +78,11 @@ export interface HubOptions {
   /** A list of PeerId strings to allow connections with */
   allowedPeers?: string[];
 
-  /** IP address string in MultiAddr format to bind to */
+  /** IP address string in MultiAddr format to bind the gossip node to */
   ipMultiAddr?: string;
+
+  /** IP address string to bind the RPC server to */
+  rpcServerHost?: string;
 
   /** External IP address to announce to peers. If not provided, it'll fetch the IP from an external service */
   announceIp?: string;
@@ -321,7 +324,7 @@ export class Hub implements HubInterface {
     });
 
     // Start the RPC server
-    await this.rpcServer.start(this.options.rpcPort ? this.options.rpcPort : 0);
+    await this.rpcServer.start(this.options.rpcServerHost, this.options.rpcPort ? this.options.rpcPort : 0);
     if (this.options.adminServerEnabled) {
       await this.adminServer.start(this.options.adminServerHost ?? '127.0.0.1');
     }


### PR DESCRIPTION
## Motivation

Have gossip node listen on 0.0.0.0 by default (set by `--ip` flag) so that it can also process incoming gossip connections

## Change Summary

- Gossip listens on 0.0.0.0 by default
- RPC server obeys `--ip`

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
