### PR TITLE
feat: revoke UserDataAdd for fname when fid transfers

### DIFF
--- a/apps/hubble/src/storage/engine/index.test.ts
+++ b/apps/hubble/src/storage/engine/index.test.ts
@@ -509,6 +509,35 @@ describe('with listeners and workers', () => {
       await sleep(200); // Wait for engine to revoke messages
       expect(revokedMessages).toEqual([fnameAdd]);
     });
+
+    test('revokes UserDataAdd when fid is transferred', async () => {
+      const fname = Factories.Fname.build();
+      const nameEvent = Factories.NameRegistryEvent.build({
+        fname,
+        to: custodyEvent.to,
+        type: protobufs.NameRegistryEventType.TRANSFER,
+      });
+      await expect(liveEngine.mergeNameRegistryEvent(nameEvent)).resolves.toBeInstanceOf(Ok);
+      const fnameAdd = await Factories.UserDataAddMessage.create(
+        {
+          data: {
+            userDataBody: { type: protobufs.UserDataType.FNAME, value: bytesToUtf8String(fname)._unsafeUnwrap() },
+            fid,
+          },
+        },
+        { transient: { signer } }
+      );
+      await expect(liveEngine.mergeMessage(fnameAdd)).resolves.toBeInstanceOf(Ok);
+      const custodyTransfer = Factories.IdRegistryEvent.build({
+        fid,
+        from: custodyEvent.to,
+        blockNumber: custodyEvent.blockNumber + 1,
+      });
+      await expect(liveEngine.mergeIdRegistryEvent(custodyTransfer)).resolves.toBeInstanceOf(Ok);
+      expect(revokedMessages).toEqual([]);
+      await sleep(200); // Wait for engine to revoke messages
+      expect(revokedMessages).toContainEqual(fnameAdd);
+    });
   });
 });
 

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -716,7 +716,7 @@ class Engine {
     const { idRegistryEvent } = event.mergeIdRegistryEventBody;
     const fromAddress = idRegistryEvent.from;
     if (fromAddress && fromAddress.length > 0) {
-      // Revoke SignerAdd messages
+      // Revoke signer messages
       const payload = protobufs.RevokeMessagesBySignerJobPayload.create({
         fid: idRegistryEvent.fid,
         signer: fromAddress,

--- a/apps/hubble/src/storage/engine/index.ts
+++ b/apps/hubble/src/storage/engine/index.ts
@@ -716,6 +716,7 @@ class Engine {
     const { idRegistryEvent } = event.mergeIdRegistryEventBody;
     const fromAddress = idRegistryEvent.from;
     if (fromAddress && fromAddress.length > 0) {
+      // Revoke SignerAdd messages
       const payload = protobufs.RevokeMessagesBySignerJobPayload.create({
         fid: idRegistryEvent.fid,
         signer: fromAddress,
@@ -725,6 +726,31 @@ class Engine {
         log.error(
           { errCode: enqueueRevoke.error.errCode },
           `failed to enqueue revoke signer job: ${enqueueRevoke.error.message}`
+        );
+      }
+
+      // Revoke UserDataAdd fname messages
+      const fnameAdd = await ResultAsync.fromPromise(
+        this._userDataStore.getUserDataAdd(idRegistryEvent.fid, protobufs.UserDataType.FNAME),
+        () => undefined
+      );
+      if (fnameAdd.isOk()) {
+        const revokeResult = await this._userDataStore.revoke(fnameAdd.value);
+        const fnameAddHex = bytesToHexString(fnameAdd.value.hash);
+        revokeResult.match(
+          () =>
+            log.info(
+              `revoked message ${fnameAddHex._unsafeUnwrap()} for fid ${
+                idRegistryEvent.fid
+              } due to IdRegistryEvent transfer`
+            ),
+          (e) =>
+            log.error(
+              { errCode: e.errCode },
+              `failed to revoke message ${fnameAddHex._unsafeUnwrap()} for fid ${
+                idRegistryEvent.fid
+              } due to IdRegistryEvent transfer: ${e.message}`
+            )
         );
       }
     }


### PR DESCRIPTION
## Motivation

Addresses an edge case where a UserDataAdd fname should be revoked when an fid is transferred, because the custody address for the fid and fname are no longer the same.

## Change Summary

* Add an extra check to the `handleMergeIdRegistryEvent` engine callback

## Merge Checklist

_Choose all relevant options below by adding an `x` now or at any time before submitting for review_

- [x] PR title adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard
- [ ] PR has a [changeset](../CONTRIBUTING.md#35-adding-changesets)
- [x] PR has been tagged with a change label(s) (i.e. documentation, feature, bugfix, or chore)
- [x] PR does not require changes to the [protocol](https://github.com/farcasterxyz/protocol)

## Additional Context

If this is a relatively large or complex change, provide more details here that will help reviewers
