### PR TITLE
fix: Refuse to startup if DB is mismatched

### DIFF
--- a/.changeset/nervous-masks-camp.md
+++ b/.changeset/nervous-masks-camp.md
@@ -1,0 +1,5 @@
+---
+'@farcaster/hubble': patch
+---
+
+Refuse to startup if DB network is mismatched

--- a/apps/hubble/src/hubble.ts
+++ b/apps/hubble/src/hubble.ts
@@ -298,6 +298,20 @@ export class Hub implements HubInterface {
       }
     }
 
+    // Get the Network ID from the DB
+    const dbNetworkResult = await this.getDbNetwork();
+    if (dbNetworkResult.isOk() && dbNetworkResult.value && dbNetworkResult.value !== this.options.network) {
+      throw new HubError(
+        'unavailable',
+        `network mismatch: DB is ${dbNetworkResult.value}, but Hub is started with ${this.options.network}. ` +
+          `Please reset the DB with --db-reset if this is intentional.`
+      );
+    }
+
+    // Set the network in the DB
+    await this.setDbNetwork(this.options.network);
+    log.info(`starting hub with network: ${this.options.network}`);
+
     await this.engine.start();
 
     // Start the ETH registry provider first
@@ -715,6 +729,37 @@ export class Hub implements HubInterface {
       this.rocksDB.get(Buffer.from([RootPrefix.HubCleanShutdown])),
       (e) => e as HubError
     ).map((value) => value?.[0] === 1);
+  }
+
+  async getDbNetwork(): HubAsyncResult<FarcasterNetwork | undefined> {
+    const dbResult = await ResultAsync.fromPromise(
+      this.rocksDB.get(Buffer.from([RootPrefix.Network])),
+      (e) => e as HubError
+    );
+    if (dbResult.isErr()) {
+      return err(dbResult.error);
+    }
+
+    // parse the buffer as an int
+    const networkNumber = Result.fromThrowable(
+      () => dbResult.value.readUInt32BE(0),
+      (e) => e as HubError
+    )();
+    if (networkNumber.isErr()) {
+      return err(networkNumber.error);
+    }
+
+    // get the enum value from the number
+    return networkNumber.map((n) => n as FarcasterNetwork);
+  }
+
+  async setDbNetwork(network: FarcasterNetwork): HubAsyncResult<void> {
+    const txn = this.rocksDB.transaction();
+    const value = Buffer.alloc(4);
+    value.writeUInt32BE(network, 0);
+    txn.put(Buffer.from([RootPrefix.Network]), value);
+
+    return ResultAsync.fromPromise(this.rocksDB.commit(txn), (e) => e as HubError);
   }
 
   /* -------------------------------------------------------------------------- */

--- a/apps/hubble/src/storage/db/types.ts
+++ b/apps/hubble/src/storage/db/types.ts
@@ -51,6 +51,8 @@ export enum RootPrefix {
   HubCleanShutdown = 14,
   /* Event log */
   HubEvents = 15,
+  /* The network ID that the rocksDB was created with */
+  Network = 16,
 }
 
 /**


### PR DESCRIPTION
Fixed #771

## Motivation

Write the network ID into the DB, so it can't accidentally be started on a different network

## Change Summary

- Write network ID into DB
- Refuse to startup if network doesn't match

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [X] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [X] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [X] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [X] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)
